### PR TITLE
[feat/#7] securityConfig 설정 및 CSRF 비활성화

### DIFF
--- a/src/main/java/at/mateball/config/SecurityConfig.java
+++ b/src/main/java/at/mateball/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package at.mateball.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/swagger/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #7 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---
- Spring Security 기본 설정에서는 CSRF 보호가 활성화되어 있어 POST 요청이 403 에러로 막히는 현상이 있었습니다.
- REST API는 기본적으로 **Stateless 구조**를 지향하고, 클라이언트(JWT 쿠키 등)에서 인증을 처리하므로 CSRF를 비활성화해도 무방합니다.
- 아래와 같이 `SecurityConfig`에서 `csrf().disable()`을 명시적으로 설정하여 CSRF 보호 기능을 비활성화했습니다.
- `sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)`를 설정해 서버에서 세션을 생성하지 않도록 했습니다. (우리는 쿠키와 토큰활용할 예정이라서)


<br/>


### ❤️ To 다진 / To 헤음

---
현재 Swagger 관련 URL 경로를  
`/swagger-ui/**`, `/v3/api-docs/**`, `/swagger-resources/**`, `/swagger/**` 로 설정해 두었슴당. 추후 Swagger가 실제로 사용하는 경로에 변경이 있다면 말해쥬떼옹


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced security settings, requiring authentication for most endpoints.
  * Allowed open access to API documentation and Swagger UI endpoints.
  * Enabled HTTP Basic authentication for secure access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->