### PR TITLE
[feat] 경기 정보 조회 api에서 예외 처리 로직을 추가합니다

### DIFF
--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -2,11 +2,7 @@ package at.mateball.domain.gameinformation.core.service;
 
 import at.mateball.domain.gameinformation.api.dto.response.GameInformationRes;
 import at.mateball.domain.gameinformation.api.dto.response.GameInformationsRes;
-import at.mateball.domain.gameinformation.core.GameInformation;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
-import at.mateball.domain.user.core.User;
-import at.mateball.domain.user.core.repository.UserRepository;
-import at.mateball.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,16 +10,16 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 
-import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
+import static at.mateball.domain.group.core.validator.DateValidator.validate;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class GameInformationService {
-    private final UserRepository userRepository;
     private final GameInformationRepository gameInformationRepository;
 
     public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
+        validate(date);
 
         List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
                 .stream()

--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -24,7 +24,6 @@ public class GameInformationService {
     private final GameInformationRepository gameInformationRepository;
 
     public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
-//        findUser(userId);
 
         List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
                 .stream()
@@ -33,10 +32,4 @@ public class GameInformationService {
 
         return new GameInformationsRes(list);
     }
-
-//    TODO: 50번 커밋 병합된 이후 적용
-//    public User findUser(final Long userId) {
-//        return userRepository.findById(userId).orElseThrow(()
-//                -> new BusinessException(USER_NOT_FOUND));
-//    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #83 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- DateValidator 적용을 통해서, 경기날짜조회시 나타나는 예외 처리 로직을 수행했습니다

<br/>


### ❤️ To 다진 / To 헤음

---

- 따봉다진도치야 고마워


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 게임 정보 조회 시 사용자 존재 여부 확인 절차가 제거되었습니다. 이제 날짜만 검증하며, 사용자 관련 검증 및 예외 처리가 더 이상 수행되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->