### PR TITLE
[feat/#14] success code 구현

### DIFF
--- a/src/main/java/at/mateball/common/MateballResponse.java
+++ b/src/main/java/at/mateball/common/MateballResponse.java
@@ -1,7 +1,7 @@
 package at.mateball.common;
 
-import at.mateball.exception.ErrorCode;
-import at.mateball.exception.SuccessCode;
+import at.mateball.exception.code.ErrorCode;
+import at.mateball.exception.code.SuccessCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 public record MateballResponse<T>(

--- a/src/main/java/at/mateball/common/MateballResponse.java
+++ b/src/main/java/at/mateball/common/MateballResponse.java
@@ -1,6 +1,7 @@
 package at.mateball.common;
 
 import at.mateball.exception.ErrorCode;
+import at.mateball.exception.SuccessCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 public record MateballResponse<T>(
@@ -9,11 +10,11 @@ public record MateballResponse<T>(
         @JsonInclude(value = JsonInclude.Include.NON_NULL)
         T data
 ) {
-    public static <T> MateballResponse<T> success(ErrorCode successCode, T data) {
+    public static <T> MateballResponse<T> success(SuccessCode successCode, T data) {
         return new MateballResponse<>(successCode.getStatus().value(), successCode.getMessage(), data);
     }
 
-    public static <T> MateballResponse<T> successWithNoData(ErrorCode successCode) {
+    public static <T> MateballResponse<T> successWithNoData(SuccessCode successCode) {
         return new MateballResponse<>(successCode.getStatus().value(), successCode.getMessage(), null);
     }
 

--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -1,7 +1,7 @@
 package at.mateball.common.jwt;
 
 import at.mateball.domain.LoginResult;
-import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.exception.BusinessException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseCookie;

--- a/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
@@ -1,6 +1,6 @@
 package at.mateball.common.jwt;
 
-import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.exception.BusinessException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenValidator.java
@@ -1,6 +1,6 @@
 package at.mateball.common.jwt;
 
-import at.mateball.exception.BusinessErrorCode;
+import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.exception.BusinessException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/at/mateball/exception/BusinessException.java
+++ b/src/main/java/at/mateball/exception/BusinessException.java
@@ -1,5 +1,6 @@
 package at.mateball.exception;
 
+import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
@@ -1,6 +1,7 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
+import at.mateball.exception.code.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
+import at.mateball.exception.code.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -1,6 +1,8 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
+import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.exception.code.ErrorCode;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;

--- a/src/main/java/at/mateball/exception/SuccessCode.java
+++ b/src/main/java/at/mateball/exception/SuccessCode.java
@@ -1,0 +1,26 @@
+package at.mateball.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum SuccessCode {
+
+    // 200 OK
+    OK(HttpStatus.OK, "요청이 성공적으로 처리되었습니다."),
+
+    // 201 CREATED
+    CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다."),
+
+    // 204 No Content
+    NO_CONTENT(HttpStatus.NO_CONTENT, "응답 본문이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    SuccessCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -1,4 +1,4 @@
-package at.mateball.exception;
+package at.mateball.exception.code;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/at/mateball/exception/code/ErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/ErrorCode.java
@@ -1,4 +1,4 @@
-package at.mateball.exception;
+package at.mateball.exception.code;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/at/mateball/exception/code/SuccessCode.java
+++ b/src/main/java/at/mateball/exception/code/SuccessCode.java
@@ -12,7 +12,7 @@ public enum SuccessCode {
     // 201 CREATED
     CREATED(HttpStatus.CREATED, "리소스가 성공적으로 생성되었습니다."),
 
-    // 204 No Content
+    // 204 NO CONTENT
     NO_CONTENT(HttpStatus.NO_CONTENT, "응답 본문이 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/at/mateball/exception/code/SuccessCode.java
+++ b/src/main/java/at/mateball/exception/code/SuccessCode.java
@@ -1,4 +1,4 @@
-package at.mateball.exception;
+package at.mateball.exception.code;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #14

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- success code 를 생성했습니다
- 기존 error code 타입으로 받아오던 type을 success 로 변환했습니다

<br/>


### ❤️ To 다진 / To 헤음

---

- success code 파일을 response 로 묶어서 MateballResponse와 함께 담아야하나 고민하다가, BusinessErrorCode/errorCode 와 함께 묶이는게 더 통일성 있을 것 같아 code 파일에 담았는데 이렇게 설정해도 괜찮나요??

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new success status codes for responses, including OK, CREATED, and NO_CONTENT, each with descriptive messages.

* **Refactor**
  * Updated usage of success and error codes throughout the application to reference newly organized code packages.
  * Adjusted method signatures to use the new success code type for response creation.

* **Chores**
  * Improved internal code organization by relocating and updating references to error and business error code classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->