### PR TITLE
[feat] 내 정보 조회 api

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -31,6 +31,9 @@ public enum SwaggerResponseDescription {
 
     GET_KAKAO_INFORMATION(
             new LinkedHashSet<>(Set.of(USER_NOT_FOUND, AGE_NOT_APPROPRIATE))
+    ),
+    GET_USER_INFORMATION(
+            new LinkedHashSet<>(Set.of(USER_NOT_FOUND))
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
     }
 
     @GetMapping("/info")
-    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
+    @CustomExceptionDescription(SwaggerResponseDescription.GET_USER_INFORMATION)
     @Operation(summary = "내 정보 조회 api")
     public ResponseEntity<MateballResponse<UserInformationRes>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -55,7 +55,7 @@ public class UserController {
     @GetMapping("/info")
     @CustomExceptionDescription(SwaggerResponseDescription.GET_USER_INFORMATION)
     @Operation(summary = "내 정보 조회 api")
-    public ResponseEntity<MateballResponse<UserInformationRes>> getUserInformation(
+    public ResponseEntity<MateballResponse<?>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -53,6 +53,8 @@ public class UserController {
     }
 
     @GetMapping("/info")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
+    @Operation(summary = "내 정보 조회 api")
     public MateballResponse<UserInformationRes> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -55,14 +55,13 @@ public class UserController {
     @GetMapping("/info")
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_NICKNAME)
     @Operation(summary = "내 정보 조회 api")
-    public MateballResponse<UserInformationRes> getUserInformation(
+    public ResponseEntity<MateballResponse<UserInformationRes>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
 
         UserInformationRes data = userService.getUserInformation(userId);
 
-        return MateballResponse.success(SuccessCode.OK, data);
-
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -5,6 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.user.api.dto.request.NicknameReq;
+import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
@@ -49,5 +50,17 @@ public class UserController {
         userService.updateNickname(userId, nicknameReq.nickname());
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
+
+    @GetMapping("/info")
+    public MateballResponse<UserInformationRes> getUserInformation(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        UserInformationRes data = userService.getUserInformation(userId);
+
+        return MateballResponse.success(SuccessCode.OK, data);
+
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/BaseUserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/BaseUserInformationRes.java
@@ -1,0 +1,10 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record BaseUserInformationRes(
+        String nickname,
+        Integer birthYear,
+        String gender,
+        Integer style,
+        String introduction,
+        String imgUrl
+) {}

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationBaseRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationBaseRes.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.user.api.dto.response;
 
-public record BaseUserInformationRes(
+public record UserInformationBaseRes(
         String nickname,
         Integer birthYear,
         String gender,

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
@@ -1,14 +1,8 @@
 package at.mateball.domain.user.api.dto.response;
 
-import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
-
-import com.querydsl.core.Tuple;
-import at.mateball.domain.user.core.QUser;
-import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Style;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.time.LocalDateTime;
 
 public record UserInformationRes(
         @Schema(description = "사용자의 닉네임")
@@ -24,21 +18,15 @@ public record UserInformationRes(
         @Schema(description = "사용자의 프로필 이미지")
         String imgUrl
 ) {
-    public static UserInformationRes from(Tuple tuple) {
-        QUser user = QUser.user;
-        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
-
-        int birthYear = tuple.get(user.birthYear);
-        int currentYear = LocalDateTime.now().getYear();
-        int age = currentYear - birthYear + 1;
-
+    public static UserInformationRes fromBase(BaseUserInformationRes baseUserInformationRes) {
+        int age = java.time.LocalDate.now().getYear() - baseUserInformationRes.birthYear() + 1;
         return new UserInformationRes(
-                tuple.get(user.nickname),
+                baseUserInformationRes.nickname(),
                 age + "세",
-                Gender.from(tuple.get(user.gender)).getLabel(),
-                Style.from(tuple.get(matchRequirement.style)).getLabel(),
-                tuple.get(user.introduction),
-                tuple.get(user.imgUrl)
+                Gender.from(baseUserInformationRes.gender()).getLabel(),
+                Style.from(baseUserInformationRes.style()).getLabel(),
+                baseUserInformationRes.introduction(),
+                baseUserInformationRes.imgUrl()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
@@ -6,15 +6,22 @@ import at.mateball.domain.matchrequirement.core.constant.Gender;
 import com.querydsl.core.Tuple;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
 public record UserInformationRes(
+        @Schema(description = "사용자의 닉네임")
         String nickname,
+        @Schema(description = "사용자의 나이")
         String age,
+        @Schema(description = "사용자의 성별")
         String gender,
+        @Schema(description = "사용자의 직관 스타일")
         String style,
+        @Schema(description = "사용자의 한 줄 소개")
         String introduction,
+        @Schema(description = "사용자의 프로필 이미지")
         String imgUrl
 ) {
     public static UserInformationRes from(Tuple tuple) {

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
@@ -18,15 +18,15 @@ public record UserInformationRes(
         @Schema(description = "사용자의 프로필 이미지")
         String imgUrl
 ) {
-    public static UserInformationRes fromBase(BaseUserInformationRes baseUserInformationRes) {
-        int age = java.time.LocalDate.now().getYear() - baseUserInformationRes.birthYear() + 1;
+    public static UserInformationRes fromBase(UserInformationBaseRes userInformationBaseRes) {
+        int age = java.time.LocalDate.now().getYear() - userInformationBaseRes.birthYear() + 1;
         return new UserInformationRes(
-                baseUserInformationRes.nickname(),
+                userInformationBaseRes.nickname(),
                 age + "세",
-                Gender.from(baseUserInformationRes.gender()).getLabel(),
-                Style.from(baseUserInformationRes.style()).getLabel(),
-                baseUserInformationRes.introduction(),
-                baseUserInformationRes.imgUrl()
+                Gender.from(userInformationBaseRes.gender()).getLabel(),
+                Style.from(userInformationBaseRes.style()).getLabel(),
+                userInformationBaseRes.introduction(),
+                userInformationBaseRes.imgUrl()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
@@ -1,0 +1,37 @@
+package at.mateball.domain.user.api.dto.response;
+
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+
+import com.querydsl.core.Tuple;
+import at.mateball.domain.user.core.QUser;
+import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+
+import java.time.LocalDateTime;
+
+public record UserInformationRes(
+        String nickname,
+        String age,
+        String gender,
+        String style,
+        String introduction,
+        String imgUrl
+) {
+    public static UserInformationRes from(Tuple tuple) {
+        QUser user = QUser.user;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        int birthYear = tuple.get(user.birthYear);
+        int currentYear = LocalDateTime.now().getYear();
+        int age = currentYear - birthYear + 1;
+
+        return new UserInformationRes(
+                tuple.get(user.nickname),
+                age + "세",
+                Gender.from(tuple.get(user.gender)).getLabel(),
+                Style.from(tuple.get(matchRequirement.style)).getLabel(),
+                tuple.get(user.introduction),
+                tuple.get(user.imgUrl)
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
@@ -7,6 +7,4 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByKakaoUserId(Long kakaoUserId);
-
-    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByKakaoUserId(Long kakaoUserId);
 
     boolean existsByNickname(String nickname);

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.user.core.repository;
+
+import at.mateball.domain.user.api.dto.response.UserInformationRes;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepositoryCustom {
+    UserInformationRes findUserInformation(Long userId);
+}

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -1,9 +1,16 @@
 package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
+import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepositoryCustom {
     UserInformationRes findUserInformation(Long userId);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> getUser(final Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
-import at.mateball.domain.user.api.dto.response.BaseUserInformationRes;
+import at.mateball.domain.user.api.dto.response.UserInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
@@ -28,7 +28,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
         var baseUserInformation = queryFactory
                 .select(Projections.constructor(
-                        BaseUserInformationRes.class,
+                        UserInformationBaseRes.class,
                         user.nickname,
                         user.birthYear,
                         user.gender,

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -3,15 +3,21 @@ package at.mateball.domain.user.core.repository;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.QUser;
+import at.mateball.domain.user.core.User;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.Optional;
 
 public class UserRepositoryImpl implements UserRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
-    public UserRepositoryImpl(JPAQueryFactory queryFactory) {
+    public UserRepositoryImpl(JPAQueryFactory queryFactory, EntityManager em) {
         this.queryFactory = queryFactory;
+        this.em = em;
     }
 
     @Override
@@ -34,5 +40,23 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .fetchOne();
 
         return tuple != null ? UserInformationRes.from(tuple) : null;
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        QUser user = QUser.user;
+
+        Integer result = queryFactory
+                .selectOne()
+                .from(user)
+                .where(user.nickname.eq(nickname))
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    @Override
+    public Optional<User> getUser(Long userId) {
+        return Optional.ofNullable(em.find(User.class, userId));
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,10 +1,11 @@
 package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+import at.mateball.domain.user.api.dto.response.BaseUserInformationRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
-import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 
@@ -25,21 +26,22 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         QUser user = QUser.user;
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
 
-        Tuple tuple = queryFactory
-                .select(
+        var baseUserInformation = queryFactory
+                .select(Projections.constructor(
+                        BaseUserInformationRes.class,
                         user.nickname,
                         user.birthYear,
                         user.gender,
                         matchRequirement.style,
                         user.introduction,
                         user.imgUrl
-                )
-                .from(user)
-                .join(matchRequirement).on(user.id.eq(matchRequirement.user.id))
-                .where(user.id.eq(userId))
+                ))
+                .from(user, matchRequirement)
+                .where(user.id.eq(userId),
+                        matchRequirement.user.id.eq(user.id))
                 .fetchOne();
 
-        return tuple != null ? UserInformationRes.from(tuple) : null;
+        return UserInformationRes.fromBase(baseUserInformation);
     }
 
     @Override

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,0 +1,38 @@
+package at.mateball.domain.user.core.repository;
+
+import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+import at.mateball.domain.user.api.dto.response.UserInformationRes;
+import at.mateball.domain.user.core.QUser;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public UserInformationRes findUserInformation(Long userId) {
+        QUser user = QUser.user;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        Tuple tuple = queryFactory
+                .select(
+                        user.nickname,
+                        user.birthYear,
+                        user.gender,
+                        matchRequirement.style,
+                        user.introduction,
+                        user.imgUrl
+                )
+                .from(user)
+                .join(matchRequirement).on(user.id.eq(matchRequirement.user.id))
+                .where(user.id.eq(userId))
+                .fetchOne();
+
+        return tuple != null ? UserInformationRes.from(tuple) : null;
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -51,13 +51,13 @@ public class UserService {
     }
 
     public UserInformationRes getUserInformation(Long userId) {
-        findUser(userId);
+        userRepository.getUser(userId);
 
         return userRepository.findUserInformation(userId);
     }
 
     public User findUser(final Long userId) {
-        return userRepository.findById(userId).orElseThrow(()
+        return userRepository.getUser(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     }
 
     public UserInformationRes getUserInformation(Long userId) {
-        User user = findUser(userId);
+        findUser(userId);
 
         return userRepository.findUserInformation(userId);
     }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -2,6 +2,7 @@ package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.matchrequirement.core.constant.Gender;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
+import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
@@ -48,5 +49,10 @@ public class UserService {
         }
 
         user.updateNickname(updatedNickname);
+    }
+
+    public UserInformationRes getUserInformation(Long userId) {
+
+        return userRepository.findUserInformation(userId);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -41,8 +41,7 @@ public class UserService {
 
     @Transactional
     public void updateNickname(final Long userId, final String updatedNickname) {
-        User user = userRepository.findById(userId).orElseThrow(()
-                -> new BusinessException(USER_NOT_FOUND));
+        User user = findUser(userId);
 
         if (userRepository.existsByNickname(updatedNickname)) {
             throw new BusinessException(DUPLICATED_NICKNAME);
@@ -52,7 +51,13 @@ public class UserService {
     }
 
     public UserInformationRes getUserInformation(Long userId) {
+        User user = findUser(userId);
 
         return userRepository.findUserInformation(userId);
+    }
+
+    public User findUser(final Long userId) {
+        return userRepository.findById(userId).orElseThrow(()
+                -> new BusinessException(USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #38 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 쿼리 DSL 사용
- User, MatchRequirement를 조인해서 사용자 정보(사용자 정보 + 직관 스타일) 조회

<br/>


### ❤️ To 다진 / To 헤음

---

- 하,,, 왜이렇게 억까가 많을까요,,, 내 잘못이겠지,,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증된 사용자의 정보를 조회할 수 있는 신규 GET 엔드포인트(`/v1/users/info`)가 추가되었습니다.
  * 사용자 정보(닉네임, 나이, 성별, 스타일, 자기소개, 프로필 이미지)를 반환하는 응답 구조가 도입되었습니다.

* **리팩터**
  * 사용자 정보 조회 및 닉네임 중복 확인 로직이 개선되었습니다.
  * 사용자 정보 관련 저장소 및 서비스 구조가 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->