### PR TITLE
[feat] 매칭 요청 상세 조회

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -3,16 +3,14 @@ package at.mateball.domain.groupmember.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.groupmember.api.dto.DetailMatchingListRes;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/users")
@@ -57,5 +55,16 @@ public class GroupMemberController {
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("/match-detail")
+    public ResponseEntity<MateballResponse<?>> getDetailMatching(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long matchId
+    ) {
+        Long userId = userDetails.getUserId();
+        DetailMatchingListRes detailMatchingListRes = groupMemberService.getDetailMatching(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, detailMatchingListRes));
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -8,6 +8,7 @@ import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberService;
 import at.mateball.exception.code.SuccessCode;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -57,10 +58,10 @@ public class GroupMemberController {
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
 
-    @GetMapping("/match-detail")
+    @GetMapping("/match-detail/{matchId}")
     public ResponseEntity<MateballResponse<?>> getDetailMatching(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long matchId
+            @NotNull @PathVariable Long matchId
     ) {
         Long userId = userDetails.getUserId();
         DetailMatchingListRes detailMatchingListRes = groupMemberService.getDetailMatching(userId, matchId);

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingListRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import java.util.List;
+
+public record DetailMatchingListRes(
+        List<DetailMatchingRes> mates
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
@@ -27,8 +27,8 @@ public record DetailMatchingRes(
 
         return new DetailMatchingRes(
                 base.id(),
-                age + "세",
                 base.nickname(),
+                age + "세",
                 Gender.from(base.gender()).getLabel(),
                 TeamName.from(base.team()).getLabel(),
                 Style.from(base.style()).getLabel(),

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 public record DetailMatchingRes(
         Long id,
         String nickname,
-        String agd,
+        String age,
         String gender,
         String team,
         String style,

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingRes.java
@@ -1,0 +1,44 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.team.core.TeamName;
+
+import java.time.LocalDate;
+
+public record DetailMatchingRes(
+        Long id,
+        String nickname,
+        String agd,
+        String gender,
+        String team,
+        String style,
+        String introduction,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String imgUrl,
+        Integer matchRate
+) {
+    public static DetailMatchingRes from(DetailMatchingBaseRes base, Integer matchRate) {
+        int age = LocalDate.now().getYear() - base.birthYear() + 1;
+
+        return new DetailMatchingRes(
+                base.id(),
+                age + "세",
+                base.nickname(),
+                Gender.from(base.gender()).getLabel(),
+                TeamName.from(base.team()).getLabel(),
+                Style.from(base.style()).getLabel(),
+                base.introduction(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                base.imgUrl(),
+                matchRate
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
@@ -1,0 +1,19 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+import java.time.LocalDate;
+
+public record DetailMatchingBaseRes(
+        Long id,
+        String nickname,
+        Integer birthYear,
+        String gender,
+        Integer team,
+        Integer style,
+        String introduction,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String imgUrl
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
+import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 
@@ -19,4 +20,6 @@ public interface GroupMemberRepositoryCustom {
     List<GroupStatusBaseRes> findGroupMatchingsByUser(Long userId);
 
     List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus);
+
+    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long matchId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -230,7 +230,10 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                 .join(groupMember.group, group)
                 .join(group.gameInformation, game)
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
-                .where(group.id.eq(matchId))
+                .where(
+                        group.id.eq(matchId),
+                        groupMember.isParticipant.isTrue()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -2,6 +2,7 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
 import at.mateball.domain.group.core.QGroup;
+import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.QGroupMember;
@@ -198,6 +199,38 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                         group.isGroup.isTrue(),
                         group.status.eq(groupStatus)
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long matchId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QUser user = QUser.user;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+        QGroup group = QGroup.group;
+        QGameInformation game = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(Projections.constructor(DetailMatchingBaseRes.class,
+                        group.id,
+                        user.nickname,
+                        user.birthYear,
+                        user.gender,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        user.introduction,
+                        game.awayTeamName,
+                        game.homeTeamName,
+                        game.stadiumName,
+                        game.gameDate,
+                        user.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.user, user)
+                .join(groupMember.group, group)
+                .join(group.gameInformation, game)
+                .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
+                .where(group.id.eq(matchId))
                 .fetch();
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -1,10 +1,8 @@
 package at.mateball.domain.groupmember.core.service;
 
 import at.mateball.domain.group.core.GroupStatus;
-import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
-import at.mateball.domain.groupmember.api.dto.DirectStatusRes;
-import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
-import at.mateball.domain.groupmember.api.dto.GroupStatusRes;
+import at.mateball.domain.groupmember.api.dto.*;
+import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
@@ -49,6 +47,10 @@ public class GroupMemberService {
     public GroupStatusListRes getGroupStatus(Long userId, GroupStatus status) {
         List<GroupStatusBaseRes> baseResList = groupMemberRepository.findGroupMatchingsByUserAndStatus(userId, status.getValue());
         return mapWithCountsAndImages(baseResList);
+    }
+
+    public DetailMatchingListRes getDetailMatching(Long userId, Long matchId) {
+        List<DetailMatchingBaseRes> baseResList
     }
 
     private GroupStatusListRes mapWithCountsAndImages(List<GroupStatusBaseRes> baseResList) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #66 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 해당 매칭의 상세정보를 확인 할 수 있는 API 작업
- 해당 그룹의 권한이 있는 사람의 정보만 보여지도록 수정
- 매칭 현황을 제외하고는 내가 만든 매칭은 보이지 않도록 리펙토링 예정

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 매치 ID에 대한 그룹 멤버 상세 매칭 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 각 그룹 멤버의 닉네임, 나이, 성별, 팀, 스타일, 자기소개, 경기 정보, 이미지, 매칭 점수 등의 상세 정보를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->