### PR TITLE
[feat] 서비스 도메인 생성

### DIFF
--- a/src/main/java/at/mateball/domain/game_information/core/GameInformation.java
+++ b/src/main/java/at/mateball/domain/game_information/core/GameInformation.java
@@ -1,0 +1,43 @@
+package at.mateball.domain.game_information.core;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@Table(name = "game_information")
+public class GameInformation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 45, nullable = false)
+    private String awayTeamName;
+
+    @Column(length = 45, nullable = false)
+    private String homeTeamName;
+
+    @Column(nullable = false)
+    private LocalDate gameDate;
+
+    @Column(nullable = false)
+    private LocalTime gameTime;
+
+    @Column(length = 45, nullable = false)
+    private String stadiumName;
+
+    protected GameInformation() {
+    }
+
+    public GameInformation(String awayTeamName, String homeTeamName, LocalDate gameDate, LocalTime gameTime, String stadiumName) {
+        this.awayTeamName = awayTeamName;
+        this.homeTeamName = homeTeamName;
+        this.gameDate = gameDate;
+        this.gameTime = gameTime;
+        this.stadiumName = stadiumName;
+    }
+}

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -28,7 +28,7 @@ public class Group {
     private LocalDateTime createdAt;
 
     @Column(nullable = false)
-    private int status = 1; // TODO: "대기중"==1 로 기본값 설정함. 값 확정 필요
+    private int status;
 
     @Column(nullable = true, length = 1000)
     private String chattingUrl;

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -33,13 +33,17 @@ public class Group {
     @Column(length = 1000)
     private String chattingUrl;
 
+    @Column(nullable = false)
+    private boolean isGroup;
+
     protected Group() {
     }
 
-    public Group(User leader, GameInformation gameInformation, LocalDateTime createdAt, int status) {
+    public Group(User leader, GameInformation gameInformation, LocalDateTime createdAt, int status, boolean isGroup) {
         this.leader = leader;
         this.gameInformation = gameInformation;
         this.createdAt = createdAt;
         this.status = status;
+        this.isGroup = isGroup;
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -27,8 +27,8 @@ public class Group {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
-    private Integer status = 1; // TODO: "대기중"==1 로 기본값 설정함. Integer 값 확정 필요
+    @Column(nullable = true)
+    private int status = 1; // TODO: "대기중"==1 로 기본값 설정함. 값 확정 필요
 
     @Column(length = 1000)
     private String chattingUrl;
@@ -36,7 +36,7 @@ public class Group {
     protected Group() {
     }
 
-    public Group(User leader, GameInformation gameInformation, LocalDateTime createdAt, Integer status) {
+    public Group(User leader, GameInformation gameInformation, LocalDateTime createdAt, int status) {
         this.leader = leader;
         this.gameInformation = gameInformation;
         this.createdAt = createdAt;

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -21,7 +21,7 @@ public class Group {
     private User leader;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "game_information_id", nullable = false, unique = true)
+    @JoinColumn(name = "game_information_id", nullable = false)
     private GameInformation gameInformation;
 
     @Column(nullable = false)

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -1,0 +1,45 @@
+package at.mateball.domain.group.core;
+
+import at.mateball.domain.game_information.core.GameInformation;
+import at.mateball.domain.user.core.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "match_group")
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // TODO: user,leader 네이밍 고민
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "game_information_id", nullable = false, unique = true)
+    private GameInformation gameInformation;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private Integer status = 1; // TODO: "대기중"==1 로 기본값 설정함. Integer 값 확정 필요
+
+    @Column(length = 1000)
+    private String chattingUrl;
+
+    protected Group() {
+    }
+
+    public Group(User user, GameInformation gameInformation, LocalDateTime createdAt, Integer status) {
+        this.user = user;
+        this.gameInformation = gameInformation;
+        this.createdAt = createdAt;
+        this.status = status;
+    }
+}

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -27,7 +27,7 @@ public class Group {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private int status = 1; // TODO: "대기중"==1 로 기본값 설정함. 값 확정 필요
 
     @Column(nullable = true, length = 1000)

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -30,7 +30,7 @@ public class Group {
     @Column(nullable = true)
     private int status = 1; // TODO: "대기중"==1 로 기본값 설정함. 값 확정 필요
 
-    @Column(length = 1000)
+    @Column(nullable = true, length = 1000)
     private String chattingUrl;
 
     @Column(nullable = false)

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -18,7 +18,7 @@ public class Group {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
-    private User user; // TODO: user,leader 네이밍 고민
+    private User leader;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "game_information_id", nullable = false, unique = true)
@@ -36,8 +36,8 @@ public class Group {
     protected Group() {
     }
 
-    public Group(User user, GameInformation gameInformation, LocalDateTime createdAt, Integer status) {
-        this.user = user;
+    public Group(User leader, GameInformation gameInformation, LocalDateTime createdAt, Integer status) {
+        this.leader = leader;
         this.gameInformation = gameInformation;
         this.createdAt = createdAt;
         this.status = status;

--- a/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
@@ -25,13 +25,13 @@ public class GroupMember {
     @Column(nullable = false)
     private Boolean isParticipant = false;
 
-    @Column(nullable = false)
-    private Integer status = 3; // TODO: "승인 대기 중"==3 로 기본값 설정함. Integer 값 확정 필요
+    @Column(nullable = true)
+    private int status = 3; // TODO: "승인 대기 중"==3 로 기본값 설정함. 값 확정 필요
 
     protected GroupMember() {
     }
 
-    public GroupMember(User user, Group group, Boolean isParticipant, Integer status) {
+    public GroupMember(User user, Group group, Boolean isParticipant, int status) {
         this.user = user;
         this.group = group;
         this.isParticipant = isParticipant;

--- a/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
@@ -26,7 +26,7 @@ public class GroupMember {
     private Boolean isParticipant = false;
 
     @Column(nullable = false)
-    private int status = 3; // TODO: "승인 대기 중"==3 로 기본값 설정함. 값 확정 필요
+    private int status;
 
     protected GroupMember() {
     }

--- a/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
@@ -25,7 +25,7 @@ public class GroupMember {
     @Column(nullable = false)
     private Boolean isParticipant = false;
 
-    @Column(nullable = true)
+    @Column(nullable = false)
     private int status = 3; // TODO: "승인 대기 중"==3 로 기본값 설정함. 값 확정 필요
 
     protected GroupMember() {

--- a/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/group_member/core/GroupMember.java
@@ -1,0 +1,40 @@
+package at.mateball.domain.group_member.core;
+
+import at.mateball.domain.group.core.Group;
+import at.mateball.domain.user.core.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "group_member")
+public class GroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(nullable = false)
+    private Boolean isParticipant = false;
+
+    @Column(nullable = false)
+    private Integer status = 3; // TODO: "승인 대기 중"==3 로 기본값 설정함. Integer 값 확정 필요
+
+    protected GroupMember() {
+    }
+
+    public GroupMember(User user, Group group, Boolean isParticipant, Integer status) {
+        this.user = user;
+        this.group = group;
+        this.isParticipant = isParticipant;
+        this.status = status;
+    }
+}

--- a/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
@@ -14,7 +14,7 @@ public class MatchRequirement {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false, unique = true) // TODO: 앱잼 기간 내에는 하나만이니까 unique 설정, 스프린트에서는 삭제 필요
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false)

--- a/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
@@ -20,7 +20,7 @@ public class MatchRequirement {
     @Column(nullable = false)
     private Integer team;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Integer teamAllowed;
 
     @Column(nullable = false)

--- a/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
@@ -1,0 +1,42 @@
+package at.mateball.domain.match_requirement.core;
+
+import at.mateball.domain.user.core.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "match_requirement")
+public class MatchRequirement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true) // TODO: 앱잼 기간 내에는 하나만이니까 unique 설정, 스프린트에서는 삭제 필요
+    private User user;
+
+    @Column(nullable = false)
+    private Integer team;
+
+    @Column(nullable = false)
+    private Integer teamAllowed;
+
+    @Column(nullable = false)
+    private Integer style;
+
+    @Column(nullable = false)
+    private Integer genderPreference;
+
+    protected MatchRequirement() {
+    }
+
+    public MatchRequirement(User user, Integer team, Integer teamAllowed, Integer style, Integer genderPreference) {
+        this.user = user;
+        this.team = team;
+        this.teamAllowed = teamAllowed;
+        this.style = style;
+        this.genderPreference = genderPreference;
+    }
+}

--- a/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/match_requirement/core/MatchRequirement.java
@@ -18,21 +18,21 @@ public class MatchRequirement {
     private User user;
 
     @Column(nullable = false)
-    private Integer team;
+    private int team;
 
     @Column(nullable = true)
     private Integer teamAllowed;
 
     @Column(nullable = false)
-    private Integer style;
+    private int style;
 
     @Column(nullable = false)
-    private Integer genderPreference;
+    private int genderPreference;
 
     protected MatchRequirement() {
     }
 
-    public MatchRequirement(User user, Integer team, Integer teamAllowed, Integer style, Integer genderPreference) {
+    public MatchRequirement(User user, int team, Integer teamAllowed, int style, int genderPreference) {
         this.user = user;
         this.team = team;
         this.teamAllowed = teamAllowed;

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -1,9 +1,11 @@
 package at.mateball.domain.user.core;
 
+import at.mateball.domain.match_requirement.core.MatchRequirement;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,12 +16,23 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private Long kakaoUserId;
-    @Column
+
+    @Column(nullable = false)
     private String gender;
-    @Column
+
+    @Column(nullable = false)
     private String birthyear;
+
+    @Column(length = 45)
+    private String nickname;
+
+    @Column(length = 500)
+    private String introduction;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
     protected User() {
 
@@ -29,5 +42,13 @@ public class User {
         this.kakaoUserId = kakaoUserId;
         this.gender = gender;
         this.birthyear = birthyear;
+    }
+
+    public void updateNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateIntroduction(final String introduction) {
+        this.introduction = introduction;
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -25,10 +25,10 @@ public class User {
     @Column(nullable = false)
     private String birthyear;
 
-    @Column(length = 45)
+    @Column(nullable = true, length = 45)
     private String nickname;
 
-    @Column(length = 500)
+    @Column(nullable = true, length = 500)
     private String introduction;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "member")
+@Table(name = "user")
 public class User {
 
     @Id

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -23,7 +23,7 @@ public class User {
     private String gender;
 
     @Column(nullable = false)
-    private String birthyear;
+    private String birthYear;
 
     @Column(nullable = true, length = 45)
     private String nickname;
@@ -38,10 +38,10 @@ public class User {
 
     }
 
-    public User(Long kakaoUserId, String gender, String birthyear) {
+    public User(Long kakaoUserId, String gender, String birthYear) {
         this.kakaoUserId = kakaoUserId;
         this.gender = gender;
-        this.birthyear = birthyear;
+        this.birthYear = birthYear;
     }
 
     public void updateNickname(final String nickname) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #19 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- `user`,`group`,`groupmember`,`matchrequirement`,`gameinformation` 엔티티를 생성했습니다. 
(user 는 일단 소셜 로그인 PR 에서 가져와 수정했습니다!)
- 기본적으로 optional,nullable 여부와 (String의 경우)길이를 설정했습니다.
- `group의 status`, `group member의 status`는 지난 노션에 status별로 숫자가 지정된 것을 바탕으로 기본값을 넣었습니다! 확정은 아닐수도 있다고 생각하여, 주석으로 설명 표시했습니다 :)
![image](https://github.com/user-attachments/assets/d6a57b34-8f9b-4a6e-8c13-c6a68bde1ad8)
- user와 동일하게, group table 의 경우도 mysql 의 예약어와 충돌하는 문제가 생겨 (group 테이블명 대신) match_group 이라는 네이밍으로 설정했습니다.
- group 에서 user_id (방장) 을 가져오는데, 방장의 의미가 더 잘보일 것 같은 (user->)leader 로 객체명을 설정했습니다!

```java
@Entity
@Getter
@Table(name = "match_group")
public class Group {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "user_id", nullable = false)
    private User leader;

    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "game_information_id", nullable = false, unique = true)
    private GameInformation gameInformation;

    ...
}
```
- 일대일 관계일때 @onetoone 을 사용하면, n+1 문제가 발생하므로, @ManyToOne을 사용하는 대신, @JoinColumn(unique=true) 로 설정했습니다. 

```java
@Entity
@Getter
@Table(name = "match_requirement")
public class MatchRequirement {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "user_id", nullable = false, unique = true) 
    // TODO: 앱잼 기간 내에는 하나만이니까 unique 설정, 스프린트에서는 삭제 필요
    private User user;

    ...
}
``` 

- `@JoinColumn(name = "user_id", nullable = false, unique = true) `
추가적으로, 앱잼 기간동안에는, 유저 매칭조건을 하나만 설정할 수 있기에 unique 옵션을 사용해 중복되지 않도록 설정했습니다! 이후 스프린트 기간에는 unique 설정을 지워주면 될 것 같아요!!

<br/>


### ❤️ To 다진 / To 헤음

---

- `group->match_group 테이블명을 변환한 것이 괜찮은지`,`user -> leader 객체명을 변환한 것이 괜찮은지`,일`일대일 관계에서 @JoinColumn(unique=true) 의 방법이 괜찮은지` 에 대해서 리드님의 의견이 궁금합니다!!
- 그룹/그룹원에서 사용되는 status를 지금 만들어둘까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced new entities for managing game information, user groups, group memberships, match requirements, and user profiles.
  * Users can now have profiles with nickname and introduction fields.
  * Support added for capturing game details, group creation with leaders, and user match preferences.

* **Enhancements**
  * Enabled associations between users, groups, and game information for improved group and match management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->