### PR TITLE
[feat] 카카오 로그인 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 ### yml ###
 application.yml
 application-local.yml
+application-test.yml
 
 ### env ###
 .env

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
@@ -5,8 +5,9 @@ public record LoginResult(
         String refreshToken,
         String kakaoAccessToken,
         Long userId,
-        String birthyear,
-        String gender
+        String gender,
+
+        String birthyear
 ) {
 
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
@@ -3,4 +3,5 @@ package at.mateball.domain.auth.api.dto;
 public record LoginUserInfo(
         Long userId,
         String gender,
-        String birthyear) {}
+        String birthyear
+) {}

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
@@ -1,7 +1,9 @@
 package at.mateball.domain.auth.api.dto.kakao;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record KakaoAccount(
         String gender,
-        String birthyear
+        @JsonProperty("birthyear") String birthyear
 ) {
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
@@ -1,7 +1,6 @@
 package at.mateball.domain.auth.api.dto.kakao;
 
 public record KakaoAccount(
-        String email,
         String gender,
         String birthyear
 ) {

--- a/src/main/java/at/mateball/util/RequestUtils.java
+++ b/src/main/java/at/mateball/util/RequestUtils.java
@@ -3,37 +3,13 @@ package at.mateball.util;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class RequestUtils {
-    private static final String[] LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"};
-
-    public static boolean isLocalhost(String host) {
-        if (host == null) {
-            return false;
-        }
-
-        for (String local : LOCAL_HOSTS) {
-            if(local.equals(host)) return true;
-        }
-
-        return false;
-    }
-
-    public static boolean isLocalRequest(HttpServletRequest request) {
-        return isLocalhost(request.getServerName());
-    }
 
     public static boolean isLocalOrigin(HttpServletRequest request) {
         String origin = request.getHeader("Origin");
-        String referer = request.getHeader("Referer");
-        String base = origin != null ? origin : referer;
-
-        if (base == null) {
-            return false;
-        }
-
-        for (String local : LOCAL_HOSTS) {
-            if(base.contains(local)) return true;
-        }
-
-        return false;
+        String host = request.getServerName();
+        return (origin != null && origin.contains("localhost"))
+                || "localhost".equals(host)
+                || "127.0.0.1".equals(host)
+                || "::1".equals(host);
     }
 }

--- a/src/test/java/at/mateball/kakao/JwtTokenGeneratorTest.java
+++ b/src/test/java/at/mateball/kakao/JwtTokenGeneratorTest.java
@@ -1,0 +1,64 @@
+package at.mateball.kakao;
+
+import at.mateball.common.jwt.JwtTokenGenerator;
+import at.mateball.common.jwt.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenGeneratorTest {
+
+    private JwtTokenGenerator jwtTokenGenerator;
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties props = new JwtProperties(
+                "test-test-test-test-test-test-test-test",
+                3600000L,
+                1209600000L,
+                600000L
+        );
+        jwtTokenGenerator = new JwtTokenGenerator(props);
+        key = Keys.hmacShaKeyFor(props.secret().getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void accessToken_생성_및_검증() {
+        // given
+        Long userId = 1L;
+
+        // when
+        String token = jwtTokenGenerator.generateAccessToken(userId);
+
+        // then
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor("test-test-test-test-test-test-test-test".getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        assertThat(claims.getSubject()).isEqualTo("1");
+        assertThat(claims.getExpiration()).isAfter(new Date());
+    }
+
+    @Test
+    void refreshToken_생성_성공() {
+        // given
+        Long userId = 123L;
+
+        // when
+        String token = jwtTokenGenerator.generateRefreshToken(userId);
+
+        // then
+        assertThat(token).isNotNull();
+    }
+}

--- a/src/test/java/at/mateball/kakao/LoginServiceTest.java
+++ b/src/test/java/at/mateball/kakao/LoginServiceTest.java
@@ -1,4 +1,106 @@
 package at.mateball.kakao;
 
-public class LoginServiceTest {
+import at.mateball.common.jwt.JwtTokenGenerator;
+import at.mateball.domain.auth.api.dto.LoginCommand;
+import at.mateball.domain.auth.api.dto.LoginResult;
+import at.mateball.domain.auth.api.dto.kakao.KakaoTokenRes;
+import at.mateball.domain.auth.api.dto.kakao.KakaoUserRes;
+import at.mateball.domain.auth.api.dto.kakao.KakaoAccount;
+import at.mateball.domain.auth.core.config.OauthClientApi;
+import at.mateball.domain.auth.core.config.RedirectUriResolver;
+import at.mateball.domain.auth.core.service.LoginService;
+import at.mateball.domain.auth.core.service.TokenService;
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import org.mockito.ArgumentCaptor;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock
+    private OauthClientApi oauthClientApi;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtTokenGenerator jwtTokenGenerator;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private RedirectUriResolver redirectUriResolver;
+
+    @InjectMocks
+    private LoginService loginService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    void login_신규유저_정상로그인() {
+        // given
+        String code = "auth_code";
+        String redirectUri = "https://mateball.co.kr/auth";
+        String kakaoAccessToken = "kakaoAccessToken";
+        String kakaoRefreshToken = "kakaoRefreshToken";
+
+        Long kakaoUserId = 12345L;
+        String gender = "male";
+        String birthYear = "1994";
+
+        KakaoTokenRes kakaoTokenRes = new KakaoTokenRes(kakaoAccessToken, kakaoRefreshToken);
+        KakaoUserRes kakaoUserRes = new KakaoUserRes(kakaoUserId,
+                new KakaoAccount(gender, birthYear));
+        User userEntity = kakaoUserRes.toEntity();
+        ReflectionTestUtils.setField(userEntity, "id", 1L);
+
+        String jwtAccessToken = "jwtAccessToken";
+        String jwtRefreshToken = "jwtRefreshToken";
+        LoginCommand command = new LoginCommand(code);
+
+        // when
+        when(redirectUriResolver.resolve(request)).thenReturn(redirectUri);
+        when(oauthClientApi.fetchToken(code, redirectUri)).thenReturn(kakaoTokenRes);
+        when(oauthClientApi.fetchUser(kakaoAccessToken)).thenReturn(kakaoUserRes);
+        when(userRepository.findByKakaoUserId(kakaoUserId)).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenReturn(userEntity);
+        when(jwtTokenGenerator.generateAccessToken(1L)).thenReturn(jwtAccessToken);
+        when(jwtTokenGenerator.generateRefreshToken(1L)).thenReturn(jwtRefreshToken);
+
+        LoginResult result = loginService.login(command, request);
+
+        // then
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User savedUser = userCaptor.getValue();
+        assertThat(savedUser.getGender()).isEqualTo(gender);
+        assertThat(savedUser.getBirthYear()).isEqualTo(birthYear);
+
+        assertThat(result.accessToken()).isEqualTo(jwtAccessToken);
+        assertThat(result.refreshToken()).isEqualTo(jwtRefreshToken);
+        assertThat(result.kakaoAccessToken()).isEqualTo(kakaoAccessToken);
+        assertThat(result.userId()).isEqualTo(1L);
+
+        verify(oauthClientApi).fetchToken(code, redirectUri);
+        verify(oauthClientApi).fetchUser(kakaoAccessToken);
+        verify(userRepository).save(any(User.class));
+        verify(jwtTokenGenerator).generateAccessToken(1L);
+        verify(jwtTokenGenerator).generateRefreshToken(1L);
+        verify(tokenService).save(1L, jwtRefreshToken);
+    }
 }

--- a/src/test/java/at/mateball/kakao/LoginServiceTest.java
+++ b/src/test/java/at/mateball/kakao/LoginServiceTest.java
@@ -1,0 +1,4 @@
+package at.mateball.kakao;
+
+public class LoginServiceTest {
+}

--- a/src/test/java/at/mateball/kakao/TokenServiceIntegrationTest.java
+++ b/src/test/java/at/mateball/kakao/TokenServiceIntegrationTest.java
@@ -1,0 +1,40 @@
+package at.mateball.kakao;
+
+import at.mateball.domain.auth.core.RefreshToken;
+import at.mateball.domain.auth.core.repository.RefreshTokenRepository;
+import at.mateball.domain.auth.core.service.TokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class TokenServiceIntegrationTest {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    void 실제_redis에_refreshToken_저장확인() {
+        // given
+        Long userId = 123L;
+        String token = "realToken";
+
+        // when
+        tokenService.save(userId, token);
+
+        // then
+        Optional<RefreshToken> saved = refreshTokenRepository.findById("RT:" + userId);
+        assertThat(saved).isPresent();
+        assertThat(saved.get().getValue()).isEqualTo(token);
+    }
+}
+

--- a/src/test/java/at/mateball/kakao/TokenServiceIntegrationTest.java
+++ b/src/test/java/at/mateball/kakao/TokenServiceIntegrationTest.java
@@ -36,5 +36,34 @@ class TokenServiceIntegrationTest {
         assertThat(saved).isPresent();
         assertThat(saved.get().getValue()).isEqualTo(token);
     }
+
+    @Test
+    void redis에_저장된_refreshToken_검증_성공() {
+        // given
+        Long userId = 456L;
+        String token = "validateToken";
+        tokenService.save(userId, token);
+
+        // when
+        boolean isValid = tokenService.validate(userId, token);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void redis에_저장된_refreshToken_검증_실패() {
+        // given
+        Long userId = 789L;
+        String savedToken = "actualToken";
+        String wrongToken = "fakeToken";
+        tokenService.save(userId, savedToken);
+
+        // when
+        boolean isValid = tokenService.validate(userId, wrongToken);
+
+        // then
+        assertThat(isValid).isFalse();
+    }
 }
 

--- a/src/test/java/at/mateball/kakao/TokenServiceTest.java
+++ b/src/test/java/at/mateball/kakao/TokenServiceTest.java
@@ -1,0 +1,50 @@
+package at.mateball.kakao;
+
+import at.mateball.domain.auth.core.RefreshToken;
+import at.mateball.domain.auth.core.repository.RefreshTokenRepository;
+import at.mateball.domain.auth.core.service.TokenService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Test
+    void save_호출시_리포지토리에_저장됨() {
+        Long userId = 1L;
+        String token = "testToken";
+
+        tokenService.save(userId, token);
+
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    void validate_정상토큰_일치하면_true() {
+        Long userId = 1L;
+        String token = "testToken";
+
+        when(refreshTokenRepository.findById("RT:" + userId))
+                .thenReturn(Optional.of(new RefreshToken("RT:" + userId, token)));
+
+        boolean result = tokenService.validate(userId, token);
+
+        assertThat(result).isTrue();
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #17 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

1. JwtTokenGeneratorTest
→ accessToken, refreshToken 생성 및 claim 파싱 검증 완료

2. LoginServiceTest
→ 신규 카카오 사용자 로그인 흐름을 Mock으로 전부 검증 (redirectUriResolver, OauthClientApi, JwtTokenGenerator, UserRepository, TokenService)

3. TokenServiceTest, TokenServiceIntegrationTest
→ Redis에 refreshToken 저장 및 검증 로직을 단위/통합 관점 모두에서 테스트

```
https://kauth.kakao.com/oauth/authorize?response_type=code
&client_id=...
&redirect_uri=http://localhost:8080/auth/login
&scope=gender,birthyear
```
4. 로그인 후 code 파라미터가 /auth/login으로 리다이렉트되는지 확인. /auth/login?code=xxx 호출 시, accessToken/refreshToken/kakaoAccessToken 모두 정상적으로 Set-Cookie 헤더에 포함되는지 브라우저 Network > Response Headers에서 검증

- accessToken 저장 누락

원인은 RedirectUriResolver에서 redirectUri를 잘못 판단하여 prod 환경 URI로 설정되었기 때문

그로 인해 카카오 인가 코드 요청과 redirect_uri가 불일치 → 토큰 발급은 되었지만 이후 JWT 발급 실패로 이어짐 → accessToken 누락

[해결 방법 요약]
RequestUtils.isLocalOrigin(HttpServletRequest) 유틸리티 메서드 개선

request.getServerName()과 Origin 헤더 기반으로 localhost, 127.0.0.1, ::1 등을 정확히 판별

RedirectUriResolver는 변경 없이 유지하고, 내부 분기만 정확하게 수행되도록 유틸 보완
<br/>


### ❤️ To 다진 / To 헤음

---
- 배포 후, 토큰 전달하여 앞으로 api 테스트에 사용할수있도록 해야함다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted handling of user information fields and JSON property mapping for improved compatibility.
  * Updated logic for identifying local requests for greater reliability.

* **Chores**
  * Updated `.gitignore` to exclude additional configuration files from version control.

* **Tests**
  * Added new unit and integration tests for login, JWT token generation, and token service functionality, including Redis integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->