### PR TITLE
[feat] 매칭된 인원 조회 api

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -60,7 +60,7 @@ public class GroupMemberController {
     }
 
     @GetMapping("/num-count/{matchId}")
-    public ResponseEntity<MateballResponse<?>> getGroups(
+    public ResponseEntity<MateballResponse<?>> countGroupMember(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @NotNull @PathVariable Long matchId
     ) {

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -5,6 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DetailMatchingListRes;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
@@ -56,6 +57,18 @@ public class GroupMemberController {
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("/num-count/{matchId}")
+    public ResponseEntity<MateballResponse<?>> getGroups(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        GroupMemberCountRes groupMemberCountRes = groupMemberService.countGroupMember(matchId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, groupMemberCountRes));
     }
 
     @GetMapping("/match-detail/{matchId}")

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMemberCountRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMemberCountRes.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.groupmember.api.dto;
+
+public record GroupMemberCountRes(
+        int count
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
+import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
@@ -20,6 +21,8 @@ public interface GroupMemberRepositoryCustom {
     List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId);
 
     List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus);
+
+    GroupMemberCountRes countGroupMember(Long groupId);
 
     List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
+import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
@@ -8,10 +9,9 @@ import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import com.querydsl.core.types.Projections;
-
 
 import java.util.List;
 import java.util.Map;
@@ -200,6 +200,19 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                         group.status.eq(groupStatus)
                 )
                 .fetch();
+    }
+
+    @Override
+    public GroupMemberCountRes countGroupMember(Long groupId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        Long count = queryFactory
+                .select(groupMember.count())
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId))
+                .fetchOne();
+
+        return new GroupMemberCountRes(count != null ? count.intValue() : 0);
     }
 
     @Override

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -1,8 +1,8 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
-import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.group.core.QGroup;
+import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
+public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     public GroupMemberRepositoryImpl(EntityManager entityManager) {
@@ -209,7 +209,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
         Long count = queryFactory
                 .select(groupMember.count())
                 .from(groupMember)
-                .where(groupMember.group.id.eq(groupId))
+                .where(groupMember.group.id.eq(groupId), groupMember.isParticipant.isTrue())
                 .fetchOne();
 
         return new GroupMemberCountRes(count != null ? count.intValue() : 0);

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.service;
 
 import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.groupmember.api.dto.*;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
@@ -18,10 +19,12 @@ import java.util.stream.Collectors;
 
 @Service
 public class GroupMemberService {
+    private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final MatchRequirementService matchRequirementService;
 
-    public GroupMemberService(GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService) {
+    public GroupMemberService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService) {
+        this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.matchRequirementService = matchRequirementService;
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -103,6 +103,9 @@ public class GroupMemberService {
     }
 
     public GroupMemberCountRes countGroupMember(final Long matchId) {
+        groupRepository.findById(matchId).orElseThrow(() ->
+                new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
         return groupMemberRepository.countGroupMember(matchId);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -101,4 +101,8 @@ public class GroupMemberService {
 
         return new GroupStatusListRes(result);
     }
+
+    public GroupMemberCountRes countGroupMember(final Long matchId) {
+        return groupMemberRepository.countGroupMember(matchId);
+    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #68 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭된 인원 조회 api를 구현했습니다.
- group/groupmember 패키지 중 어디에 위치해야할지 고민했는데, member 수 count를 해야하니 groupmember 패키지에 최종으로 두었습니다!


<br/>


### ❤️ To 다진 / To 헤음

---

- 아 맞다...group 이랑 match 구분 이거 올리고 생각하고 있겠읍니다...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 매치 ID에 대한 그룹 멤버 수를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 그룹이 존재하지 않을 경우 적절한 오류가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->