### PR TITLE
[feat] 쿠키 기반 JWT 인증/인가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,11 @@ dependencies {
 
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/at/mateball/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/at/mateball/common/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,47 @@
 package at.mateball.common.jwt;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
 
 @Component
-public class JwtAuthenticationFilter {
-    private final
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtCookieProvider cookieProvider;
+    private final JwtTokenValidator tokenValidator;
+    private final JwtAuthenticationProvider authenticationProvider;
+
+    public JwtAuthenticationFilter(JwtCookieProvider cookieProvider, JwtTokenValidator tokenValidator, JwtAuthenticationProvider authenticationProvider) {
+        this.cookieProvider = cookieProvider;
+        this.tokenValidator = tokenValidator;
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String token = cookieProvider.extractAccessToken(request);
+            tokenValidator.validate(token);
+            Authentication authentication = authenticationProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (Exception e) {
+            logger.debug("JWT 인증 실패", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/auth/");
+    }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/at/mateball/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,8 @@
+package at.mateball.common.jwt;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationFilter {
+    private final
+}

--- a/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
@@ -1,4 +1,55 @@
 package at.mateball.common.jwt;
 
+import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
 public class JwtAuthenticationProvider {
+    private final JwtProperties jwtProperties;
+    private final Key key;
+
+    public JwtAuthenticationProvider(JwtProperties jwtProperties, Key key) {
+        this.jwtProperties = jwtProperties;
+        this.key = key;
+    }
+    
+    public Long extractUserId(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            throw new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, jwtProperties.accessExpiration());
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, jwtProperties.refreshExpiration());
+    }
+
+    private String generateToken(Long userId, long expiryMillis) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiryMillis);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
@@ -1,55 +1,21 @@
 package at.mateball.common.jwt;
 
-import at.mateball.exception.BusinessErrorCode;
-import at.mateball.exception.BusinessException;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import at.mateball.common.security.CustomUserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
-
-import java.security.Key;
-import java.util.Date;
+import org.springframework.security.core.Authentication;
 
 @Component
 public class JwtAuthenticationProvider {
-    private final JwtProperties jwtProperties;
-    private final Key key;
+    private final JwtTokenGenerator jwtTokenGenerator;
 
-    public JwtAuthenticationProvider(JwtProperties jwtProperties, Key key) {
-        this.jwtProperties = jwtProperties;
-        this.key = key;
-    }
-    
-    public Long extractUserId(String token) {
-        try {
-            Claims claims = Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token)
-                    .getBody();
-            return Long.parseLong(claims.getSubject());
-        } catch (Exception e) {
-            throw new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN);
-        }
+    public JwtAuthenticationProvider(JwtTokenGenerator jwtTokenGenerator) {
+        this.jwtTokenGenerator = jwtTokenGenerator;
     }
 
-    public String generateAccessToken(Long userId) {
-        return generateToken(userId, jwtProperties.accessExpiration());
-    }
-
-    public String generateRefreshToken(Long userId) {
-        return generateToken(userId, jwtProperties.refreshExpiration());
-    }
-
-    private String generateToken(Long userId, long expiryMillis) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + expiryMillis);
-
-        return Jwts.builder()
-                .setSubject(String.valueOf(userId))
-                .setIssuedAt(now)
-                .setExpiration(expiry)
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+    public Authentication getAuthentication(String token) {
+        Long userId = jwtTokenGenerator.extractUserId(token);
+        CustomUserDetails userDetails = new CustomUserDetails(userId);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtAuthenticationProvider {
+}

--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -1,4 +1,100 @@
 package at.mateball.common.jwt;
 
+import at.mateball.domain.LoginResult;
+import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.BusinessException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Component
 public class JwtCookieProvider {
+    private final JwtProperties jwtProperties;
+
+    public JwtCookieProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+    }
+
+    private static final String ACCESS_TOKEN_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_NAME = "refreshToken";
+    private static final String KAKAO_TOKEN_NAME = "kakaoAccessToken";
+
+    public String extractAccessToken(HttpServletRequest request) {
+        return extractCookie(request, ACCESS_TOKEN_NAME)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN));
+    }
+
+    public String extractRefreshToken(HttpServletRequest request) {
+        return extractCookie(request, REFRESH_TOKEN_NAME)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MISSING_TOKEN));
+    }
+
+    public String extractKakaoToken(HttpServletRequest request) {
+        return extractCookie(request, KAKAO_TOKEN_NAME)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MISSING_TOKEN));
+    }
+
+    public List<ResponseCookie> createAllCookies(LoginResult result, HttpServletRequest request) {
+        return List.of(
+                createCookie(ACCESS_TOKEN_NAME, result.accessToken(), jwtProperties.accessExpiration(), request),
+                createCookie(REFRESH_TOKEN_NAME, result.refreshToken(), jwtProperties.refreshExpiration(), request),
+                createCookie(KAKAO_TOKEN_NAME, result.kakaoAccessToken(), jwtProperties.kakaoExpiration(), request)
+        );
+    }
+
+    public List<ResponseCookie> deleteAllCookies(HttpServletRequest request) {
+        return List.of(
+                deleteCookie(ACCESS_TOKEN_NAME, request),
+                deleteCookie(REFRESH_TOKEN_NAME, request),
+                deleteCookie(KAKAO_TOKEN_NAME, request)
+        );
+    }
+
+    private Optional<String> extractCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return Optional.empty();
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+    }
+
+    private ResponseCookie createCookie(String name, String value, long maxAge, HttpServletRequest request) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(isSecure(request))
+                .sameSite(getSameSite(request))
+                .path("/")
+                .maxAge(Duration.ofMillis(maxAge))
+                .build();
+    }
+
+    private ResponseCookie deleteCookie(String name, HttpServletRequest request) {
+        return ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(isSecure(request))
+                .sameSite(getSameSite(request))
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+
+    private boolean isSecure(HttpServletRequest request) {
+        String serverName = request.getServerName();
+        return !isLocalhost(serverName);
+    }
+
+    private boolean isLocalhost(String host) {
+        return "localhost".equals(host)
+                || "127.0.0.1".equals(host)
+                || "::1".equals(host);
+    }
+
+    private String getSameSite(HttpServletRequest request) {
+        return isSecure(request) ? "None" : "Lax"; // dev용 분기
+    }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -95,6 +95,6 @@ public class JwtCookieProvider {
     }
 
     private String getSameSite(HttpServletRequest request) {
-        return isSecure(request) ? "None" : "Lax"; // dev용 분기
+        return isSecure(request) ? "None" : "Lax";
     }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -6,6 +6,8 @@ import at.mateball.exception.BusinessException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
+import jakarta.servlet.http.Cookie;
+
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtCookieProvider {
+}

--- a/src/main/java/at/mateball/common/jwt/JwtProperties.java
+++ b/src/main/java/at/mateball/common/jwt/JwtProperties.java
@@ -1,4 +1,12 @@
 package at.mateball.common.jwt;
 
-public class JwtProperties {
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        Long accessExpiration,
+        Long refreshExpiration,
+        Long kakaoExpiration
+) {
 }

--- a/src/main/java/at/mateball/common/jwt/JwtProperties.java
+++ b/src/main/java/at/mateball/common/jwt/JwtProperties.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtProperties {
+}

--- a/src/main/java/at/mateball/common/jwt/JwtPropertiesConfiguration.java
+++ b/src/main/java/at/mateball/common/jwt/JwtPropertiesConfiguration.java
@@ -1,4 +1,9 @@
 package at.mateball.common.jwt;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
 public class JwtPropertiesConfiguration {
 }

--- a/src/main/java/at/mateball/common/jwt/JwtPropertiesConfiguration.java
+++ b/src/main/java/at/mateball/common/jwt/JwtPropertiesConfiguration.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtPropertiesConfiguration {
+}

--- a/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
@@ -1,4 +1,58 @@
 package at.mateball.common.jwt;
 
+import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
 public class JwtTokenGenerator {
+
+    private final JwtProperties jwtProperties;
+    private final Key key;
+
+    public JwtTokenGenerator(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, jwtProperties.accessExpiration());
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, jwtProperties.refreshExpiration());
+    }
+
+    private String generateToken(Long userId, long expiryMillis) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expiryMillis);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long extractUserId(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return Long.parseLong(claims.getSubject());
+        } catch (Exception e) {
+            throw new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtTokenGenerator {
+}

--- a/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
@@ -1,4 +1,35 @@
 package at.mateball.common.jwt;
 
+import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.BusinessException;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+
+@Component
 public class JwtTokenValidator {
+
+    private final JwtProperties jwtProperties;
+    private final Key key;
+
+    public JwtTokenValidator(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.key = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public void validate(String token) {
+        try {
+            if (!token.contains(".")) {
+                throw new BusinessException(BusinessErrorCode.INVALID_SERVER_JWT);
+            }
+
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(BusinessErrorCode.KAKAO_CLIENT_ERROR);
+        }
+    }
 }

--- a/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
@@ -2,6 +2,9 @@ package at.mateball.common.jwt;
 
 import at.mateball.exception.BusinessErrorCode;
 import at.mateball.exception.BusinessException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
@@ -1,0 +1,4 @@
+package at.mateball.common.jwt;
+
+public class JwtTokenValidator {
+}

--- a/src/main/java/at/mateball/common/security/CustomUserDetails.java
+++ b/src/main/java/at/mateball/common/security/CustomUserDetails.java
@@ -1,0 +1,26 @@
+package at.mateball.common.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+
+    public CustomUserDetails(Long userId) {
+        this.userId = userId;
+    }
+
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(); }
+    @Override public String getPassword() { return null; }
+    @Override public String getUsername() { return String.valueOf(userId); }
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/at/mateball/domain/LoginResult.java
+++ b/src/main/java/at/mateball/domain/LoginResult.java
@@ -1,0 +1,12 @@
+package at.mateball.domain;
+
+public record LoginResult(
+        String accessToken,
+        String refreshToken,
+        String kakaoAccessToken,
+        Long userId,
+        String birthyear,
+        String gender
+) {
+
+}

--- a/src/main/java/at/mateball/exception/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/BusinessErrorCode.java
@@ -13,6 +13,8 @@ public enum BusinessErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
     INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "Kakao Access Token이 유효하지 않습니다."),
+    INVALID_SERVER_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 서버 JWT입니다."),
+    KAKAO_CLIENT_ERROR(HttpStatus.UNAUTHORIZED, "카카오 JWT 파싱 중 오류가 발생했습니다."),
 
     // 403 FORBIDDEN
 

--- a/src/main/java/at/mateball/exception/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/BusinessErrorCode.java
@@ -1,0 +1,34 @@
+package at.mateball.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BusinessErrorCode {
+    // 400 BAD REQUEST
+    MISSING_TOKEN(HttpStatus.BAD_REQUEST, "요청 쿠키에 토큰이 없습니다."),
+    INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "토큰 형식이 잘못되었습니다."),
+
+    // 401 UNAUTHORIZED
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 유효하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
+    INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "Kakao Access Token이 유효하지 않습니다."),
+
+    // 403 FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404 NOT FOUND
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다."),
+
+    // 405 METHOD NOT ALLOWED
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP 메서드입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    BusinessErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/at/mateball/exception/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/BusinessErrorCode.java
@@ -10,20 +10,14 @@ public enum BusinessErrorCode {
     INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "토큰 형식이 잘못되었습니다."),
 
     // 401 UNAUTHORIZED
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token이 유효하지 않습니다."),
     INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "Kakao Access Token이 유효하지 않습니다."),
 
     // 403 FORBIDDEN
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     // 404 NOT FOUND
-    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다."),
-
-    // 405 METHOD NOT ALLOWED
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP 메서드입니다.");
-
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다.");
     private final HttpStatus status;
     private final String message;
 

--- a/src/main/java/at/mateball/exception/BusinessException.java
+++ b/src/main/java/at/mateball/exception/BusinessException.java
@@ -1,14 +1,14 @@
 package at.mateball.exception;
+
+import lombok.Getter;
+
+@Getter
 public class BusinessException extends RuntimeException {
     private final BusinessErrorCode businessErrorCode;
 
     public BusinessException(BusinessErrorCode businessErrorCode) {
         super(businessErrorCode.getMessage());
         this.businessErrorCode = businessErrorCode;
-    }
-
-    public BusinessErrorCode getErrorCode() {
-        return businessErrorCode;
     }
 }
 

--- a/src/main/java/at/mateball/exception/BusinessException.java
+++ b/src/main/java/at/mateball/exception/BusinessException.java
@@ -1,0 +1,3 @@
+package at.mateball.exception;
+public class BusinessException {
+}

--- a/src/main/java/at/mateball/exception/BusinessException.java
+++ b/src/main/java/at/mateball/exception/BusinessException.java
@@ -1,3 +1,14 @@
 package at.mateball.exception;
-public class BusinessException {
+public class BusinessException extends RuntimeException {
+    private final BusinessErrorCode businessErrorCode;
+
+    public BusinessException(BusinessErrorCode businessErrorCode) {
+        super(businessErrorCode.getMessage());
+        this.businessErrorCode = businessErrorCode;
+    }
+
+    public BusinessErrorCode getErrorCode() {
+        return businessErrorCode;
+    }
 }
+

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -18,6 +18,13 @@ import org.springframework.security.access.AccessDeniedException;
 @RestControllerAdvice
 @Slf4j
 public class GlobalException {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<MateballResponse<?>> handleBusinessException(BusinessException exception) {
+        BusinessErrorCode code = exception.getBusinessErrorCode();
+        return ResponseEntity.status(code.getStatus())
+                .body(new MateballResponse<>(code.getStatus().value(), code.getMessage(), null));
+    }
+
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<MateballResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException exception) {
         return toResponse(ErrorCode.INVALID_REQUEST_BODY);

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -1,6 +1,7 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
+import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
@@ -58,6 +59,11 @@ public class GlobalException {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<MateballResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
         return toResponse(ErrorCode.VALIDATION_ERROR);
+    }
+
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<MateballResponse<?>> handleJwtException(JwtException exception) {
+        return toResponse(ErrorCode.UNAUTHORIZED);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #11 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

> 클라이언트 → accessToken 쿠키 포함 요청
 → `JwtAuthenticationFilter`에서 쿠키 추출 → 검증 및 파싱 → 사용자 인증(Authentication) 생성 → SecurityContext에 등록 → 컨트롤러 진입 시 인증된 사용자 정보 활용 가능

1. `JwtAuthenticationFilter` - 핵심 인증 필터
    - OncePerRequestFilter는 매 요청마다 한 번 실행되는 필터로, 인증 필터에 활용

2. `JwtAuthenticationProvider` - 토큰에서 userId 추출 → UserDetails 생성 → 인증 객체 반환
3. `JwtCookieProvider` - 쿠키에서 토큰 추출, 생성, 삭제
4. `JwtTokenGenerator` - HMAC SHA256 방식으로 토큰 생성
5. `JwtTokenValidator` - 구조적 유효성 및 시그니처 유효성 검증

<br/>


### ❤️ To 다진 / To 헤음

---
* 원래는 각 도메인 별로 BusinessException을 처리하려했으나, 빌드시 문제가 되어, exception에 BusinessExeption을 추가하였습니다. 추후 비지니스 로직관련 예외처리가 필요하다면 이곳에 추가하면 됩니당,,ㅜㅜ
