### PR TITLE
[feat] 그룹 매칭 리스트 조회

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -69,7 +69,7 @@ public class GroupController {
     @GetMapping("/group")
     public ResponseEntity<MateballResponse<?>> getGoups(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @NotNull @PathVariable LocalDate date
+            @NotNull @RequestParam LocalDate date
     ) {
         Long userId = customUserDetails.getUserId();
         GroupGetListRes groupGetListRes = groupService.getGroups(userId, date);

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -67,7 +67,7 @@ public class GroupController {
     }
 
     @GetMapping("/group")
-    public ResponseEntity<MateballResponse<?>> getGoups(
+    public ResponseEntity<MateballResponse<?>> getGroups(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @NotNull @RequestParam LocalDate date
     ) {

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -7,6 +7,7 @@ import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.DirectGetListRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
+import at.mateball.domain.group.api.dto.GroupGetListRes;
 import at.mateball.domain.group.core.service.GroupService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -64,4 +65,16 @@ public class GroupController {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, groupCreateRes));
     }
+
+    @GetMapping("/group")
+    public ResponseEntity<MateballResponse<?>> getGoups(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @PathVariable LocalDate date
+    ) {
+        Long userId = customUserDetails.getUserId();
+        GroupGetListRes groupGetListRes = groupService.getGroups(userId, date);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, groupGetListRes));
+    }
+
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.group.api.dto;
 
 
+import at.mateball.domain.group.api.dto.base.GroupCreateBaseRes;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -32,7 +33,7 @@ public record GroupCreateRes(
         @Schema(description = "이미지 URL", nullable = true)
         List<String> imgUrl
 ) {
-    public static GroupCreateRes from(GroupBaseDto base, Integer count, List<String> imgUrls) {
+    public static GroupCreateRes from(GroupCreateBaseRes base, Integer count, List<String> imgUrls) {
         return new GroupCreateRes(
                 base.id(),
                 base.nickname(),

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupGetListRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupGetListRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.group.api.dto;
+
+import java.util.List;
+
+public record GroupGetListRes(
+        List<GroupGetRes> mates
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupGetRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupGetRes.java
@@ -1,0 +1,32 @@
+package at.mateball.domain.group.api.dto;
+
+import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupGetRes(
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        Integer matchRate,
+        Integer count,
+        List<String> imgUrl
+) {
+    public static GroupGetRes from(GroupGetBaseRes base, Integer matchRate, Integer count, List<String> imgUrls) {
+        return new GroupGetRes(
+                base.id(),
+                base.nickname(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                matchRate,
+                count,
+                imgUrls
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/base/DirectGetBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/DirectGetBaseRes.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 public record DirectGetBaseRes(
         Long id,
+        Long leaderId,
         String nickname,
         Integer birthYear,
         String gender,
@@ -19,6 +20,7 @@ public record DirectGetBaseRes(
     public DirectGetBaseRes withMatchRate(Integer matchRate) {
         return new DirectGetBaseRes(
                 id,
+                leaderId,
                 nickname,
                 birthYear,
                 gender,

--- a/src/main/java/at/mateball/domain/group/api/dto/base/GroupCreateBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/GroupCreateBaseRes.java
@@ -1,8 +1,8 @@
-package at.mateball.domain.group.api.dto;
+package at.mateball.domain.group.api.dto.base;
 
 import java.time.LocalDate;
 
-public record GroupBaseDto(
+public record GroupCreateBaseRes(
         Long id,
         String nickname,
         String awayTeam,

--- a/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
@@ -1,0 +1,13 @@
+package at.mateball.domain.group.api.dto.base;
+
+import java.time.LocalDate;
+
+public record GroupGetBaseRes(
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.group.api.dto.base;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public record GroupGetBaseRes(
         Long id,

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -2,17 +2,14 @@ package at.mateball.domain.group.core.repository.querydsl;
 
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
-import at.mateball.domain.group.api.dto.GroupGetRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-@Repository
 public interface GroupRepositoryCustom {
     DirectCreateRes findDirectCreateResults(Long userId, Long matchId);
 
@@ -20,8 +17,4 @@ public interface GroupRepositoryCustom {
     List<DirectGetBaseRes> findDirectGroupsByDate(LocalDate date);
 
     List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date);
-
-    Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds);
-
-    Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -2,11 +2,14 @@ package at.mateball.domain.group.core.repository.querydsl;
 
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
+import at.mateball.domain.group.api.dto.GroupGetRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
+import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +18,10 @@ public interface GroupRepositoryCustom {
 
     Optional<GroupCreateRes> findGroupCreateRes(Long matchId);
     List<DirectGetBaseRes> findDirectGroupsByDate(LocalDate date);
+
+    List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date);
+
+    Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds);
+
+    Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -1,7 +1,6 @@
 package at.mateball.domain.group.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
-import at.mateball.domain.group.api.dto.GroupGetRes;
 import at.mateball.domain.group.api.dto.base.GroupCreateBaseRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
 import at.mateball.domain.group.api.dto.base.DirectCreateBaseRes;
@@ -19,9 +18,7 @@ import jakarta.persistence.EntityManager;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static at.mateball.domain.user.core.QUser.user;
 
@@ -171,45 +168,5 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                         game.gameDate.eq(date)
                 )
                 .fetch();
-    }
-
-    @Override
-    public Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds) {
-        QGroupMember member = QGroupMember.groupMember;
-        QUser user = QUser.user;
-
-        if (groupIds.isEmpty()) return Map.of();
-
-        return queryFactory
-                .select(member.group.id, member.count())
-                .from(member)
-                .where(member.group.id.in(groupIds))
-                .groupBy(member.group.id)
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(
-                        tuple -> tuple.get(0, Long.class),
-                        tuple -> tuple.get(1, Long.class).intValue() + 1
-                ));
-    }
-
-    @Override
-    public Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds) {
-        QGroupMember member = QGroupMember.groupMember;
-        QUser user = QUser.user;
-
-        if (groupIds.isEmpty()) return Map.of();
-
-        return queryFactory
-                .select(member.group.id, user.imgUrl)
-                .from(member)
-                .join(user).on(member.user.eq(user))
-                .where(member.group.id.in(groupIds))
-                .fetch()
-                .stream()
-                .collect(Collectors.groupingBy(
-                        tuple -> tuple.get(0, Long.class),
-                        Collectors.mapping(t -> t.get(1, String.class), Collectors.toList())
-                ));
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -79,6 +79,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         return queryFactory
                 .select(Projections.constructor(DirectGetBaseRes.class,
                         group.id,
+                        user.id,
                         user.nickname,
                         user.birthYear,
                         user.gender,

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.group.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
-import at.mateball.domain.group.api.dto.GroupBaseDto;
+import at.mateball.domain.group.api.dto.base.GroupCreateBaseRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
 import at.mateball.domain.group.api.dto.base.DirectCreateBaseRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
@@ -10,7 +10,6 @@ import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -108,8 +107,8 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         QGroupMember groupMember = QGroupMember.groupMember;
         QUser member = new QUser("member");
 
-        GroupBaseDto base = queryFactory
-                .select(Projections.constructor(GroupBaseDto.class,
+        GroupCreateBaseRes base = queryFactory
+                .select(Projections.constructor(GroupCreateBaseRes.class,
                         group.id,
                         leader.nickname,
                         gameInformation.awayTeamName,

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -7,6 +7,7 @@ import at.mateball.domain.group.api.dto.DirectGetListRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
 import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.exception.BusinessException;
@@ -24,10 +25,12 @@ import java.util.stream.Collectors;
 public class GroupService {
     private final GroupRepository groupRepository;
     private final MatchRequirementService matchRequirementService;
+    private final GroupMemberRepository groupMemberRepository;
 
-    public GroupService(GroupRepository groupRepository, MatchRequirementService matchRequirementService) {
+    public GroupService(GroupRepository groupRepository, MatchRequirementService matchRequirementService, GroupMemberRepository groupMemberRepository) {
         this.groupRepository = groupRepository;
         this.matchRequirementService = matchRequirementService;
+        this.groupMemberRepository = groupMemberRepository;
     }
 
     public DirectCreateRes getDirectMatching(Long userId, Long matchId) {
@@ -111,8 +114,8 @@ public class GroupService {
                         MatchingScoreDto::totalScore
                 ));
 
-        Map<Long, Integer> countMap = groupRepository.findGroupMemberCountMap(groupIds);
-        Map<Long, List<String>> imgMap = groupRepository.findGroupMemberImgMap(groupIds);
+        Map<Long, Integer> countMap = groupMemberRepository.findGroupMemberCountMap(groupIds);
+        Map<Long, List<String>> imgMap = groupMemberRepository.findGroupMemberImgMap(groupIds);
 
         List<GroupGetRes> result = baseList.stream()
                 .map(base -> {

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -15,11 +15,10 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static at.mateball.domain.groupmember.core.QGroupMember.groupMember;
 
 @Service
 public class GroupService {
@@ -70,8 +69,9 @@ public class GroupService {
                 ));
 
         List<DirectGetRes> directGetRes = result.stream()
-                .map(res -> res.withMatchRate(matchRateMap.getOrDefault(res.id(), 0)))
+                .map(res -> res.withMatchRate(matchRateMap.getOrDefault(res.leaderId(), 0)))
                 .map(DirectGetRes::from)
+                .sorted(Comparator.comparingInt(DirectGetRes::matchRate).reversed())
                 .toList();
 
         return new DirectGetListRes(directGetRes);
@@ -122,6 +122,7 @@ public class GroupService {
                     int avg = Math.round((float) score / count);
                     return GroupGetRes.from(base, avg, count, imgs);
                 })
+                .sorted(Comparator.comparingInt(GroupGetRes::matchRate).reversed())
                 .toList();
 
         return new GroupGetListRes(result);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static at.mateball.domain.group.core.validator.DateValidator.validate;
+
 @Service
 public class GroupService {
     private final GroupRepository groupRepository;
@@ -44,24 +46,7 @@ public class GroupService {
     }
 
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
-        LocalDate today = LocalDate.now();
-
-        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
-        }
-
-        if (date.isBefore(today)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
-        }
-
-        LocalDate minAvailableDate = today.plusDays(2);
-        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
-            minAvailableDate = today.plusDays(3);
-        }
-
-        if (date.isBefore(minAvailableDate)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_DATE);
-        }
+        validate(date);
 
         List<DirectGetBaseRes> result = groupRepository.findDirectGroupsByDate(date);
 
@@ -86,24 +71,7 @@ public class GroupService {
     }
 
     public GroupGetListRes getGroups(Long userId, LocalDate date) {
-        LocalDate today = LocalDate.now();
-
-        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
-        }
-
-        if (date.isBefore(today)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
-        }
-
-        LocalDate minAvailableDate = today.plusDays(2);
-        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
-            minAvailableDate = today.plusDays(3);
-        }
-
-        if (date.isBefore(minAvailableDate)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_DATE);
-        }
+        validate(date);
 
         List<GroupGetBaseRes> baseList = groupRepository.findGroupsWithBaseInfo(date);
         List<Long> groupIds = baseList.stream().map(GroupGetBaseRes::id).toList();

--- a/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
+++ b/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
@@ -1,0 +1,35 @@
+package at.mateball.domain.group.core.validator;
+
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+public class DateValidator {
+    private DateValidator() {
+
+    }
+
+    public static void validate(LocalDate date) {
+        LocalDate today = LocalDate.now();
+
+        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
+            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
+        }
+
+        if (date.isBefore(today)) {
+            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
+        }
+
+        LocalDate minAvailableDate = today.plusDays(2);
+        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
+            minAvailableDate = today.plusDays(3);
+        }
+
+        if (date.isBefore(minAvailableDate)) {
+            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_DATE);
+
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -1,6 +1,5 @@
-package at.mateball.domain.groupmember.core;
+package at.mateball.domain.groupmember;
 
-import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.Getter;

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/GroupMemberRepository.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/GroupMemberRepository.java
@@ -1,0 +1,10 @@
+package at.mateball.domain.groupmember.core.repository;
+
+import at.mateball.domain.groupmember.core.GroupMember;
+import at.mateball.domain.groupmember.core.repository.querydsl.GroupMemberRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberRepositoryCustom {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,0 +1,11 @@
+package at.mateball.domain.groupmember.core.repository.querydsl;
+
+
+import java.util.List;
+import java.util.Map;
+
+public interface GroupMemberRepositoryCustom {
+    Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds);
+
+    Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds);
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -1,0 +1,58 @@
+package at.mateball.domain.groupmember.core.repository.querydsl;
+
+import at.mateball.domain.groupmember.core.QGroupMember;
+import at.mateball.domain.user.core.QUser;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    public GroupMemberRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds) {
+        QGroupMember member = QGroupMember.groupMember;
+        QUser user = QUser.user;
+
+        if (groupIds.isEmpty()) return Map.of();
+
+        return queryFactory
+                .select(member.group.id, member.count())
+                .from(member)
+                .where(member.group.id.in(groupIds))
+                .groupBy(member.group.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(0, Long.class),
+                        tuple -> tuple.get(1, Long.class).intValue() + 1
+                ));
+    }
+
+    @Override
+    public Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds) {
+        QGroupMember member = QGroupMember.groupMember;
+        QUser user = QUser.user;
+
+        if (groupIds.isEmpty()) return Map.of();
+
+        return queryFactory
+                .select(member.group.id, user.imgUrl)
+                .from(member)
+                .join(user).on(member.user.eq(user))
+                .where(member.group.id.in(groupIds))
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> tuple.get(0, Long.class),
+                        Collectors.mapping(t -> t.get(1, String.class), Collectors.toList())
+                ));
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #58 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 그룹 ID, 리더 닉네임, 이미지 URL
- 경기 정보 (원정/홈 팀, 경기장, 경기 날짜)
- 리더 기준 매칭률 계산 (MatchRequirement 기반)
- 그룹 참여 인원수 및 이미지 리스트 포함


- `GroupService.getGroups()`:
  - 날짜 유효성 검증 `DateValidator.validate(date)` 추가
  - `groupRepository.findGroupsWithBaseInfo(date)`로 기본 정보 조회
  - `matchRequirementService.getMatchings(userId)` 통해 리더 매칭률 계산
  - `groupMemberRepository.findGroupMemberCountMap()`으로 인원수 집계
  - `groupMemberRepository.findGroupMemberImgMap()`으로 이미지 리스트 매핑
  - 정렬: 매칭률 내림차순


- 날짜 유효성 검증 로직 `DateValidator` 클래스로 추출 → 재사용 가능
- `GroupMemberRepositoryCustom` 및 `Impl`로 QueryDSL 조회 책임 분리
- `GroupQueryRepository`는 그룹 중심, `GroupMemberRepository`는 멤버 중심 책임 분리하여 SRP 준수

<br/>


### ❤️ To 다진 / To 헤음

---
- 뚱뚱 PR이 탄생해버렸다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 사용자가 지정한 날짜에 속한 그룹 목록을 조회할 수 있는 새로운 GET API 엔드포인트(`/v1/users/group`)가 추가되었습니다.
  * 그룹 목록 응답에 그룹별 매치율, 인원수, 멤버 이미지 등 다양한 정보가 포함됩니다.
  * 날짜 유효성 검사를 수행하는 새로운 기능이 도입되어 특정 조건에 맞지 않는 날짜 요청 시 오류가 발생합니다.

* **버그 수정**
  * 날짜 유효성 검사 로직이 중앙화되어, 잘못된 날짜 요청 시 일관된 오류 처리가 적용됩니다.

* **기타**
  * 도메인 구조 개선 및 DTO, 레포지토리, 서비스 계층의 신규 클래스 및 메서드가 추가되어 그룹 및 멤버 관련 데이터 제공이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->