### PR TITLE
[feat] 에러핸들링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
+++ b/src/main/java/at/mateball/domain/sample/api/controller/SampleController.java
@@ -16,6 +16,6 @@ public class SampleController {
     public MateballResponse<SampleResponse> getSampleData() {
         SampleResponse sampleData = new SampleResponse("다진언니 안녕");
 
-        return MateballResponse.success(ErrorCode.SUCCESS_SAMPLE, sampleData);
+        return MateballResponse.success(ErrorCode.INTERNAL_SERVER_ERROR, sampleData);
     }
 }

--- a/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package at.mateball.exception;
+
+import at.mateball.common.MateballResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        MateballResponse<?> errorResponse = MateballResponse.failure(ErrorCode.FORBIDDEN);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package at.mateball.exception;
+
+import at.mateball.common.MateballResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authenticationException
+    ) throws IOException {
+        MateballResponse<?> errorResponse = MateballResponse.failure(ErrorCode.UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/at/mateball/exception/ErrorCode.java
+++ b/src/main/java/at/mateball/exception/ErrorCode.java
@@ -6,7 +6,30 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    SUCCESS_SAMPLE(HttpStatus.OK, "샘플 성공 코드입니다.");
+    // 400 BAD REQUEST
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 잘못되었습니다."),
+    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST, "경로 변수가 누락된 잘못된 URL입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 잘못되었습니다."),
+
+    // 401 UNAUTHORIZED
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    UNAUTHORIZED_HEADER(HttpStatus.UNAUTHORIZED, "요청 헤더가 올바르지 않는 토큰입니다."),
+
+    // 403 FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404 NOT FOUND
+    NOT_FOUND_URL(HttpStatus.NOT_FOUND, "요청한 URL을 찾을 수 없습니다."),
+
+    // 405 METHOD NOT ALLOWED
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP 메서드입니다."),
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // VALIDATION
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값이 유효하지 않습니다."),
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 전달되었습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -1,9 +1,82 @@
 package at.mateball.exception;
 
+import at.mateball.common.MateballResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.nio.file.AccessDeniedException;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalException {
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<MateballResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException exception) {
+        return toResponse(ErrorCode.INVALID_REQUEST_BODY);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<MateballResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException exception) {
+        return toResponse(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
+    }
+
+    @ExceptionHandler(MissingPathVariableException.class)
+    public ResponseEntity<MateballResponse<?>> handleMissingPathVariable(MissingPathVariableException exception) {
+        return toResponse(ErrorCode.MISSING_PATH_VARIABLE);
+    }
+
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<MateballResponse<?>> handleMissingRequestHeader(MissingRequestHeaderException exception) {
+        return toResponse(ErrorCode.UNAUTHORIZED_HEADER);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<MateballResponse<?>> handleNotFound(NoResourceFoundException exception) {
+        return toResponse(ErrorCode.NOT_FOUND_URL);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<MateballResponse<?>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException exception) {
+        return toResponse(ErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<MateballResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
+        return toResponse(ErrorCode.VALIDATION_ERROR);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<MateballResponse<?>> handleValidation(ConstraintViolationException exception) {
+        return toResponse(ErrorCode.VALIDATION_ERROR);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<MateballResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
+        return toResponse(ErrorCode.ILLEGAL_ARGUMENT);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<MateballResponse<?>> handleAccessDenied(AccessDeniedException ex) {
+        return toResponse(ErrorCode.FORBIDDEN);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<MateballResponse<?>> handleException(Exception ex) {
+        log.error("서버 내부 오류 : ", ex);
+        return toResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<MateballResponse<?>> toResponse(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(MateballResponse.failure(errorCode));
+    }
 }

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -13,8 +13,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-
-import java.nio.file.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 
 @RestControllerAdvice
 @Slf4j

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -1,0 +1,9 @@
+package at.mateball.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalException {
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #3 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---
- gradle에 시큐리티 추가
- CustomAuthenticationEntryPoint로 인증 실패시 예외처리
- CustomAccessDeniedHandler로 인가 실패시 예외 처리
- 이 외의 다른 클라이언트 오류는 GlobalException추가


<br/>


### ❤️ To 다진 / To 헤음

---

- AuthenticationException은 시큐리티 필터 체인에서 발생하으로, `RestContollerAdvice`의 `@ExceptionHandler`보다 우선적으로 필터 단에서 처리되어야합니다. 따라서 이를 위한 지점이 AuthenticationEntryPoint입니당!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive security and error handling, including custom responses for unauthorized and forbidden access.
  * Standardized error messages for various HTTP error scenarios, such as bad requests, validation errors, and server errors.
  * Centralized exception handling to provide consistent and user-friendly error responses throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->