### PR TITLE
[feat] 카카오 유저 정보 조회 api 

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -5,9 +5,13 @@ import lombok.Getter;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
+<<<<<<< HEAD
 import static at.mateball.exception.code.BusinessErrorCode.DUPLICATED_NICKNAME;
 import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 import static at.mateball.exception.code.BusinessErrorCode.GROUP_NOT_FOUND;
+=======
+
+>>>>>>> 7c7106e ([feat/#33] 카카오 정보 조회 api 스웨거 연동)
 import static at.mateball.exception.code.BusinessErrorCode.*;
 import static at.mateball.exception.code.CommonErrorCode.*;
 
@@ -17,6 +21,7 @@ public enum SwaggerResponseDescription {
     UPDATE_NICKNAME(
             new LinkedHashSet<>(Set.of(USER_NOT_FOUND, DUPLICATED_NICKNAME))
     ),
+<<<<<<< HEAD
 
     DIRECT_MATCHING(
             new LinkedHashSet<>(Set.of(GROUP_NOT_FOUND))
@@ -28,6 +33,10 @@ public enum SwaggerResponseDescription {
 
     GROUP_MATCHING(
             new LinkedHashSet<>(Set.of(GROUP_NOT_FOUND))
+=======
+    GET_KAKAO_INFORMATION(
+            new LinkedHashSet<>(Set.of(USER_NOT_FOUND, AGE_NOT_APPROPRIATE))
+>>>>>>> 7c7106e ([feat/#33] 카카오 정보 조회 api 스웨거 연동)
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     @GetMapping("kakao/info")
     @CustomExceptionDescription(SwaggerResponseDescription.GET_KAKAO_INFORMATION)
     @Operation(summary = "카카오에서 받아온 사용자 정보 api")
-    public ResponseEntity<MateballResponse<KaKaoInformationRes>> getKaKaoInformation(
+    public ResponseEntity<MateballResponse<?>> getKaKaoInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -23,6 +23,8 @@ public class UserController {
     }
 
     @GetMapping("kakao/info")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
+    @Operation(summary = "카카오에서 받아온 사용자 정보 api")
     public ResponseEntity<MateballResponse<KaKaoInformationRes>> getKaKaoInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
     }
 
     @GetMapping("kakao/info")
-    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
+    @CustomExceptionDescription(SwaggerResponseDescription.GET_KAKAO_INFORMATION)
     @Operation(summary = "카카오에서 받아온 사용자 정보 api")
     public ResponseEntity<MateballResponse<KaKaoInformationRes>> getKaKaoInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -5,15 +5,13 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.user.api.dto.request.NicknameReq;
+import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/users/")
@@ -23,6 +21,19 @@ public class UserController {
     public UserController(UserService userService) {
         this.userService = userService;
     }
+
+    @GetMapping("kakao/info")
+    public ResponseEntity<MateballResponse<KaKaoInformationRes>> getKaKaoInformation(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        KaKaoInformationRes data = userService.getKakaoInformation(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
+
+    }
+
 
     @PostMapping("/info/nickname")
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)

--- a/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
@@ -1,7 +1,11 @@
 package at.mateball.domain.user.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record KaKaoInformationRes(
+        @Schema(description = "사용자의 생년월일")
         Integer birthYear,
+        @Schema(description = "사용자의 성별")
         String gender
 ) {
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
@@ -1,10 +1,14 @@
 package at.mateball.domain.user.api.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record KaKaoInformationRes(
+        @NotNull
         @Schema(description = "사용자의 생년월일")
         Integer birthYear,
+        @NotBlank
         @Schema(description = "사용자의 성별")
         String gender
 ) {

--- a/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/KaKaoInformationRes.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record KaKaoInformationRes(
+        Integer birthYear,
+        String gender
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
@@ -8,14 +10,33 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static at.mateball.exception.code.BusinessErrorCode.DUPLICATED_NICKNAME;
-import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
+import java.time.LocalDateTime;
+
+import static at.mateball.exception.code.BusinessErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
+
+    public KaKaoInformationRes getKakaoInformation(final Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        int currentYear = LocalDateTime.now().getYear();
+        int birthYear = user.getBirthYear();
+
+        int LIMIT_AGE = 19;
+        int age = currentYear - birthYear + 1;
+        if (age < LIMIT_AGE) {
+            throw new BusinessException(AGE_NOT_APPROPRIATE);
+        }
+
+        String gender = Gender.from(user.getGender()).getLabel();
+
+        return new KaKaoInformationRes(birthYear, gender);
+    }
 
     @Transactional
     public void updateNickname(final Long userId, final String updatedNickname) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
         int currentYear = LocalDateTime.now().getYear();
         int birthYear = user.getBirthYear();
 
-        int LIMIT_AGE = 19;
+        final int LIMIT_AGE = 19;
         int age = currentYear - birthYear + 1;
         if (age < LIMIT_AGE) {
             throw new BusinessException(AGE_NOT_APPROPRIATE);

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -24,6 +24,7 @@ public enum BusinessErrorCode implements ErrorCode {
     KAKAO_CLIENT_ERROR(HttpStatus.UNAUTHORIZED, "카카오 JWT 파싱 중 오류가 발생했습니다."),
 
     // 403 FORBIDDEN
+    AGE_NOT_APPROPRIATE(HttpStatus.FORBIDDEN, "만 19세 이상부터 가입이 가능합니다."),
 
     // 404 NOT FOUND
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #33

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 카카오에서 받아온 생년과 성별을 받아오는 api 를 구현했습니다
- 일대일 매칭 리스트 조회에서 생년 -> 나이 로 변환하는 로직이 제 코드와 같은데, 이를 utils 로 사용해도 좋을 것 같습니다!

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 사용자 정보를 조회하는 새로운 GET 엔드포인트(`/v1/users/kakao/info`)가 추가되었습니다. 해당 엔드포인트를 통해 사용자의 출생 연도와 성별 정보를 확인할 수 있습니다.
  * 만 19세 미만 사용자는 접근이 제한됩니다.

* **버그 수정**
  * 만 19세 미만 사용 시 적절한 오류 메시지와 함께 접근이 차단됩니다.

* **문서화**
  * API 문서에 카카오 정보 조회 및 관련 오류 코드가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->