### PR TITLE
[feat] 그룹 매칭 현황 조회 api

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -4,6 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,24 @@ public class GroupMemberController {
         } else {
             GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
             result = groupMemberService.getDirectStatus(userId, groupStatus);
+        }
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("/match-stage/group")
+    public ResponseEntity<MateballResponse<?>> getGroupStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "status", required = false) String statusLabel
+    ) {
+        Long userId = userDetails.getUserId();
+        GroupStatusListRes result;
+
+        if (statusLabel == null || statusLabel.isBlank()) {
+            result = groupMemberService.getAllGroupStatus(userId);
+        } else {
+            GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
+            result = groupMemberService.getAllGroupStatus(userId, groupStatus);
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -53,7 +53,7 @@ public class GroupMemberController {
             result = groupMemberService.getAllGroupStatus(userId);
         } else {
             GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
-            result = groupMemberService.getAllGroupStatus(userId, groupStatus);
+            result = groupMemberService.getGroupStatus(userId, groupStatus);
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import java.util.List;
+
+public record GroupStatusListRes(
+        List<GroupStatusRes> mates
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusRes.java
@@ -1,0 +1,33 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupStatusRes(
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String status,
+        Integer count,
+        List<String> imgUrl
+) {
+    public static GroupStatusRes from(GroupStatusBaseRes base, Integer count, List<String> imgUrls) {
+        return new GroupStatusRes(
+                base.id(),
+                base.nickname(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                GroupMemberStatus.from(base.status()).getLabel(),
+                count,
+                imgUrls
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseRes.java
@@ -1,0 +1,14 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+import java.time.LocalDate;
+
+public record GroupStatusBaseRes(
+     Long id,
+     String nickname,
+     String awayTeam,
+     String homeTeam,
+     String stadium,
+     LocalDate date,
+     Integer status
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 
 import java.util.List;
 import java.util.Map;
@@ -14,4 +15,8 @@ public interface GroupMemberRepositoryCustom {
     List<DirectStatusBaseRes> findDirectMatchingsByUserAndGroupStatus(Long userId, int groupStatus);
 
     List<DirectStatusBaseRes> findAllDirectMatchingsByUser(Long userId);
+
+    List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId);
+
+    List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -33,13 +33,16 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
         return queryFactory
                 .select(member.group.id, member.count())
                 .from(member)
-                .where(member.group.id.in(groupIds))
+                .where(
+                        member.group.id.in(groupIds),
+                        member.isParticipant.isTrue()
+                )
                 .groupBy(member.group.id)
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(
                         tuple -> tuple.get(0, Long.class),
-                        tuple -> tuple.get(1, Long.class).intValue() + 1
+                        tuple -> tuple.get(1, Long.class).intValue()
                 ));
     }
 
@@ -54,7 +57,10 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                 .select(member.group.id, user.imgUrl)
                 .from(member)
                 .join(user).on(member.user.eq(user))
-                .where(member.group.id.in(groupIds))
+                .where(
+                        member.group.id.in(groupIds),
+                        member.isParticipant.isTrue()
+                )
                 .fetch()
                 .stream()
                 .collect(Collectors.groupingBy(

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -3,6 +3,7 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 import at.mateball.domain.gameinformation.core.QGameInformation;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
@@ -131,6 +132,65 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                         groupMember.user.id.eq(userId),
                         groupMember.isParticipant.isTrue(),
                         group.isGroup.isFalse()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser user = QUser.user;
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(groupMember.user, user)
+                .join(group.gameInformation, gameInformation)
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isParticipant.isTrue(),
+                        group.isGroup.isTrue()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser user = QUser.user;
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(groupMember.user, user)
+                .join(group.gameInformation, gameInformation)
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isParticipant.isTrue(),
+                        group.isGroup.isTrue(),
+                        group.status.eq(groupStatus)
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -11,6 +11,7 @@ import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class GroupMemberService {
@@ -42,6 +43,30 @@ public class GroupMemberService {
 
     public GroupStatusListRes getAllGroupStatus(Long userId) {
         List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUser(userId);
+        return mapWithCountsAndImages(baseResList);
+    }
 
+    public GroupStatusListRes getGroupStatus(Long userId, GroupStatus status) {
+        List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUserAndStatus(userId, status.getValue());
+        return mapWithCountsAndImages(baseResList);
+    }
+
+    private GroupStatusListRes mapWithCountsAndImages(List<GroupStatusBaseRes> baseResList) {
+        List<Long> groupIds = baseResList.stream()
+                .map(GroupStatusBaseRes::id)
+                .toList();
+
+        Map<Long, Integer> countMap = groupMemberRepository.findGroupMemberCountMap(groupIds);
+        Map<Long, List<String>> imgMap = groupMemberRepository.findGroupMemberImgMap(groupIds);
+
+        List<GroupStatusRes> result = baseResList.stream()
+                .map(res -> GroupStatusRes.from(
+                        res,
+                        countMap.getOrDefault(res.id(), 0),
+                        imgMap.getOrDefault(res.id(), List.of())
+                ))
+                .toList();
+
+        return new GroupStatusListRes(result);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -3,7 +3,10 @@ package at.mateball.domain.groupmember.core.service;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.api.dto.DirectStatusRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -30,10 +33,15 @@ public class GroupMemberService {
     public DirectStatusListRes getAllDirectStatus(Long userId) {
         List<DirectStatusBaseRes> baseResList = groupMemberRepository.findAllDirectMatchingsByUser(userId);
 
-        List<DirectStatusRes> mapped = baseResList.stream()
+        List<DirectStatusRes> result = baseResList.stream()
                 .map(DirectStatusRes::from)
                 .toList();
 
-        return new DirectStatusListRes(mapped);
+        return new DirectStatusListRes(result);
+    }
+
+    public GroupStatusListRes getAllGroupStatus(Long userId) {
+        List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUser(userId);
+
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -52,6 +52,10 @@ public class GroupMemberService {
     }
 
     private GroupStatusListRes mapWithCountsAndImages(List<GroupStatusBaseRes> baseResList) {
+        if (baseResList.isEmpty()) {
+            return new GroupStatusListRes(List.of());
+        }
+
         List<Long> groupIds = baseResList.stream()
                 .map(GroupStatusBaseRes::id)
                 .toList();


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #64 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- Group 상태 조회 API (`/match-stage/group`)
- 관련 서비스 메서드 `getAllGroupStatus`, `getGroupStatus`
- 반환 DTO인 `GroupStatusRes`의 count 및 imgUrl 값 정확성 향상

- 방장도 group_member 테이블에 포함되는 구조로 변경됨에 따라,
  `findGroupMemberCountMap` 및 `findGroupMemberImgMap`의 로직을 아래와 같이 수정했습니다.
  - count: isParticipant == true 조건으로 참가자 수만 정확히 집계 (방장 포함)
  - imgMap: 모든 group_member에 대해 imgUrl 수집 (isParticipant 조건 제거)


<br/>


### ❤️ To 다진 / To 헤음

---
- GroupMemberService랑 관련 레포지토리는 이 브랜치 머지하고 한번에 진행하도록 할게옹!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 인증된 사용자의 그룹 상태 정보를 조회할 수 있는 새로운 GET 엔드포인트(`/v1/users/match-stage/group`)가 추가되었습니다. 선택적으로 상태별로 필터링하여 조회할 수 있습니다.
  * 그룹 상태 정보는 그룹별 멤버 수, 이미지, 경기 정보 등 상세 데이터를 포함해 응답됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->