### PR TITLE
[feat] 매칭 조건 설정 api

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -37,6 +37,9 @@ public enum SwaggerResponseDescription {
     ),
     GET_GAME_INFORMATION(
             new LinkedHashSet<>(Set.of(USER_NOT_FOUND))
+    ),
+    UPDATE_MATCH_REQUIREMENT(
+            new LinkedHashSet<>(Set.of(USER_NOT_FOUND))
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
@@ -27,7 +27,7 @@ public class MatchRequirementController {
     @PostMapping("/match-condition")
     @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MATCH_REQUIREMENT)
     @Operation(summary = "매칭 조건 설정 api")
-    public ResponseEntity<MateballResponse<?>> updateNickname(
+    public ResponseEntity<MateballResponse<?>> updateMatchRequirement(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody MatchRequirementReq matchRequirementReq
     ) {

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
@@ -1,13 +1,35 @@
 package at.mateball.domain.matchrequirement.api.controller;
 
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
+import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v1/users/")
 public class MatchRequirementController {
     private final MatchRequirementService matchRequirementService;
 
     public MatchRequirementController(MatchRequirementService matchRequirementService) {
         this.matchRequirementService = matchRequirementService;
+    }
+
+    @PostMapping("/match-condition")
+    public ResponseEntity<MateballResponse<?>> updateNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MatchRequirementReq matchRequirementReq
+    ) {
+        Long userId = userDetails.getUserId();
+
+        matchRequirementService.setMatchRequirement(userId, matchRequirementReq.team(), matchRequirementReq.teamAllowed(), matchRequirementReq.style(), matchRequirementReq.genderPreference());
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
@@ -2,9 +2,12 @@ package at.mateball.domain.matchrequirement.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.common.swagger.CustomExceptionDescription;
+import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
 import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +25,8 @@ public class MatchRequirementController {
     }
 
     @PostMapping("/match-condition")
+    @CustomExceptionDescription(SwaggerResponseDescription.UPDATE_MATCH_REQUIREMENT)
+    @Operation(summary = "매칭 조건 설정 api")
     public ResponseEntity<MateballResponse<?>> updateNickname(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody MatchRequirementReq matchRequirementReq

--- a/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
@@ -39,4 +39,15 @@ public class MatchRequirement {
         this.style = style;
         this.genderPreference = genderPreference;
     }
+
+    public void getMatchRequirement(){
+
+    }
+
+    public void updateAll(int team, Integer teamAllowed, int style, int genderPreference) {
+        this.team = team;
+        this.teamAllowed = teamAllowed;
+        this.style = style;
+        this.genderPreference = genderPreference;
+    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/Gender.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/Gender.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.matchrequirement.core.constant;
 
-import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;
@@ -26,6 +25,13 @@ public enum Gender {
     public static Gender from(String raw) {
         return Arrays.stream(values())
                 .filter(g -> g.raw.equalsIgnoreCase(raw))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
+    public static Gender fromLabel(String label) {
+        return Arrays.stream(values())
+                .filter(e -> e.label.equalsIgnoreCase(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.matchrequirement.core.constant;
 
-import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;
@@ -24,6 +23,13 @@ public enum Style {
     public static Style from(int value) {
         return Arrays.stream(values())
                 .filter(g -> g.value == value)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
+    public static Style fromLabel(String label) {
+        return Arrays.stream(values())
+                .filter(e -> e.label.equalsIgnoreCase(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.matchrequirement.core.constant;
 
-import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;
@@ -23,6 +22,13 @@ public enum TeamAllowed {
     public static TeamAllowed from(int value) {
         return Arrays.stream(values())
                 .filter(g -> g.value == value)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
+    public static TeamAllowed fromLabel(String label) {
+        return Arrays.stream(values())
+                .filter(e -> e.label.equalsIgnoreCase(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryCustom.java
@@ -1,11 +1,14 @@
 package at.mateball.domain.matchrequirement.core.repository.querydsl;
 
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
+import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MatchRequirementRepositoryCustom {
     List<MatchingScoreDto> findMatchingUsers(Long userId);
+    Optional<MatchRequirement> findUserMatchRequirement(Long userId);
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryCustom.java
@@ -5,10 +5,10 @@ import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface MatchRequirementRepositoryCustom {
     List<MatchingScoreDto> findMatchingUsers(Long userId);
-    Optional<MatchRequirement> findUserMatchRequirement(Long userId);
+
+    MatchRequirement findUserMatchRequirement(Long userId);
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
@@ -1,8 +1,8 @@
 package at.mateball.domain.matchrequirement.core.repository.querydsl;
 
-import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
 import com.querydsl.core.types.Projections;
@@ -12,6 +12,7 @@ import jakarta.persistence.EntityManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public class MatchRequirementRepositoryImpl implements MatchRequirementRepositoryCustom {
     private final JPAQueryFactory queryFactory;
@@ -78,5 +79,17 @@ public class MatchRequirementRepositoryImpl implements MatchRequirementRepositor
                         ).loe(5))
                 )
                 .fetch();
+    }
+
+    @Override
+    public Optional<MatchRequirement> findUserMatchRequirement(Long userId) {
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        MatchRequirement userMatchRequirement = queryFactory
+                .selectFrom(matchRequirement)
+                .where(matchRequirement.user.id.eq(userId))
+                .fetchOne();
+
+        return Optional.ofNullable(userMatchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
@@ -12,7 +12,6 @@ import jakarta.persistence.EntityManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public class MatchRequirementRepositoryImpl implements MatchRequirementRepositoryCustom {
     private final JPAQueryFactory queryFactory;
@@ -82,14 +81,12 @@ public class MatchRequirementRepositoryImpl implements MatchRequirementRepositor
     }
 
     @Override
-    public Optional<MatchRequirement> findUserMatchRequirement(Long userId) {
+    public MatchRequirement findUserMatchRequirement(Long userId) {
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
 
-        MatchRequirement userMatchRequirement = queryFactory
+        return queryFactory
                 .selectFrom(matchRequirement)
                 .where(matchRequirement.user.id.eq(userId))
                 .fetchOne();
-
-        return Optional.ofNullable(userMatchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
@@ -1,20 +1,55 @@
 package at.mateball.domain.matchrequirement.core.service;
 
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
+import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.team.core.TeamName;
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
+
 @Service
 public class MatchRequirementService {
+    private final UserRepository userRepository;
     private final MatchRequirementRepository matchRequirementRepository;
 
-    public MatchRequirementService(MatchRequirementRepository matchRequirementRepository) {
+    public MatchRequirementService(
+            UserRepository userRepository,
+            MatchRequirementRepository matchRequirementRepository) {
+        this.userRepository = userRepository;
         this.matchRequirementRepository = matchRequirementRepository;
     }
 
     public List<MatchingScoreDto> getMatchings(Long userId) {
         return matchRequirementRepository.findMatchingUsers(userId);
+    }
+
+    @Transactional
+    public void setMatchRequirement(Long userId, String team, String teamAllowed, String style, String genderPreference) {
+
+        findUser(userId);
+        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        matchRequirement.updateAll(
+                TeamName.fromLabel(team).getValue(),
+                teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
+                Style.fromLabel(style).getValue(),
+                Gender.fromLabel(genderPreference).getValue()
+        );
+    }
+
+    public User findUser(final Long userId) {
+        return userRepository.findById(userId).orElseThrow(()
+                -> new BusinessException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
@@ -48,7 +48,7 @@ public class MatchRequirementService {
         );
     }
 
-    public User findUser(final Long userId) {
+    private User findUser(final Long userId) {
         return userRepository.findById(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
@@ -7,15 +7,11 @@ import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
-import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
-import at.mateball.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 
 @Service
 public class MatchRequirementService {
@@ -35,9 +31,9 @@ public class MatchRequirementService {
 
     @Transactional
     public void setMatchRequirement(Long userId, String team, String teamAllowed, String style, String genderPreference) {
+        // TODO: 50번 PR 병합 후 findUser 사용 - 유저가 존재하는지 판별
 
-        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId)
-                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
         matchRequirement.updateAll(
                 TeamName.fromLabel(team).getValue(),

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
@@ -36,7 +36,6 @@ public class MatchRequirementService {
     @Transactional
     public void setMatchRequirement(Long userId, String team, String teamAllowed, String style, String genderPreference) {
 
-        findUser(userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
@@ -46,10 +45,5 @@ public class MatchRequirementService {
                 Style.fromLabel(style).getValue(),
                 Gender.fromLabel(genderPreference).getValue()
         );
-    }
-
-    private User findUser(final Long userId) {
-        return userRepository.findById(userId).orElseThrow(()
-                -> new BusinessException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/at/mateball/domain/team/core/TeamName.java
+++ b/src/main/java/at/mateball/domain/team/core/TeamName.java
@@ -37,7 +37,7 @@ public enum TeamName {
 
     public static TeamName fromLabel(String label) {
         return Arrays.stream(values())
-                .filter(e -> e.label.equals(label))
+                .filter(e -> e.label.equalsIgnoreCase(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/team/core/TeamName.java
+++ b/src/main/java/at/mateball/domain/team/core/TeamName.java
@@ -8,16 +8,16 @@ import java.util.Arrays;
 
 @Getter
 public enum TeamName {
-    KIA(1, "KIA 타이거즈"),
-    SAMSUNG(2, "삼성 라이온즈"),
-    LG(3, "LG 트윈스"),
-    DOOSAN(4, "두산 베어스"),
-    KT(5, "KT 위즈"),
-    SSG(6, "SSG 랜더스"),
-    LOTTE(7, "롯데 자이언츠"),
-    HANWHA(8, "한화 이글스"),
-    NC(9, "NC 다이노스"),
-    KIWOOM(10, "키움 히어로즈"),
+    KIA(1, "KIA"),
+    SAMSUNG(2, "삼성"),
+    LG(3, "LG"),
+    DOOSAN(4, "두산"),
+    KT(5, "KT"),
+    SSG(6, "SSG"),
+    LOTTE(7, "롯데"),
+    HANWHA(8, "한화"),
+    NC(9, "NC"),
+    KIWOOM(10, "키움"),
     NONE(11, "응원하는 팀이 없어요.");
 
     private final int value;

--- a/src/main/java/at/mateball/domain/team/core/TeamName.java
+++ b/src/main/java/at/mateball/domain/team/core/TeamName.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.team.core;
 
-import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;
@@ -9,16 +8,16 @@ import java.util.Arrays;
 
 @Getter
 public enum TeamName {
-    KIA(1, "KIA"),
-    SAMSUNG(2, "삼성"),
-    LG(3, "LG"),
-    DOOSAN(4, "두산"),
-    KT(5, "KT"),
-    SSG(6, "SSG"),
-    LOTTE(7, "롯데"),
-    HANWHA(8, "한화"),
-    NC(9, "NC"),
-    KIWOOM(10, "키움"),
+    KIA(1, "KIA 타이거즈"),
+    SAMSUNG(2, "삼성 라이온즈"),
+    LG(3, "LG 트윈스"),
+    DOOSAN(4, "두산 베어스"),
+    KT(5, "KT 위즈"),
+    SSG(6, "SSG 랜더스"),
+    LOTTE(7, "롯데 자이언츠"),
+    HANWHA(8, "한화 이글스"),
+    NC(9, "NC 다이노스"),
+    KIWOOM(10, "키움 히어로즈"),
     NONE(11, "응원하는 팀이 없어요.");
 
     private final int value;
@@ -32,6 +31,13 @@ public enum TeamName {
     public static TeamName from(int value) {
         return Arrays.stream(values())
                 .filter(g -> g.value == value)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
+    public static TeamName fromLabel(String label) {
+        return Arrays.stream(values())
+                .filter(e -> e.label.equals(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/MatchRequirementReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/MatchRequirementReq.java
@@ -1,9 +1,15 @@
 package at.mateball.domain.user.api.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record MatchRequirementReq(
+        @Schema(description = "응원하는 팀 이름")
         String team,
+        @Schema(description = "응원 팀 허용 여부", nullable = true)
         String teamAllowed,
+        @Schema(description = "관람스타일")
         String style,
+        @Schema(description = "선호 성별")
         String genderPreference
 ) {
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/MatchRequirementReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/MatchRequirementReq.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.user.api.dto.request;
+
+public record MatchRequirementReq(
+        String team,
+        String teamAllowed,
+        String style,
+        String genderPreference
+) {
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #52 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존에 설정했던 팀 이름을 변경했습니다 `두산` -> `두산 베어스`
- enum label -> value 로 매핑하는 함수를 생성했습니다
- 응원팀이 없을 경우, 응원팀 허용 여부가 null 이 되는데, null 이 들어왔을 때 자동으로 2(상관없어요)로 매핑되도록 설정했습니다


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 사용자가 자신의 매칭 조건(응원팀, 허용 팀, 관람 스타일, 선호 성별)을 설정할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 매칭 조건 관련 요청을 위한 데이터 전송 객체(DTO)가 추가되었습니다.
  * 응원팀, 허용 팀, 관람 스타일, 성별 등에서 라벨로 값을 조회할 수 있는 기능이 추가되었습니다.
  * 사용자의 매칭 조건 정보를 조회하고 업데이트할 수 있는 기능이 강화되었습니다.

* **버그 수정**
  * 불필요한 import가 제거되어 코드가 정리되었습니다.

* **문서화**
  * Swagger를 통한 API 문서에 매칭 조건 관련 응답 및 요청 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->