### PR TITLE
[fix] 매칭현황을 제외하고는 사용자와 관련된 매칭 보이지 않도록 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface GroupRepositoryCustom {
     DirectCreateRes findDirectCreateResults(Long userId, Long matchId);
 
-    Optional<GroupCreateRes> findGroupCreateRes(Long matchId);
+    Optional<GroupCreateRes> findGroupCreateRes(Long userId, Long matchId);
 
     List<DirectGetBaseRes> findDirectGroupsByDate(Long userId, LocalDate date);
 

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -14,7 +14,8 @@ public interface GroupRepositoryCustom {
     DirectCreateRes findDirectCreateResults(Long userId, Long matchId);
 
     Optional<GroupCreateRes> findGroupCreateRes(Long matchId);
-    List<DirectGetBaseRes> findDirectGroupsByDate(LocalDate date);
+
+    List<DirectGetBaseRes> findDirectGroupsByDate(Long userId, LocalDate date);
 
     List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -144,14 +144,20 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         int count = Optional.ofNullable(queryFactory
                 .select(groupMember.count().intValue())
                 .from(groupMember)
-                .where(groupMember.group.id.eq(matchId))
+                .where(
+                        groupMember.group.id.eq(matchId),
+                        groupMember.isParticipant.isTrue()
+                )
                 .fetchOne()).orElse(0);
 
         List<String> imgUrls = queryFactory
                 .select(member.imgUrl)
                 .from(groupMember)
                 .join(member).on(groupMember.user.eq(member))
-                .where(groupMember.group.id.eq(matchId))
+                .where(
+                        groupMember.group.id.eq(matchId),
+                        groupMember.isParticipant.isTrue()
+                )
                 .fetch();
 
         return Optional.of(GroupCreateRes.from(base, count, imgUrls));
@@ -184,7 +190,8 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                 .from(groupMember)
                                 .where(
                                         groupMember.group.id.eq(group.id),
-                                        groupMember.status.ne(1)
+                                        groupMember.status.ne(1),
+                                        groupMember.isParticipant.isTrue()
                                 )
                                 .notExists()
                 )

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -58,7 +58,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .join(game).on(group.gameInformation.eq(game))
                 .join(matchRequirement).on(matchRequirement.user.eq(user))
                 .where(
-                        user.id.eq(userId),
+                        group.leader.id.eq(userId),
                         group.id.eq(matchId),
                         group.isGroup.isFalse()
                 )

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -103,7 +103,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                 .from(groupMember)
                                 .where(
                                         groupMember.group.id.eq(group.id),
-                                        groupMember.status.in(2, 3, 4, 5, 6)
+                                        groupMember.status.ne(1)
                                 )
                                 .notExists()
 
@@ -113,7 +113,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
     }
 
     @Override
-    public Optional<GroupCreateRes> findGroupCreateRes(Long matchId) {
+    public Optional<GroupCreateRes> findGroupCreateRes(Long userId, Long matchId) {
         QGroup group = QGroup.group;
         QUser leader = user;
         QGameInformation gameInformation = QGameInformation.gameInformation;
@@ -132,7 +132,8 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .join(leader).on(group.leader.eq(leader))
                 .where(
                         group.id.eq(matchId),
-                        group.isGroup.isTrue()
+                        group.isGroup.isTrue(),
+                        group.leader.id.eq(userId)
                 )
                 .fetchOne();
 
@@ -161,6 +162,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         QGroup group = QGroup.group;
         QUser leader = user;
         QGameInformation game = QGameInformation.gameInformation;
+        QGroupMember groupMember = QGroupMember.groupMember;
 
         return queryFactory
                 .select(Projections.constructor(GroupGetBaseRes.class,
@@ -176,7 +178,15 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .join(game).on(group.gameInformation.eq(game))
                 .where(
                         group.isGroup.isTrue(),
-                        game.gameDate.eq(date)
+                        game.gameDate.eq(date),
+                        JPAExpressions
+                                .selectOne()
+                                .from(groupMember)
+                                .where(
+                                        groupMember.group.id.eq(group.id),
+                                        groupMember.status.ne(1)
+                                )
+                                .notExists()
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -66,7 +66,7 @@ public class GroupService {
     }
 
     public GroupCreateRes getGroupMatching(Long userId, Long matchId) {
-        return groupRepository.findGroupCreateRes(matchId)
+        return groupRepository.findGroupCreateRes(userId, matchId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
     }
 

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -48,7 +48,7 @@ public class GroupService {
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
         validate(date);
 
-        List<DirectGetBaseRes> result = groupRepository.findDirectGroupsByDate(date);
+        List<DirectGetBaseRes> result = groupRepository.findDirectGroupsByDate(userId, date);
 
         Map<Long, Integer> matchRateMap = matchRequirementService.getMatchings(userId).stream()
                 .collect(Collectors.toMap(

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 public record DetailMatchingBaseRes(
         Long id,
+        Long userId,
         String nickname,
         Integer birthYear,
         String gender,

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -21,5 +21,5 @@ public interface GroupMemberRepositoryCustom {
 
     List<GroupStatusBaseRes> findGroupMatchingsByUserAndStatus(Long userId, int groupStatus);
 
-    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long matchId);
+    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -203,7 +203,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
     }
 
     @Override
-    public List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long matchId) {
+    public List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId) {
         QGroupMember groupMember = QGroupMember.groupMember;
         QUser user = QUser.user;
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
@@ -232,7 +232,9 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
                 .where(
                         group.id.eq(matchId),
-                        groupMember.isParticipant.isTrue()
+                        groupMember.isParticipant.isTrue(),
+                        groupMember.status.eq(1),
+                        user.id.ne(userId)
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -213,6 +213,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom{
         return queryFactory
                 .select(Projections.constructor(DetailMatchingBaseRes.class,
                         group.id,
+                        user.id,
                         user.nickname,
                         user.birthYear,
                         user.gender,

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -57,7 +57,7 @@ public class GroupMemberService {
     }
 
     public DetailMatchingListRes getDetailMatching(Long userId, Long matchId) {
-        List<DetailMatchingBaseRes> baseResList = groupMemberRepository.findGroupMatesByMatchId(matchId);
+        List<DetailMatchingBaseRes> baseResList = groupMemberRepository.findGroupMatesByMatchId(userId, matchId);
 
         if (baseResList == null || baseResList.isEmpty()) {
             throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -71,7 +71,7 @@ public class GroupMemberService {
 
         List<DetailMatchingRes> result = baseResList.stream()
                 .map(base -> {
-                    Integer matchRate = matchRateMap.getOrDefault(base.id(), 0);
+                    Integer matchRate = matchRateMap.getOrDefault(base.userId(), 0);
                     return DetailMatchingRes.from(base, matchRate);
                 })
                 .toList();

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementRepositoryImpl.java
@@ -3,6 +3,7 @@ package at.mateball.domain.matchrequirement.core.repository.querydsl;
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
 import com.querydsl.core.types.Projections;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class MatchRequirementRepositoryImpl implements MatchRequirementRepositoryCustom {
+
     private final JPAQueryFactory queryFactory;
     private final EntityManager entityManager;
 
@@ -28,54 +30,68 @@ public class MatchRequirementRepositoryImpl implements MatchRequirementRepositor
         QUser userB = QUser.user;
 
         User user = entityManager.find(User.class, userId);
-        MatchRequirement reqAEntity = entityManager.createQuery(
+        MatchRequirement reqA = entityManager.createQuery(
                         "SELECT r FROM MatchRequirement r WHERE r.user.id = :id", MatchRequirement.class)
                 .setParameter("id", userId)
                 .getSingleResult();
 
         int birthYearA = user.getBirthYear();
-        int teamA = reqAEntity.getTeam();
-        int allowA = reqAEntity.getTeamAllowed();
-        int styleA = reqAEntity.getStyle();
-        int prefA = reqAEntity.getGenderPreference();
-        String genderA = user.getGender();
+        int teamA = reqA.getTeam();
+        int allowA = reqA.getTeamAllowed();
+        int styleA = reqA.getStyle();
+        int prefA = reqA.getGenderPreference();
+        int genderA = Gender.from(user.getGender()).getValue();
 
         int thisYear = LocalDateTime.now().getYear();
 
         return queryFactory.select(Projections.constructor(MatchingScoreDto.class,
                         userB.id,
+
                         Expressions.numberTemplate(Integer.class,
-                                "CASE WHEN {0} = 2 AND {1} = 2 THEN 40 " +
+                                "CASE " +
+                                        "WHEN {0} = 2 AND {1} = 2 THEN 40 " +
                                         "WHEN ({0} = 1 OR {1} = 1) AND {2} = {3} AND {2} != 11 THEN 40 " +
-                                        "WHEN ({2} = 11 OR {3} = 11) AND {0} = 2 AND {1} = 2 THEN 40 ELSE 0 END",
-                                Expressions.constant(allowA), requirementB.teamAllowed,
-                                Expressions.constant(teamA), requirementB.team),
+                                        "WHEN ({2} = 11 OR {3} = 11) AND {0} = 2 AND {1} = 2 THEN 40 " +
+                                        "ELSE 0 END",
+                                Expressions.constant(allowA),
+                                requirementB.teamAllowed,
+                                Expressions.constant(teamA),
+                                requirementB.team),
 
                         Expressions.numberTemplate(Integer.class,
-                                "CASE WHEN {0} = 3 AND {1} = 3 THEN 35 " +
-                                        "WHEN ({0} = 3 AND (({2} = 'M' AND {3} = 1) OR ({2} = 'F' AND {3} = 2))) THEN 35 " +
-                                        "WHEN ({1} = 3 AND (({4} = 'M' AND {5} = 1) OR ({4} = 'F' AND {5} = 2))) THEN 35 " +
-                                        "WHEN ({3} = 1 AND {2} = 'M' AND {5} = 2 AND {4} = 'F') THEN 35 " +
-                                        "WHEN ({3} = 2 AND {2} = 'F' AND {5} = 1 AND {4} = 'M') THEN 35 " +
-                                        "WHEN ({3} = 1 AND {2} = 'M' AND {5} = 1 AND {4} = 'M') THEN 35 " +
-                                        "WHEN ({3} = 2 AND {2} = 'F' AND {5} = 2 AND {4} = 'F') THEN 35 ELSE 0 END",
-                                Expressions.constant(prefA), requirementB.genderPreference,
-                                Expressions.constant(genderA), requirementB.genderPreference,
-                                userB.gender, Expressions.constant(prefA)),
+                                "CASE " +
+                                        "WHEN {0} = 3 AND {1} = 3 THEN 35 " +
+                                        "WHEN {0} = 3 AND {2} = {3} THEN 35 " +
+                                        "WHEN {1} = 3 AND {4} = {5} THEN 35 " +
+                                        "WHEN {0} = {4} AND {1} = {2} THEN 35 " +
+                                        "ELSE 0 END",
+                                Expressions.constant(prefA),
+                                requirementB.genderPreference,
+                                Expressions.constant(genderA),
+                                requirementB.genderPreference,
+                                Expressions.numberTemplate(Integer.class,
+                                        "CASE WHEN {0} = 'male' THEN 1 WHEN {0} = 'female' THEN 2 ELSE 3 END", userB.gender),
+                                Expressions.constant(prefA)
+                        ),
 
                         Expressions.numberTemplate(Integer.class,
-                                "CASE WHEN {0} = {1} THEN 25 " +
-                                        "WHEN ({0} = 1 AND {1} = 3) OR ({0} = 3 AND {1} = 1) THEN 20 ELSE 10 END",
-                                Expressions.constant(styleA), requirementB.style)
+                                "CASE " +
+                                        "WHEN {0} = {1} THEN 25 " +
+                                        "WHEN ({0} = 1 AND {1} = 3) OR ({0} = 3 AND {1} = 1) THEN 20 " +
+                                        "ELSE 10 END",
+                                Expressions.constant(styleA),
+                                requirementB.style)
+
                 ))
                 .from(requirementB)
                 .join(requirementB.user, userB)
-                .where(userB.id.ne(userId)
-                        .and(Expressions.numberTemplate(Integer.class,
+                .where(
+                        userB.id.ne(userId),
+                        Expressions.numberTemplate(Integer.class,
                                 "ABS(({0} - {1} + 1) - ({2} - {3} + 1))",
                                 Expressions.constant(thisYear), userB.birthYear,
                                 Expressions.constant(thisYear), Expressions.constant(birthYearA)
-                        ).loe(5))
+                        ).loe(5)
                 )
                 .fetch();
     }

--- a/src/test/java/at/mateball/match/MatchRequirementRepositoryTest.java
+++ b/src/test/java/at/mateball/match/MatchRequirementRepositoryTest.java
@@ -8,7 +8,7 @@ import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@DataJpaTest
 @ActiveProfiles("test")
 @Transactional
 @Slf4j
@@ -31,12 +31,12 @@ class MatchRequirementRepositoryTest {
     @Test
     void 매칭_점수_계산_정상작동_테스트() {
         // given
-        User userA = new User(12345L, "M", 1997);
+        User userA = new User(12345L, "male", 1997);
         entityManager.persist(userA);
         MatchRequirement reqA = new MatchRequirement(userA, 1, 1, 1, 3);
         entityManager.persist(reqA);
 
-        User userB = new User(67890L, "F", 1998);
+        User userB = new User(67890L, "female", 1998);
         entityManager.persist(userB);
         MatchRequirement reqB = new MatchRequirement(userB, 1, 1, 1, 3);
         entityManager.persist(reqB);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #71 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

-  요청대기중 상태의 사용자만 매칭화면에서 보여지도록 수정
- 매칭률 로직 수정


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 그룹 및 매칭 관련 조회 결과가 사용자별로 필터링되어 더욱 개인화된 정보를 제공합니다.
  * 상세 매칭 응답에 userId 필드가 추가되었습니다.

* **버그 수정**
  * 그룹 및 그룹원 조회 시 상태(status)와 참가 여부를 정확히 반영하도록 쿼리 조건이 개선되었습니다.

* **리팩터링**
  * 성별 관련 로직이 enum 기반으로 일관성 있게 개선되었습니다.

* **테스트**
  * 테스트 환경이 JPA 중심으로 최적화되었으며, 성별 값이 명확하게 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->