### PR TITLE
[feat] 공통 응답 구조 생성

### DIFF
--- a/src/main/java/at/mateball/common/MateballResponse.java
+++ b/src/main/java/at/mateball/common/MateballResponse.java
@@ -1,0 +1,23 @@
+package at.mateball.common;
+
+import at.mateball.exception.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record MateballResponse<T>(
+        int status,
+        String message,
+        @JsonInclude(value = JsonInclude.Include.NON_NULL)
+        T data
+) {
+    public static <T> MateballResponse<T> success(ErrorCode successCode, T data) {
+        return new MateballResponse<>(successCode.getStatus().value(), successCode.getMessage(), data);
+    }
+
+    public static <T> MateballResponse<T> successWithNoData(ErrorCode successCode) {
+        return new MateballResponse<>(successCode.getStatus().value(), successCode.getMessage(), null);
+    }
+
+    public static <T> MateballResponse<T> failure(ErrorCode failureCode) {
+        return new MateballResponse<>(failureCode.getStatus().value(), failureCode.getMessage(), null);
+    }
+}

--- a/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
+++ b/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
@@ -16,6 +16,6 @@ public class SampleController {
     public MateballResponse<SampleResponseDto> getSampleData() {
         SampleResponseDto sampleData = new SampleResponseDto("다진언니 안녕");
 
-        return MateballResponse.success(ErrorCode.Success_Sample, sampleData);
+        return MateballResponse.success(ErrorCode.SUCCESS_SAMPLE, sampleData);
     }
 }

--- a/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
+++ b/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
@@ -1,0 +1,21 @@
+package at.mateball.domain.sample.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.exception.ErrorCode;
+import at.mateball.domain.sample.api.dto.SampleResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SampleController {
+
+    public SampleController() {
+    }
+
+    @GetMapping("/sample")
+    public MateballResponse<SampleResponseDto> getSampleData() {
+        SampleResponseDto sampleData = new SampleResponseDto("다진언니 안녕");
+
+        return MateballResponse.success(ErrorCode.Success_Sample, sampleData);
+    }
+}

--- a/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
+++ b/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
@@ -2,7 +2,7 @@ package at.mateball.domain.sample.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.exception.ErrorCode;
-import at.mateball.domain.sample.api.dto.SampleResponseDto;
+import at.mateball.domain.sample.api.dto.response.SampleResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,8 +13,8 @@ public class SampleController {
     }
 
     @GetMapping("/sample")
-    public MateballResponse<SampleResponseDto> getSampleData() {
-        SampleResponseDto sampleData = new SampleResponseDto("다진언니 안녕");
+    public MateballResponse<SampleResponse> getSampleData() {
+        SampleResponse sampleData = new SampleResponse("다진언니 안녕");
 
         return MateballResponse.success(ErrorCode.SUCCESS_SAMPLE, sampleData);
     }

--- a/src/main/java/at/mateball/domain/sample/api/dto/SampleResponseDto.java
+++ b/src/main/java/at/mateball/domain/sample/api/dto/SampleResponseDto.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.sample.api.dto;
+
+public record SampleResponseDto(
+        String toDajin
+) {
+}

--- a/src/main/java/at/mateball/domain/sample/api/dto/SampleResponseDto.java
+++ b/src/main/java/at/mateball/domain/sample/api/dto/SampleResponseDto.java
@@ -1,6 +1,0 @@
-package at.mateball.domain.sample.api.dto;
-
-public record SampleResponseDto(
-        String toDajin
-) {
-}

--- a/src/main/java/at/mateball/domain/sample/api/dto/response/SampleResponse.java
+++ b/src/main/java/at/mateball/domain/sample/api/dto/response/SampleResponse.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.sample.api.dto.response;
+
+public record SampleResponse(
+        String toDajin
+) {
+}

--- a/src/main/java/at/mateball/exception/ErrorCode.java
+++ b/src/main/java/at/mateball/exception/ErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    Success_Sample(HttpStatus.OK, "샘플 성공 코드입니다.");
+    SUCCESS_SAMPLE(HttpStatus.OK, "샘플 성공 코드입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/at/mateball/exception/ErrorCode.java
+++ b/src/main/java/at/mateball/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package at.mateball.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    Success_Sample(HttpStatus.OK, "샘플 성공 코드입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #1 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- MateballResponse 를 생성했습니다
   - api 명세서에 맞게 status/message/data 로 구성되어 있습니다
   - data는 null일때 제외될 수 있도록 NON_NULL설정을 했습니다
- 샘플 코드/컨트롤러/dto를 설정해놨습니다! 포스트맨에서 잘돌아가는 것도 확인했습니다 :)
- 킥오프때 정했던 패키지 구조에 맞게 파일을 분리했습니다

<br/>


### ❤️ To 다진 / To 헤음

---

- 공통 응답구조에서 data를 내려줄 필요가 없는 경우에 사용할 수 있도록 successWithNoData라는 응답도 추가해봤는데 어떻게 생각하시나요! 단순 자원생성(Created)의 경우에 사용할 수 있을 것이라고 판단하고 생성했는데 리드님의 의견이 궁금하옵니다..! 굳이 필요없다고 생각하신다면 삭제해도 괜찮아요!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a standardized API response structure for consistent and clear responses.
	- Added a sample API endpoint that returns a message in a unified response format.
	- Implemented an error code system for improved response messaging and status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->