### PR TITLE
[feat] 그룹 매칭 생성 결과 조회(Conflict)

### DIFF
--- a/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/at/mateball/common/swagger/SwaggerResponseDescription.java
@@ -24,6 +24,10 @@ public enum SwaggerResponseDescription {
 
     DIRECT_MATCH(
             new LinkedHashSet<>(Set.of(BAD_REQUEST_DATE, BAD_REQUEST_MONDAY, BAD_REQUEST_PAST))
+    ),
+
+    GROUP_MATCHING(
+            new LinkedHashSet<>(Set.of(GROUP_NOT_FOUND))
     );
 
     private final Set<ErrorCode> commonErrorCodeList;

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -6,6 +6,7 @@ import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.DirectGetListRes;
+import at.mateball.domain.group.api.dto.GroupCreateRes;
 import at.mateball.domain.group.core.service.GroupService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,5 +50,18 @@ public class GroupController {
         DirectGetListRes directGetListRes = groupService.getDirects(userId, date);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, directGetListRes));
+    }
+
+    @GetMapping("/group/{matchId}")
+    @CustomExceptionDescription(SwaggerResponseDescription.GROUP_MATCHING)
+    @Operation(summary = "그룹 매칭 생성 결과 화면입니다.")
+    public ResponseEntity<MateballResponse<?>> getGroupMatching(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+        GroupCreateRes groupCreateRes = groupService.getGroupMatching(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, groupCreateRes));
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupBaseDto.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupBaseDto.java
@@ -1,0 +1,13 @@
+package at.mateball.domain.group.api.dto;
+
+import java.time.LocalDate;
+
+public record GroupBaseDto(
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
@@ -1,0 +1,47 @@
+package at.mateball.domain.group.api.dto;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupCreateRes(
+        @NotNull
+        @Schema(description = "매칭 ID")
+        Long id,
+        @NotNull
+        @Schema(description = "닉네임")
+        String nickname,
+        @NotNull
+        @Schema(description = "원정 팀")
+        String awayTeam,
+        @NotNull
+        @Schema(description = "홈 팀")
+        String homeTeam,
+        @NotNull
+        @Schema(description = "경기장")
+        String stadium,
+        @NotNull
+        @Schema(description = "경기 날짜")
+        LocalDate date,
+        @NotNull
+        @Schema(description = "그룹매칭에 들어온 인원 수")
+        Integer count,
+        @Schema(description = "이미지 URL", nullable = true)
+        List<String> imgUrl
+) {
+    public static GroupCreateRes from(GroupBaseDto base, Integer count, List<String> imgUrls) {
+        return new GroupCreateRes(
+                base.id(),
+                base.nickname(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                count,
+                imgUrls
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -2,14 +2,18 @@ package at.mateball.domain.group.core.repository.querydsl;
 
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.DirectBaseRes;
+import at.mateball.domain.group.api.dto.GroupCreateRes;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface GroupRepositoryCustom {
     DirectCreateRes findDirectCreateResults(Long userId, Long matchId);
 
     List<DirectBaseRes> findDirectGroupsByDate(LocalDate date);
+
+    Optional<GroupCreateRes> findGroupCreateRes(Long matchId);
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -1,9 +1,6 @@
 package at.mateball.domain.group.core.service;
 
-import at.mateball.domain.group.api.dto.DirectGetRes;
-import at.mateball.domain.group.api.dto.DirectCreateRes;
-import at.mateball.domain.group.api.dto.DirectGetListRes;
-import at.mateball.domain.group.api.dto.DirectBaseRes;
+import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
@@ -71,5 +68,10 @@ public class GroupService {
                 .toList();
 
         return new DirectGetListRes(directGetRes);
+    }
+
+    public GroupCreateRes getGroupMatching(Long userId, Long matchId) {
+        return groupRepository.findGroupCreateRes(matchId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #54 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---
- 충돌 이슈,,,,


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 그룹 매칭 결과를 조회할 수 있는 새로운 GET 엔드포인트(`/v1/users/group/{matchId}`)가 추가되었습니다.
  * 그룹 매칭 결과 응답에 그룹 정보, 인원수, 이미지 URL 목록 등이 포함됩니다.

* **버그 수정**
  * 내부 상수 정의의 문법 오류가 수정되었습니다.

* **문서화**
  * Swagger를 통한 API 문서 및 오류 응답 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->