### PR TITLE
[feat] 사용자 정보 반환

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -67,7 +67,7 @@ public class UserController {
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }
 
-    @PostMapping("/v1/users/info")
+    @PostMapping("/info")
     public ResponseEntity<MateballResponse<?>> createUserInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody UserInfoReq userInfoReq
@@ -75,6 +75,6 @@ public class UserController {
         Long userId = customUserDetails.getUserId();
         userService.createUserInfo(userId, userInfoReq.gender(), userInfoReq.birthYear());
 
-        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.OK));
+        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.CREATED));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -5,6 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.user.api.dto.request.NicknameReq;
+import at.mateball.domain.user.api.dto.request.UserInfoReq;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.service.UserService;
@@ -63,5 +64,16 @@ public class UserController {
         UserInformationRes data = userService.getUserInformation(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
+    }
+
+    @PostMapping("/v1/users/info")
+    public ResponseEntity<MateballResponse<?>> createUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody UserInfoReq userInfoReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userService.createUserInfo(userId, userInfoReq);
+
+        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.OK));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -11,6 +11,7 @@ import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.service.UserService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -69,10 +70,10 @@ public class UserController {
     @PostMapping("/v1/users/info")
     public ResponseEntity<MateballResponse<?>> createUserInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @RequestBody UserInfoReq userInfoReq
+            @Valid @RequestBody UserInfoReq userInfoReq
     ) {
         Long userId = customUserDetails.getUserId();
-        userService.createUserInfo(userId, userInfoReq);
+        userService.createUserInfo(userId, userInfoReq.gender(), userInfoReq.birthYear());
 
         return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.OK));
     }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
@@ -1,7 +1,15 @@
 package at.mateball.domain.user.api.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 public record UserInfoReq(
+        @NotBlank(message = "성별은 필수 입력해야합니다.")
         String gender,
+
+        @Min(value = 1900, message = "유효하지 않은 출생년도입니다.")
+        @Max(value = 2025, message = "지금 태어났을리 없습니다. 미래의 출생년도는 입력할 수 없어요.")
         int birthYear
 ) {
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
@@ -1,10 +1,13 @@
 package at.mateball.domain.user.api.dto.request;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
 public record UserInfoReq(
+        @Enumerated(EnumType.STRING)
         @NotBlank(message = "성별은 필수 입력해야합니다.")
         String gender,
 

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoReq.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.user.api.dto.request;
+
+public record UserInfoReq(
+        String gender,
+        int birthYear
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.user.core;
 
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -65,5 +66,10 @@ public class User {
 
     public void updateImgUrl(final String imgUrl) {
         this.imgUrl = imgUrl;
+    }
+
+    public void updateGenderAndBirthYear(Gender gender, int birthYear) {
+        this.gender = gender.getRaw();
+        this.birthYear = birthYear;
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.user.api.dto.request.UserInfoReq;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
@@ -59,5 +60,11 @@ public class UserService {
     public User findUser(final Long userId) {
         return userRepository.getUser(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
+    }
+
+
+    @Transactional
+    public void createUserInfo(Long userId, String gender, int birthYear) {
+
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -7,6 +7,7 @@ import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -65,6 +66,10 @@ public class UserService {
 
     @Transactional
     public void createUserInfo(Long userId, String gender, int birthYear) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
+        Gender genderStatus = Gender.fromLabel(gender);
+        user.updateGenderAndBirthYear(genderStatus, birthYear);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static at.mateball.exception.code.BusinessErrorCode.*;
@@ -69,6 +70,12 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
+        int currentYear = LocalDate.now().getYear();
+        int age = currentYear - birthYear;
+
+        if (age < 19) {
+            throw new BusinessException(AGE_NOT_APPROPRIATE);
+        }
         Gender genderStatus = Gender.fromLabel(gender);
         user.updateGenderAndBirthYear(genderStatus, birthYear);
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #89 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사용자의 나이가 만 19세 이상인 경우에만 가입가능하도록 처리
- 나이와 성별 받도록 처리완료
- `@Enumerated(EnumType.STRING)`로 enum으로 받을 수 있도록 하였습니다.

<br/>


### ❤️ To 다진 / To 헤음

---

- 이거 기존 로그인 로직이랑 다 합치고 테스트해봐야해잉!! 왜냐면 여기서 수정하면 충돌이 겁나 날거같아요오ㅠㅜ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 성별과 출생연도를 입력하여 정보를 등록할 수 있는 새로운 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 없음

* **기타**
  * 사용자 정보 입력 시 유효성 검사가 강화되었습니다.
  * 입력한 출생연도를 기반으로 연령 제한(19세 이상)이 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->