### PR TITLE
[feat] 경기 정보 조회 api

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -34,6 +34,9 @@ public enum SwaggerResponseDescription {
     ),
     GET_USER_INFORMATION(
             new LinkedHashSet<>(Set.of(USER_NOT_FOUND))
+    ),
+    GET_GAME_INFORMATION(
+            new LinkedHashSet<>(Set.of(USER_NOT_FOUND))
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
@@ -31,11 +31,11 @@ public class GameInformationController {
     @Operation(summary = "경기 정보 조회 api")
     public ResponseEntity<MateballResponse<GameInformationsRes>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("date") LocalDate gameInformationReq
+            @RequestParam("gameDate") LocalDate gameDate
     ) {
         Long userId = userDetails.getUserId();
 
-        GameInformationsRes data = gameInformationService.getGameInformation(userId, gameInformationReq);
+        GameInformationsRes data = gameInformationService.getGameInformation(userId, gameDate);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }

--- a/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
@@ -29,13 +29,13 @@ public class GameInformationController {
     @GetMapping("/game/schedule")
     @CustomExceptionDescription(SwaggerResponseDescription.GET_GAME_INFORMATION)
     @Operation(summary = "경기 정보 조회 api")
-    public ResponseEntity<MateballResponse<GameInformationsRes>> getUserInformation(
+    public ResponseEntity<MateballResponse<?>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("gameDate") LocalDate gameDate
+            @RequestParam("date") LocalDate date
     ) {
         Long userId = userDetails.getUserId();
 
-        GameInformationsRes data = gameInformationService.getGameInformation(userId, gameDate);
+        GameInformationsRes data = gameInformationService.getGameInformation(userId, date);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }

--- a/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
@@ -2,9 +2,12 @@ package at.mateball.domain.gameinformation.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.common.swagger.CustomExceptionDescription;
+import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.gameinformation.api.dto.response.GameInformationsRes;
 import at.mateball.domain.gameinformation.core.service.GameInformationService;
 import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +27,8 @@ public class GameInformationController {
     }
 
     @GetMapping("/game/schedule")
+    @CustomExceptionDescription(SwaggerResponseDescription.GET_GAME_INFORMATION)
+    @Operation(summary = "경기 정보 조회 api")
     public ResponseEntity<MateballResponse<GameInformationsRes>> getUserInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("date") LocalDate gameInformationReq

--- a/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/controller/GameInformationController.java
@@ -1,0 +1,37 @@
+package at.mateball.domain.gameinformation.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.gameinformation.api.dto.response.GameInformationsRes;
+import at.mateball.domain.gameinformation.core.service.GameInformationService;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/v1/users/")
+public class GameInformationController {
+    private final GameInformationService gameInformationService;
+
+    public GameInformationController(GameInformationService gameInformationService) {
+        this.gameInformationService = gameInformationService;
+    }
+
+    @GetMapping("/game/schedule")
+    public ResponseEntity<MateballResponse<GameInformationsRes>> getUserInformation(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("date") LocalDate gameInformationReq
+    ) {
+        Long userId = userDetails.getUserId();
+
+        GameInformationsRes data = gameInformationService.getGameInformation(userId, gameInformationReq);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
+    }
+}

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/request/GameInformationReq.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/request/GameInformationReq.java
@@ -1,8 +1,0 @@
-package at.mateball.domain.gameinformation.api.dto.request;
-
-import java.time.LocalDate;
-
-public record GameInformationReq(
-        LocalDate date
-) {
-}

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/request/GameInformationReq.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/request/GameInformationReq.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.gameinformation.api.dto.request;
+
+import java.time.LocalDate;
+
+public record GameInformationReq(
+        LocalDate date
+) {
+}

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationRes.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationRes.java
@@ -1,0 +1,21 @@
+package at.mateball.domain.gameinformation.api.dto.response;
+
+import at.mateball.domain.gameinformation.core.GameInformation;
+
+public record GameInformationRes(
+        Long id,
+        String awayTeam,
+        String homeTeam,
+        String gameTime,
+        String stadium
+) {
+    public static GameInformationRes from(GameInformation game) {
+        return new GameInformationRes(
+                game.getId(),
+                game.getAwayTeamName(),
+                game.getHomeTeamName(),
+                game.getGameTime().toString(),
+                game.getStadiumName()
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationRes.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationRes.java
@@ -1,12 +1,18 @@
 package at.mateball.domain.gameinformation.api.dto.response;
 
 import at.mateball.domain.gameinformation.core.GameInformation;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GameInformationRes(
+        @Schema(description = "경기 아이디")
         Long id,
+        @Schema(description = "원정팀 이름")
         String awayTeam,
+        @Schema(description = "홈팀 이름")
         String homeTeam,
+        @Schema(description = "경기 시간")
         String gameTime,
+        @Schema(description = "경기장")
         String stadium
 ) {
     public static GameInformationRes from(GameInformation game) {

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationsRes.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationsRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.gameinformation.api.dto.response;
+
+import java.util.List;
+
+public record GameInformationsRes(
+        List<GameInformationRes> gameSchedule
+) {
+}

--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationsRes.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/response/GameInformationsRes.java
@@ -1,8 +1,11 @@
 package at.mateball.domain.gameinformation.api.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record GameInformationsRes(
+        @Schema(description = "경기 정보 리스트")
         List<GameInformationRes> gameSchedule
 ) {
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
@@ -1,0 +1,11 @@
+package at.mateball.domain.gameinformation.core.repository;
+
+import at.mateball.domain.gameinformation.core.GameInformation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface GameInformationRepository extends JpaRepository<GameInformation, Long> {
+    List<GameInformation> findByGameDate(LocalDate gameDate);
+}

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDate;
 import java.util.List;
 
-public interface GameInformationRepository extends JpaRepository<GameInformation, Long> {
-    List<GameInformation> findByGameDate(LocalDate gameDate);
+public interface GameInformationRepository extends JpaRepository<GameInformation, Long>, GameInformationRepositoryCustom {
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
@@ -1,0 +1,14 @@
+package at.mateball.domain.gameinformation.core.repository;
+
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.user.core.User;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GameInformationRepositoryCustom {
+    List<GameInformation> findByGameDate(LocalDate gameDate);
+}

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
@@ -24,7 +24,4 @@ public class GameInformationRepositoryImpl implements GameInformationRepositoryC
                 .where(gameInformation.gameDate.eq(gameDate))
                 .fetch();
     }
-
-    ;
-
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
@@ -1,0 +1,30 @@
+package at.mateball.domain.gameinformation.core.repository;
+
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.gameinformation.core.QGameInformation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class GameInformationRepositoryImpl implements GameInformationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public GameInformationRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public List<GameInformation> findByGameDate(LocalDate gameDate) {
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+
+        return queryFactory
+                .selectFrom(gameInformation)
+                .where(gameInformation.gameDate.eq(gameDate))
+                .fetch();
+    }
+
+    ;
+
+}

--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -1,0 +1,41 @@
+package at.mateball.domain.gameinformation.core.service;
+
+import at.mateball.domain.gameinformation.api.dto.response.GameInformationRes;
+import at.mateball.domain.gameinformation.api.dto.response.GameInformationsRes;
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GameInformationService {
+    private final UserRepository userRepository;
+    private final GameInformationRepository gameInformationRepository;
+
+    public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
+        findUser(userId);
+
+        List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
+                .stream()
+                .map(GameInformationRes::from)
+                .toList();
+
+        return new GameInformationsRes(list);
+    }
+
+    public User findUser(final Long userId) {
+        return userRepository.findById(userId).orElseThrow(()
+                -> new BusinessException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -24,7 +24,7 @@ public class GameInformationService {
     private final GameInformationRepository gameInformationRepository;
 
     public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
-        findUser(userId);
+//        findUser(userId);
 
         List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
                 .stream()
@@ -34,8 +34,9 @@ public class GameInformationService {
         return new GameInformationsRes(list);
     }
 
-    public User findUser(final Long userId) {
-        return userRepository.findById(userId).orElseThrow(()
-                -> new BusinessException(USER_NOT_FOUND));
-    }
+//    TODO: 50번 커밋 병합된 이후 적용
+//    public User findUser(final Long userId) {
+//        return userRepository.findById(userId).orElseThrow(()
+//                -> new BusinessException(USER_NOT_FOUND));
+//    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #47 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사용자로부터 LocalDate를 받아, 해당 날짜에 있는 경기들을 조회하는 api를 구현했습니다
- params의 경우, 따로 class 를 만들어서 가져오려고 했는데, String -> Date 로 변환이 되지 않아서 바로 타입을 지정해주었습니다!
- 단순하게 데이터 조회이기에 따로 쿼리 DSL 을 사용하지는 않았습니다!

<br/>


### ❤️ To 다진 / To 헤음

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 지정한 날짜의 경기 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 경기 정보 응답에 경기 ID, 원정팀, 홈팀, 경기 시간, 경기장 이름이 포함됩니다.
  * 여러 경기 정보를 리스트 형태로 반환하는 응답 구조가 제공됩니다.

* **문서화**
  * 새로 추가된 API 및 응답 구조에 대한 Swagger 문서가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->