### PR TITLE
[feat/#76] 그룹 멤버 상태 변환

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -81,4 +81,15 @@ public class GroupMemberController {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, detailMatchingListRes));
     }
+
+    @PatchMapping("/match-stage/{matchId}")
+    public ResponseEntity<MateballResponse<?>> updateStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @NotNull @PathVariable Long matchId
+    ) {
+        Long userId = userDetails.getUserId();
+        groupMemberService.updateStatus(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -48,4 +48,5 @@ public interface GroupMemberRepositoryCustom {
     List<GroupMemberBaseRes> getGroupMember(Long groupId);
 
     void updateAllGroupMemberStatus(Long groupId, Long requesterId);
+    boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -398,4 +398,18 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .where(groupMember.group.id.eq(groupId))
                 .execute();
     }
+
+    public boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId) {
+        long updatedCount = queryFactory
+                .update(groupMember)
+                .set(groupMember.status, GroupMemberStatus.PENDING_REQUEST.getValue())
+                .where(
+                        groupMember.group.id.eq(matchId),
+                        groupMember.user.id.eq(userId),
+                        groupMember.status.eq(GroupMemberStatus.APPROVED.getValue())
+                )
+                .execute();
+
+        return updatedCount > 0;
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -12,6 +12,7 @@ import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -110,5 +111,14 @@ public class GroupMemberService {
                 new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
 
         return groupMemberRepository.countGroupMember(matchId);
+    }
+
+    @Transactional
+    public void updateStatus(Long userId, Long matchId) {
+        boolean updated = groupMemberRepository.updateMyStatusFromApprovedToRequest(userId, matchId);
+
+        if (!updated) {
+            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
+        }
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #76

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---



<br/>


### ❤️ To 다진 / To 헤음

---

- 퇴근하고,,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 특정 매치에서 자신의 상태를 "승인됨"에서 "요청됨"으로 변경할 수 있는 PATCH 엔드포인트(`/v1/users/match-stage/{matchId}`)가 추가되었습니다.
* **버그 수정**
  * 상태 변경 시 매치가 존재하지 않으면 오류 메시지가 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->