### PR TITLE
[feat] 닉네임 설정 api 구현

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -6,13 +6,15 @@ import lombok.Getter;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static at.mateball.exception.code.BusinessErrorCode.DUPLICATED_NICKNAME;
+import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 import static at.mateball.exception.code.CommonErrorCode.*;
 
 @Getter
 public enum SwaggerResponseDescription {
 
     UPDATE_NICKNAME(
-            new LinkedHashSet<>(Set.of())
+            new LinkedHashSet<>(Set.of(USER_NOT_FOUND, DUPLICATED_NICKNAME))
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
@@ -1,14 +1,14 @@
 package at.mateball.domain.auth.core.service;
 
 import at.mateball.common.jwt.JwtTokenGenerator;
-import at.mateball.domain.auth.api.dto.kakao.KakaoTokenRes;
-import at.mateball.domain.auth.api.dto.kakao.KakaoUserRes;
 import at.mateball.domain.auth.api.dto.LoginCommand;
 import at.mateball.domain.auth.api.dto.LoginResult;
+import at.mateball.domain.auth.api.dto.kakao.KakaoTokenRes;
+import at.mateball.domain.auth.api.dto.kakao.KakaoUserRes;
 import at.mateball.domain.auth.core.config.OauthClientApi;
 import at.mateball.domain.auth.core.config.RedirectUriResolver;
 import at.mateball.domain.user.core.User;
-import at.mateball.domain.user.core.UserRepository;
+import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -8,6 +8,7 @@ import at.mateball.domain.user.api.dto.request.NicknameRequest;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,7 +27,7 @@ public class UserController {
     @PostMapping("/info/nickname")
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
     @Operation(summary = "닉네임 설정 api")
-    public MateballResponse<Void> updateNickname(
+    public ResponseEntity<MateballResponse<Void>> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody NicknameRequest nicknameRequest
     ) {
@@ -34,6 +35,6 @@ public class UserController {
 
         userService.updateNickname(userId, nicknameRequest.nickname());
 
-        return MateballResponse.successWithNoData(SuccessCode.CREATED);
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -2,9 +2,12 @@ package at.mateball.domain.user.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.common.swagger.CustomExceptionDescription;
+import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.user.api.dto.request.NicknameRequest;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +24,8 @@ public class UserController {
     }
 
     @PostMapping("/info/nickname")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
+    @Operation(summary = "닉네임 설정 api")
     public MateballResponse<Void> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody NicknameRequest nicknameRequest

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -4,7 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
-import at.mateball.domain.user.api.dto.request.NicknameRequest;
+import at.mateball.domain.user.api.dto.request.NicknameReq;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,13 +27,13 @@ public class UserController {
     @PostMapping("/info/nickname")
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
     @Operation(summary = "닉네임 설정 api")
-    public ResponseEntity<MateballResponse<Void>> updateNickname(
+    public ResponseEntity<MateballResponse<?>> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody NicknameRequest nicknameRequest
+            @RequestBody NicknameReq nicknameReq
     ) {
         Long userId = userDetails.getUserId();
 
-        userService.updateNickname(userId, nicknameRequest.nickname());
+        userService.updateNickname(userId, nicknameReq.nickname());
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
     }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -1,0 +1,34 @@
+package at.mateball.domain.user.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.user.api.dto.request.NicknameRequest;
+import at.mateball.domain.user.core.service.UserService;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users/")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/info/nickname")
+    public MateballResponse<Void> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody NicknameRequest nicknameRequest
+    ) {
+        Long userId = userDetails.getUserId();
+
+        userService.updateNickname(userId, nicknameRequest.nickname());
+
+        return MateballResponse.successWithNoData(SuccessCode.CREATED);
+    }
+}

--- a/src/main/java/at/mateball/domain/user/api/dto/request/NicknameReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/NicknameReq.java
@@ -2,9 +2,8 @@ package at.mateball.domain.user.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
-public record NicknameRequest(
+public record NicknameReq(
         @NotBlank
         @Schema(description = "설정할 닉네임")
         String nickname

--- a/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
@@ -1,10 +1,11 @@
 package at.mateball.domain.user.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record NicknameRequest(
-        @NotNull
+        @NotBlank
         @Schema(description = "설정할 닉네임")
         String nickname
 ) {

--- a/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
@@ -1,6 +1,11 @@
 package at.mateball.domain.user.api.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
 public record NicknameRequest(
+        @NotNull
+        @Schema(description = "설정할 닉네임")
         String nickname
 ) {
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/NicknameRequest.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.user.api.dto.request;
+
+public record NicknameRequest(
+        String nickname
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
@@ -1,9 +1,12 @@
-package at.mateball.domain.user.core;
+package at.mateball.domain.user.core.repository;
 
+import at.mateball.domain.user.core.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoUserId(Long kakaoUserId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -1,0 +1,31 @@
+package at.mateball.domain.user.core.service;
+
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static at.mateball.exception.code.BusinessErrorCode.DUPLICATED_NICKNAME;
+import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateNickname(long userId, String updatedNickname) {
+        User user = userRepository.findById(userId).orElseThrow(()
+                -> new BusinessException(USER_NOT_FOUND));
+
+        if (userRepository.existsByNickname(updatedNickname)) {
+            throw new BusinessException(DUPLICATED_NICKNAME);
+        }
+
+        user.updateNickname(updatedNickname);
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -18,7 +18,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void updateNickname(long userId, String updatedNickname) {
+    public void updateNickname(final Long userId, final String updatedNickname) {
         User user = userRepository.findById(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
 

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -27,7 +27,7 @@ public enum BusinessErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자입니다."),
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),
 
-    // 404 CONFLICT
+    // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -25,7 +25,11 @@ public enum BusinessErrorCode implements ErrorCode {
     // 404 NOT FOUND
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 사용자입니다."),
-    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),;
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),
+
+    // 404 CONFLICT
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다.");
+
     private final HttpStatus status;
     private final String message;
 

--- a/src/test/java/at/mateball/kakao/LoginServiceTest.java
+++ b/src/test/java/at/mateball/kakao/LoginServiceTest.java
@@ -11,7 +11,7 @@ import at.mateball.domain.auth.core.config.RedirectUriResolver;
 import at.mateball.domain.auth.core.service.LoginService;
 import at.mateball.domain.auth.core.service.TokenService;
 import at.mateball.domain.user.core.User;
-import at.mateball.domain.user.core.UserRepository;
+import at.mateball.domain.user.core.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #39

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- body로 변경할 nickname 을 받아옴 -> 1차로 존재하는 유저인지 판별 -> 2차로 닉네임 중복인지 판별 합니다
- 스웨거는 제가 이번 PR 에서 적용한 것 처럼 해주시면 됩니다! 만약 api 에 대한 추가 설명이 필요하다면,     `@Operation(summary = "닉네임 설정 api", description =  "상세 설명 추가")` 로 작성해주시면 됩니다! 제 노션 작업실에도 적혀있으니 참고하시거나 저한테 직접 물어보셔두 됩니다잉


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 닉네임을 변경할 수 있는 API 엔드포인트가 추가되었습니다.
  * 닉네임 중복 여부를 확인하는 기능이 추가되었습니다.
  * 닉네임 변경 시, 이미 존재하는 닉네임이거나 사용자가 존재하지 않을 경우 각각의 에러 메시지가 제공됩니다.

* **버그 수정**
  * 닉네임 중복 및 사용자 미존재에 대한 상세 오류 코드가 안내됩니다.

* **문서화**
  * Swagger를 통한 닉네임 변경 API 명세 및 에러 응답 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->