### PR TITLE
[feat] 오늘 날짜 기준 지난 날짜 필터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	// Jakarta Persistence
 	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
+	// Scheduling
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 tasks.named('test') {

--- a/src/main/java/at/mateball/MateballApplication.java
+++ b/src/main/java/at/mateball/MateballApplication.java
@@ -2,8 +2,10 @@ package at.mateball;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MateballApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -18,4 +18,10 @@ public interface GroupRepositoryCustom {
     List<DirectGetBaseRes> findDirectGroupsByDate(Long userId, LocalDate date);
 
     List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date);
+
+    List<Long> findGroupIdsByGameDate(LocalDate date);
+
+    int bulkUpdateGroupStatusToFailed(List<Long> groupIds);
+
+    int bulkUpdateGroupMemberStatusToMatchFailed(List<Long> groupIds);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -6,8 +6,10 @@ import at.mateball.domain.group.api.dto.GroupCreateRes;
 import at.mateball.domain.group.api.dto.base.DirectCreateBaseRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
+import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.group.api.dto.DirectCreateRes;
+import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
@@ -196,5 +198,40 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                 .notExists()
                 )
                 .fetch();
+    }
+
+    @Override
+    public List<Long> findGroupIdsByGameDate(LocalDate targetDate) {
+        QGroup group = QGroup.group;
+        QGameInformation game = QGameInformation.gameInformation;
+
+        return queryFactory
+                .select(group.id)
+                .from(group)
+                .join(group.gameInformation, game).on(game.gameDate.eq(targetDate))
+                .fetch();
+    }
+
+    @Override
+    public int bulkUpdateGroupStatusToFailed(List<Long> groupIds) {
+        QGroup group = QGroup.group;
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        return (int) queryFactory
+                .update(group)
+                .set(groupMember.status, GroupMemberStatus.MATCH_FAILED.getValue())
+                .where(group.id.in(groupIds))
+                .execute();
+    }
+
+    @Override
+    public int bulkUpdateGroupMemberStatusToMatchFailed(List<Long> groupIds) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        return (int) queryFactory
+                .update(groupMember)
+                .set(groupMember.status, GroupMemberStatus.MATCH_FAILED.getValue())
+                .where(groupMember.group.id.in(groupIds))
+                .execute();
     }
 }

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
@@ -8,16 +8,16 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class GroupMatchFailScheduler {
-    private final GroupMatchFailScheduler groupMatchFailScheduler;
+    private final GroupMatchFailService groupMatchFailService;
 
-    public GroupMatchFailScheduler(GroupMatchFailScheduler groupMatchFailScheduler) {
-        this.groupMatchFailScheduler = groupMatchFailScheduler;
+    public GroupMatchFailScheduler(GroupMatchFailService groupMatchFailService) {
+        this.groupMatchFailService = groupMatchFailService;
     }
 
     @Scheduled(cron = "0 0 3 * * *")
     public void run() {
         try {
-            groupMatchFailScheduler.failExpiredGroups();
+            groupMatchFailService.failExpiredGroups();
         } catch (Exception exception) {
             log.error("그룹 매칭 실패 처리 중 예외 발생", exception);
         }

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
@@ -16,6 +16,8 @@ public class GroupMatchFailScheduler {
 
     @Scheduled(cron = "0 0 3 * * *")
     public void run() {
+        log.info("스케줄러 호출 완료");
+
         try {
             groupMatchFailService.failExpiredGroups();
         } catch (Exception exception) {

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class GroupMatchFailScheduler {
     private final GroupMatchFailScheduler groupMatchFailScheduler;
+
+    public GroupMatchFailScheduler(GroupMatchFailScheduler groupMatchFailScheduler) {
+        this.groupMatchFailScheduler = groupMatchFailScheduler;
+    }
 
     @Scheduled(cron = "0 0 3 * * *")
     public void run() {

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailScheduler.java
@@ -1,0 +1,22 @@
+package at.mateball.domain.group.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GroupMatchFailScheduler {
+    private final GroupMatchFailScheduler groupMatchFailScheduler;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void run() {
+        try {
+            groupMatchFailScheduler.failExpiredGroups();
+        } catch (Exception exception) {
+            log.error("그룹 매칭 실패 처리 중 예외 발생", exception);
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
@@ -1,7 +1,45 @@
 package at.mateball.domain.group.scheduler;
 
+import at.mateball.domain.group.core.repository.GroupRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
+@Slf4j
 public class GroupMatchFailService {
+    private final GroupRepository groupRepository;
+
+    public GroupMatchFailService(GroupRepository groupRepository) {
+        this.groupRepository = groupRepository;
+    }
+
+    @Transactional
+    public void failExpiredGroups() {
+        LocalDate date = calculateTargetDate(LocalDate.now());
+
+        List<Long> matchId = groupRepository.findGroupIdsByGameDate(date);
+
+        if (matchId.isEmpty()) {
+            log.info("처리 대상 그룹 없음 - 기준일 : {}", date);
+            return;
+        }
+
+        int groupCnt = groupRepository.bulkUpdateGroupStatusToFailed(matchId);
+        int memberCnt = groupRepository.bulkUpdateGroupMemberStatusToMatchFailed(matchId);
+        log.info("해당 날짜: {}, 그룹 실패 처리 {}건, 멤버 실패 처리 {}건", matchId, groupCnt, memberCnt);
+    }
+
+    private LocalDate calculateTargetDate(LocalDate today) {
+        DayOfWeek day = today.getDayOfWeek();
+        if (day == DayOfWeek.SATURDAY) {
+            return today.plusDays(3);
+        }
+
+        return today.plusDays(2);
+    }
 }

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.group.scheduler;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class GroupMatchFailService {
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
@@ -21,8 +21,10 @@ public class GroupMatchFailService {
     @Transactional
     public void failExpiredGroups() {
         LocalDate date = calculateTargetDate(LocalDate.now());
+        log.info("[스케줄러 테스트] 기준 날짜 = {}", date);
 
         List<Long> matchId = groupRepository.findGroupIdsByGameDate(date);
+        log.info("[스케줄러 테스트] 해당 날짜 그룹 수 = {}", matchId.size());
 
         if (matchId.isEmpty()) {
             log.info("처리 대상 그룹 없음 - 기준일 : {}", date);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #86 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---
1. 스케줄러 실행
- @Scheduled(cron = "0 0 3 * * *") 설정으로 매일 03:00에 자동 실행
- 로컬 개발 중에는 */30 * * * * * 등으로 테스트 가능하도록 설정

2. 기준일 계산
- LocalDate.now().plusDays(2) 기본
- 토요일인 경우 plusDays(3) 처리로 월요일 포함

3. QueryDSL로 groupId 추출
- GameInformation.date = 기준일 조건으로 게임 조회

4. 상태 일괄 변경 (Bulk Update)


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 만료된 그룹 매치 상태를 자동으로 처리하는 스케줄러가 추가되었습니다. 매일 오전 3시에 만료된 그룹 및 그룹 멤버의 상태가 자동으로 실패로 변경됩니다.
* **기타**
  * 스케줄링 기능이 활성화되어, 그룹 매치 만료 처리가 자동으로 실행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->