### PR TITLE
[feat] 일대일 매칭 현황 조회

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/GroupStatus.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupStatus.java
@@ -26,4 +26,11 @@ public enum GroupStatus {
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
+
+    public static GroupStatus fromCode(String label) {
+        return Arrays.stream(values())
+                .filter(g -> g.label.equals(label))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -1,13 +1,34 @@
 package at.mateball.domain.groupmember.api.controller;
 
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/v1/users")
 public class GroupMemberController {
     private final GroupMemberService groupMemberService;
 
     public GroupMemberController(GroupMemberService groupMemberService) {
         this.groupMemberService = groupMemberService;
+    }
+
+    @GetMapping("/match-stage/direct")
+    public ResponseEntity<MateballResponse<?>> getDirectStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam String status
+    ) {
+        Long userId = userDetails.getUserId();
+        DirectStatusListRes directStatusListRes = groupMemberService.getDirectStatus(userId, status);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, directStatusListRes));
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -4,6 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,24 @@ public class GroupMemberController {
         } else {
             GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
             result = groupMemberService.getDirectStatus(userId, groupStatus);
+        }
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("/match-stage/group")
+    public ResponseEntity<MateballResponse<?>> getGroupStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "status", required = false) String statusLabel
+    ) {
+        Long userId = userDetails.getUserId();
+        GroupStatusListRes result;
+
+        if (statusLabel == null || statusLabel.isBlank()) {
+            result = groupMemberService.getAllGroupStatus(userId);
+        } else {
+            GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
+            result = groupMemberService.getAllGroupStatus(userId, groupStatus);
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -2,6 +2,7 @@ package at.mateball.domain.groupmember.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
@@ -24,10 +25,10 @@ public class GroupMemberController {
     @GetMapping("/match-stage/direct")
     public ResponseEntity<MateballResponse<?>> getDirectStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam String status
-    ) {
+            @RequestParam("status")GroupStatus groupStatus
+            ) {
         Long userId = userDetails.getUserId();
-        DirectStatusListRes directStatusListRes = groupMemberService.getDirectStatus(userId, status);
+        DirectStatusListRes directStatusListRes = groupMemberService.getDirectStatus(userId, groupStatus);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, directStatusListRes));
     }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -1,0 +1,13 @@
+package at.mateball.domain.groupmember.api.controller;
+
+import at.mateball.domain.groupmember.core.service.GroupMemberService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GroupMemberController {
+    private final GroupMemberService groupMemberService;
+
+    public GroupMemberController(GroupMemberService groupMemberService) {
+        this.groupMemberService = groupMemberService;
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -25,12 +25,18 @@ public class GroupMemberController {
     @GetMapping("/match-stage/direct")
     public ResponseEntity<MateballResponse<?>> getDirectStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("status") String statusLabel
+            @RequestParam(value = "status", required = false) String statusLabel
     ) {
         Long userId = userDetails.getUserId();
-        GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
-        DirectStatusListRes directStatusListRes = groupMemberService.getDirectStatus(userId, groupStatus);
+        DirectStatusListRes result;
 
-        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, directStatusListRes));
+        if (statusLabel == null || statusLabel.isBlank()) {
+            result = groupMemberService.getAllDirectStatus(userId);
+        } else {
+            GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
+            result = groupMemberService.getDirectStatus(userId, groupStatus);
+        }
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -25,9 +25,10 @@ public class GroupMemberController {
     @GetMapping("/match-stage/direct")
     public ResponseEntity<MateballResponse<?>> getDirectStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam("status")GroupStatus groupStatus
-            ) {
+            @RequestParam("status") String statusLabel
+    ) {
         Long userId = userDetails.getUserId();
+        GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
         DirectStatusListRes directStatusListRes = groupMemberService.getDirectStatus(userId, groupStatus);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, directStatusListRes));

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -53,7 +53,7 @@ public class GroupMemberController {
             result = groupMemberService.getAllGroupStatus(userId);
         } else {
             GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
-            result = groupMemberService.getAllGroupStatus(userId, groupStatus);
+            result = groupMemberService.getGroupStatus(userId, groupStatus);
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
@@ -1,0 +1,5 @@
+package at.mateball.domain.groupmember.api.dto;
+
+public class DirectStatusListRes
+{
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
@@ -1,5 +1,8 @@
 package at.mateball.domain.groupmember.api.dto;
 
-public class DirectStatusListRes
-{
+import java.util.List;
+
+public record DirectStatusListRes(
+        List<DirectStatusRes> mates) {
+
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
@@ -1,0 +1,4 @@
+package at.mateball.domain.groupmember.api.dto;
+
+public class DirectStatusRes {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
@@ -1,4 +1,41 @@
 package at.mateball.domain.groupmember.api.dto;
 
-public class DirectStatusRes {
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.team.core.TeamName;
+
+import java.time.LocalDate;
+
+public record DirectStatusRes(
+        Long id,
+        String nickname,
+        String age,
+        String gender,
+        String team,
+        String style,
+        String awayTeam,
+        String homeTeam,
+        LocalDate date,
+        String status,
+        String imgUrl
+) {
+    public static DirectStatusRes from(DirectStatusBaseRes baseRes) {
+        int age = LocalDate.now().getYear() - baseRes.birthYear() + 1;
+
+        return new DirectStatusRes(
+                baseRes.id(),
+                baseRes.nickname(),
+                age + "세",
+                Gender.from(baseRes.gender()).getLabel(),
+                TeamName.from(baseRes.team()).getLabel(),
+                Style.from(baseRes.style()).getLabel(),
+                baseRes.awayTeam(),
+                baseRes.homeTeam(),
+                baseRes.date(),
+                GroupMemberStatus.from(baseRes.status()).getLabel(),
+                baseRes.imgUrl()
+        );
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import java.util.List;
+
+public record GroupStatusListRes(
+        List<GroupStatusRes> mates
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusRes.java
@@ -1,0 +1,33 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupStatusRes(
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String status,
+        Integer count,
+        List<String> imgUrl
+) {
+    public static GroupStatusRes from(GroupStatusBaseRes base, Integer count, List<String> imgUrls) {
+        return new GroupStatusRes(
+                base.id(),
+                base.nickname(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                GroupMemberStatus.from(base.status()).getLabel(),
+                count,
+                imgUrls
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
@@ -1,0 +1,4 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+public class DirectStatusBaseRes {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
@@ -1,4 +1,19 @@
 package at.mateball.domain.groupmember.api.dto.base;
 
-public class DirectStatusBaseRes {
+import java.time.LocalDate;
+
+public record DirectStatusBaseRes(
+        Long id,
+        String nickname,
+        Integer birthYear,
+        String gender,
+        Integer team,
+        Integer style,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        Integer status,
+        String imgUrl
+) {
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseRes.java
@@ -1,0 +1,14 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+import java.time.LocalDate;
+
+public record GroupStatusBaseRes(
+     Long id,
+     String nickname,
+     String awayTeam,
+     String homeTeam,
+     String stadium,
+     LocalDate date,
+     Integer status
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 
 import java.util.List;
 import java.util.Map;
@@ -14,4 +15,8 @@ public interface GroupMemberRepositoryCustom {
     List<DirectStatusBaseRes> findDirectMatchingsByUserAndGroupStatus(Long userId, int groupStatus);
 
     List<DirectStatusBaseRes> findAllDirectMatchingsByUser(Long userId);
+
+    List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId);
+
+    List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface GroupMemberRepositoryCustom {
     Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds);
 
     List<DirectStatusBaseRes> findDirectMatchingsByUserAndGroupStatus(Long userId, int groupStatus);
+
+    List<DirectStatusBaseRes> findAllDirectMatchingsByUser(Long userId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,6 +1,8 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
+import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+
 import java.util.List;
 import java.util.Map;
 
@@ -8,4 +10,6 @@ public interface GroupMemberRepositoryCustom {
     Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds);
 
     Map<Long, List<String>> findGroupMemberImgMap(List<Long> groupIds);
+
+    List<DirectStatusBaseRes> findDirectMatchingsByUserAndGroupStatus(Long userId, int groupStatus);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -33,13 +33,16 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
         return queryFactory
                 .select(member.group.id, member.count())
                 .from(member)
-                .where(member.group.id.in(groupIds))
+                .where(
+                        member.group.id.in(groupIds),
+                        member.isParticipant.isTrue()
+                )
                 .groupBy(member.group.id)
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(
                         tuple -> tuple.get(0, Long.class),
-                        tuple -> tuple.get(1, Long.class).intValue() + 1
+                        tuple -> tuple.get(1, Long.class).intValue()
                 ));
     }
 
@@ -54,7 +57,10 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                 .select(member.group.id, user.imgUrl)
                 .from(member)
                 .join(user).on(member.user.eq(user))
-                .where(member.group.id.in(groupIds))
+                .where(
+                        member.group.id.in(groupIds),
+                        member.isParticipant.isTrue()
+                )
                 .fetch()
                 .stream()
                 .collect(Collectors.groupingBy(

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -3,6 +3,7 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 import at.mateball.domain.gameinformation.core.QGameInformation;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
@@ -131,6 +132,65 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                         groupMember.user.id.eq(userId),
                         groupMember.isParticipant.isTrue(),
                         group.isGroup.isFalse()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser user = QUser.user;
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(groupMember.user, user)
+                .join(group.gameInformation, gameInformation)
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isParticipant.isTrue(),
+                        group.isGroup.isTrue()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser user = QUser.user;
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(groupMember.user, user)
+                .join(group.gameInformation, gameInformation)
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isParticipant.isTrue(),
+                        group.isGroup.isTrue(),
+                        group.status.eq(groupStatus)
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -98,4 +98,40 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                 )
                 .fetch();
     }
+
+    @Override
+    public List<DirectStatusBaseRes> findAllDirectMatchingsByUser(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser user = QUser.user;
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        return queryFactory
+                .select(Projections.constructor(DirectStatusBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        user.birthYear,
+                        user.gender,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status,
+                        user.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(groupMember.user, user)
+                .join(group.gameInformation, gameInformation)
+                .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isParticipant.isTrue(),
+                        group.isGroup.isFalse()
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -18,13 +18,12 @@ public class GroupMemberService {
     }
 
     public DirectStatusListRes getDirectStatus(Long userId, GroupStatus groupStatus) {
-        List<DirectStatusBaseRes> baseResList =
-                groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus.getValue());
+        List<DirectStatusBaseRes> baseResList = groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus.getValue());
 
-        List<DirectStatusRes> mappedList = baseResList.stream()
+        List<DirectStatusRes> result = baseResList.stream()
                 .map(DirectStatusRes::from)
                 .toList();
 
-        return new DirectStatusListRes(mappedList);
+        return new DirectStatusListRes(result);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -11,6 +11,7 @@ import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class GroupMemberService {
@@ -42,6 +43,30 @@ public class GroupMemberService {
 
     public GroupStatusListRes getAllGroupStatus(Long userId) {
         List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUser(userId);
+        return mapWithCountsAndImages(baseResList);
+    }
 
+    public GroupStatusListRes getGroupStatus(Long userId, GroupStatus status) {
+        List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUserAndStatus(userId, status.getValue());
+        return mapWithCountsAndImages(baseResList);
+    }
+
+    private GroupStatusListRes mapWithCountsAndImages(List<GroupStatusBaseRes> baseResList) {
+        List<Long> groupIds = baseResList.stream()
+                .map(GroupStatusBaseRes::id)
+                .toList();
+
+        Map<Long, Integer> countMap = groupMemberRepository.findGroupMemberCountMap(groupIds);
+        Map<Long, List<String>> imgMap = groupMemberRepository.findGroupMemberImgMap(groupIds);
+
+        List<GroupStatusRes> result = baseResList.stream()
+                .map(res -> GroupStatusRes.from(
+                        res,
+                        countMap.getOrDefault(res.id(), 0),
+                        imgMap.getOrDefault(res.id(), List.of())
+                ))
+                .toList();
+
+        return new GroupStatusListRes(result);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -26,4 +26,14 @@ public class GroupMemberService {
 
         return new DirectStatusListRes(result);
     }
+
+    public DirectStatusListRes getAllDirectStatus(Long userId) {
+        List<DirectStatusBaseRes> baseResList = groupMemberRepository.findAllDirectMatchingsByUser(userId);
+
+        List<DirectStatusRes> mapped = baseResList.stream()
+                .map(DirectStatusRes::from)
+                .toList();
+
+        return new DirectStatusListRes(mapped);
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -3,7 +3,10 @@ package at.mateball.domain.groupmember.core.service;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.api.dto.DirectStatusRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -30,10 +33,15 @@ public class GroupMemberService {
     public DirectStatusListRes getAllDirectStatus(Long userId) {
         List<DirectStatusBaseRes> baseResList = groupMemberRepository.findAllDirectMatchingsByUser(userId);
 
-        List<DirectStatusRes> mapped = baseResList.stream()
+        List<DirectStatusRes> result = baseResList.stream()
                 .map(DirectStatusRes::from)
                 .toList();
 
-        return new DirectStatusListRes(mapped);
+        return new DirectStatusListRes(result);
+    }
+
+    public GroupStatusListRes getAllGroupStatus(Long userId) {
+        List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUser(userId);
+
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -1,9 +1,13 @@
 package at.mateball.domain.groupmember.core.service;
 
-import at.mateball.domain.group.api.dto.DirectGetListRes;
 import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.DirectStatusRes;
+import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class GroupMemberService {
@@ -13,7 +17,14 @@ public class GroupMemberService {
         this.groupMemberRepository = groupMemberRepository;
     }
 
-    public DirectGetListRes getDirectStatus(Long userId, GroupStatus groupStatus) {
-        return groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus);
+    public DirectStatusListRes getDirectStatus(Long userId, GroupStatus groupStatus) {
+        List<DirectStatusBaseRes> baseResList =
+                groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus.getValue());
+
+        List<DirectStatusRes> mappedList = baseResList.stream()
+                .map(DirectStatusRes::from)
+                .toList();
+
+        return new DirectStatusListRes(mappedList);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.groupmember.core.service;
 
+import at.mateball.domain.group.api.dto.DirectGetListRes;
+import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -9,5 +11,9 @@ public class GroupMemberService {
 
     public GroupMemberService(GroupMemberRepository groupMemberRepository) {
         this.groupMemberRepository = groupMemberRepository;
+    }
+
+    public DirectGetListRes getDirectStatus(Long userId, GroupStatus groupStatus) {
+        return groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -52,6 +52,10 @@ public class GroupMemberService {
     }
 
     private GroupStatusListRes mapWithCountsAndImages(List<GroupStatusBaseRes> baseResList) {
+        if (baseResList.isEmpty()) {
+            return new GroupStatusListRes(List.of());
+        }
+
         List<Long> groupIds = baseResList.stream()
                 .map(GroupStatusBaseRes::id)
                 .toList();

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -1,0 +1,13 @@
+package at.mateball.domain.groupmember.core.service;
+
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GroupMemberService {
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupMemberService(GroupMemberRepository groupMemberRepository) {
+        this.groupMemberRepository = groupMemberRepository;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #62 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사용자의 1:1 매칭 현황(대기/완료/실패 등)을 조회하는 API 구현
- 대상 조건: Group의 `is_group = false` 인 경우만
- 필터 조건: Group의 `status`(대기중/완료/실패) 기준으로 조회
- 응답 구조: 유저 + 경기 + 매칭 상태 정보를 포함한 DTO 반환

- Label을 Code로 변환하는 로직 추가

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 직접 매칭 현황과 그룹 매칭 현황을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 매칭 현황을 상태 코드로 필터링하는 기능이 도입되었습니다.
  * 직접 매칭과 그룹 매칭 현황을 리스트 형태로 반환하는 새로운 응답 구조가 도입되었습니다.
  * 매칭 상세 정보(닉네임, 나이, 성별, 팀, 스타일, 경기 정보, 이미지 등)가 개선된 형태로 제공됩니다.
  * 그룹 매칭 현황에 참여자 수와 이미지 목록이 함께 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->