### PR TITLE
[feat] 에러 코드 구조 변경

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -6,21 +6,19 @@ import lombok.Getter;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static at.mateball.exception.code.ErrorCode.*;
+import static at.mateball.exception.code.CommonErrorCode.*;
 
 @Getter
 public enum SwaggerResponseDescription {
 
-    SAMPLE_GET(new LinkedHashSet<>(Set.of(
-    ))),
-    SAMPLE_POST(new LinkedHashSet<>(Set.of(
-            // enum을 사용하려는 api에서 해당되는 에러만 추가 -> ex) 300자 이상 입력해야합니다
-    )));
+    UPDATE_NICKNAME(
+            new LinkedHashSet<>(Set.of())
+    );
 
-    private final Set<ErrorCode> errorCodeList;
+    private final Set<ErrorCode> commonErrorCodeList;
 
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
-        errorCodeList.addAll(new LinkedHashSet<>(Set.of(
+        errorCodeList.addAll(Set.of(
                 INVALID_REQUEST_BODY,
                 MISSING_PATH_VARIABLE,
                 METHOD_ARGUMENT_TYPE_MISMATCH,
@@ -32,9 +30,9 @@ public enum SwaggerResponseDescription {
                 INTERNAL_SERVER_ERROR,
                 VALIDATION_ERROR,
                 ILLEGAL_ARGUMENT
-        )));
+        ));
 
-        this.errorCodeList = errorCodeList;
+        this.commonErrorCodeList = errorCodeList;
     }
 
 }

--- a/src/main/java/at/mateball/config/SwaggerConfig.java
+++ b/src/main/java/at/mateball/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.ExampleHolder;
 import at.mateball.common.swagger.SwaggerResponseDescription;
+import at.mateball.exception.code.CommonErrorCode;
 import at.mateball.exception.code.ErrorCode;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -95,15 +96,15 @@ public class SwaggerConfig {
 
         ApiResponses responses = operation.getResponses();
 
-        Set<ErrorCode> errorCodeList = type.getErrorCodeList();
+        Set<ErrorCode> commonErrorCodeList = type.getCommonErrorCodeList();
 
         Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
-                errorCodeList.stream()
+                commonErrorCodeList.stream()
                         .map(
                                 errorCode -> {
                                     return ExampleHolder.builder()
                                             .holder(
-                                                    createSwaggerErrorExample(errorCode))
+                                                    createSwaggerErrorExample((CommonErrorCode) errorCode))
                                             .code(errorCode.getStatus().value())
                                             .name(errorCode.toString())
                                             .build();
@@ -112,8 +113,8 @@ public class SwaggerConfig {
         addExamplesToResponses(responses, statusWithExampleHolders);
     }
 
-    private Example createSwaggerErrorExample(ErrorCode errorCode) {
-        MateballResponse<Void> errorResponse = new MateballResponse<>(errorCode.getStatus().value(), errorCode.getMessage(), null);
+    private Example createSwaggerErrorExample(CommonErrorCode commonErrorCode) {
+        MateballResponse<Void> errorResponse = new MateballResponse<>(commonErrorCode.getStatus().value(), commonErrorCode.getMessage(), null);
         Example example = new Example();
         example.setValue(errorResponse);
         return example;

--- a/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/at/mateball/exception/CustomAccessDeniedHandler.java
@@ -1,7 +1,7 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
-import at.mateball.exception.code.ErrorCode;
+import at.mateball.exception.code.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,7 +21,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException {
-        MateballResponse<?> errorResponse = MateballResponse.failure(ErrorCode.FORBIDDEN);
+        MateballResponse<?> errorResponse = MateballResponse.failure(CommonErrorCode.FORBIDDEN);
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/at/mateball/exception/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,7 @@
 package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
-import at.mateball.exception.code.ErrorCode;
+import at.mateball.exception.code.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,7 +21,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             HttpServletResponse response,
             AuthenticationException authenticationException
     ) throws IOException {
-        MateballResponse<?> errorResponse = MateballResponse.failure(ErrorCode.UNAUTHORIZED);
+        MateballResponse<?> errorResponse = MateballResponse.failure(CommonErrorCode.UNAUTHORIZED);
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/at/mateball/exception/GlobalException.java
+++ b/src/main/java/at/mateball/exception/GlobalException.java
@@ -2,7 +2,7 @@ package at.mateball.exception;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.exception.code.BusinessErrorCode;
-import at.mateball.exception.code.ErrorCode;
+import at.mateball.exception.code.CommonErrorCode;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
@@ -30,67 +30,67 @@ public class GlobalException {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<MateballResponse<?>> handleHttpMessageNotReadable(HttpMessageNotReadableException exception) {
-        return toResponse(ErrorCode.INVALID_REQUEST_BODY);
+        return toResponse(CommonErrorCode.INVALID_REQUEST_BODY);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<MateballResponse<?>> handleTypeMismatch(MethodArgumentTypeMismatchException exception) {
-        return toResponse(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
+        return toResponse(CommonErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
     }
 
     @ExceptionHandler(MissingPathVariableException.class)
     public ResponseEntity<MateballResponse<?>> handleMissingPathVariable(MissingPathVariableException exception) {
-        return toResponse(ErrorCode.MISSING_PATH_VARIABLE);
+        return toResponse(CommonErrorCode.MISSING_PATH_VARIABLE);
     }
 
     @ExceptionHandler(MissingRequestHeaderException.class)
     public ResponseEntity<MateballResponse<?>> handleMissingRequestHeader(MissingRequestHeaderException exception) {
-        return toResponse(ErrorCode.UNAUTHORIZED_HEADER);
+        return toResponse(CommonErrorCode.UNAUTHORIZED_HEADER);
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<MateballResponse<?>> handleNotFound(NoResourceFoundException exception) {
-        return toResponse(ErrorCode.NOT_FOUND_URL);
+        return toResponse(CommonErrorCode.NOT_FOUND_URL);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<MateballResponse<?>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException exception) {
-        return toResponse(ErrorCode.METHOD_NOT_ALLOWED);
+        return toResponse(CommonErrorCode.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<MateballResponse<?>> handleValidation(MethodArgumentNotValidException ex) {
-        return toResponse(ErrorCode.VALIDATION_ERROR);
+        return toResponse(CommonErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(JwtException.class)
     public ResponseEntity<MateballResponse<?>> handleJwtException(JwtException exception) {
-        return toResponse(ErrorCode.UNAUTHORIZED);
+        return toResponse(CommonErrorCode.UNAUTHORIZED);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<MateballResponse<?>> handleValidation(ConstraintViolationException exception) {
-        return toResponse(ErrorCode.VALIDATION_ERROR);
+        return toResponse(CommonErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<MateballResponse<?>> handleIllegalArgument(IllegalArgumentException ex) {
-        return toResponse(ErrorCode.ILLEGAL_ARGUMENT);
+        return toResponse(CommonErrorCode.ILLEGAL_ARGUMENT);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<MateballResponse<?>> handleAccessDenied(AccessDeniedException ex) {
-        return toResponse(ErrorCode.FORBIDDEN);
+        return toResponse(CommonErrorCode.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<MateballResponse<?>> handleException(Exception ex) {
         log.error("서버 내부 오류 : ", ex);
-        return toResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+        return toResponse(CommonErrorCode.INTERNAL_SERVER_ERROR);
     }
 
-    private ResponseEntity<MateballResponse<?>> toResponse(ErrorCode errorCode) {
-        return ResponseEntity.status(errorCode.getStatus())
-                .body(MateballResponse.failure(errorCode));
+    private ResponseEntity<MateballResponse<?>> toResponse(CommonErrorCode commonErrorCode) {
+        return ResponseEntity.status(commonErrorCode.getStatus())
+                .body(MateballResponse.failure(commonErrorCode));
     }
 }

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum BusinessErrorCode {
+public enum BusinessErrorCode implements ErrorCode {
     // 400 BAD REQUEST
     MISSING_TOKEN(HttpStatus.BAD_REQUEST, "요청 쿠키에 토큰이 없습니다."),
     INVALID_TOKEN_FORMAT(HttpStatus.BAD_REQUEST, "토큰 형식이 잘못되었습니다."),

--- a/src/main/java/at/mateball/exception/code/CommonErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/CommonErrorCode.java
@@ -1,0 +1,42 @@
+package at.mateball.exception.code;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+
+    // 400 BAD REQUEST
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 잘못되었습니다."),
+    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST, "경로 변수가 누락된 잘못된 URL입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 잘못되었습니다."),
+
+    // 401 UNAUTHORIZED
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    UNAUTHORIZED_HEADER(HttpStatus.UNAUTHORIZED, "요청 헤더가 올바르지 않는 토큰입니다."),
+
+    // 403 FORBIDDEN
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // 404 NOT FOUND
+    NOT_FOUND_URL(HttpStatus.NOT_FOUND, "요청한 URL을 찾을 수 없습니다."),
+
+    // 405 METHOD NOT ALLOWED
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP 메서드입니다."),
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // VALIDATION
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값이 유효하지 않습니다."),
+    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 전달되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    CommonErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/at/mateball/exception/code/ErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/ErrorCode.java
@@ -1,42 +1,8 @@
 package at.mateball.exception.code;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-@Getter
-public enum ErrorCode {
-
-    // 400 BAD REQUEST
-    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "요청 본문이 잘못되었습니다."),
-    MISSING_PATH_VARIABLE(HttpStatus.BAD_REQUEST, "경로 변수가 누락된 잘못된 URL입니다."),
-    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 파라미터 타입이 잘못되었습니다."),
-
-    // 401 UNAUTHORIZED
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
-    UNAUTHORIZED_HEADER(HttpStatus.UNAUTHORIZED, "요청 헤더가 올바르지 않는 토큰입니다."),
-
-    // 403 FORBIDDEN
-    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-
-    // 404 NOT FOUND
-    NOT_FOUND_URL(HttpStatus.NOT_FOUND, "요청한 URL을 찾을 수 없습니다."),
-
-    // 405 METHOD NOT ALLOWED
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP 메서드입니다."),
-
-    // 500 INTERNAL SERVER ERROR
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
-
-    // VALIDATION
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "요청값이 유효하지 않습니다."),
-    ILLEGAL_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자가 전달되었습니다.");
-
-    private final HttpStatus status;
-    private final String message;
-
-    ErrorCode(HttpStatus status, String message) {
-        this.status = status;
-        this.message = message;
-    }
-
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #40

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 errorcode 를 enum class - > interface 로 변경했습니다
- 비즈니스/글로버 에러코드는 이를 상속받는 구조로 설정했습니다

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 공통 에러 코드(enum)인 CommonErrorCode가 추가되어 다양한 HTTP 오류 상황에 대한 메시지와 상태를 제공합니다.

* **버그 수정**
  * 인증 및 인가 오류 발생 시, 더 명확한 공통 에러 코드 메시지가 반환됩니다.

* **리팩토링**
  * 에러 코드 구조가 개선되어, ErrorCode가 enum에서 인터페이스로 변경되고, BusinessErrorCode와 CommonErrorCode가 이를 구현하도록 변경되었습니다.
  * Swagger 문서의 에러 응답 예시가 공통 에러 코드 기준으로 일관성 있게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->