### PR TITLE
[feat] 매칭 생성 api 구현

### DIFF
--- a/src/main/java/at/mateball/domain/gameinformation/api/dto/response/base/GroupMemberBaseRes.java
+++ b/src/main/java/at/mateball/domain/gameinformation/api/dto/response/base/GroupMemberBaseRes.java
@@ -1,0 +1,10 @@
+package at.mateball.domain.gameinformation.api.dto.response.base;
+
+import java.time.LocalDate;
+
+public record GroupMemberBaseRes(
+    LocalDate gameDate,
+    Long totalMatches,
+    boolean hasMatchOnSameDate
+) {
+}

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
@@ -1,7 +1,6 @@
 package at.mateball.domain.gameinformation.core.repository;
 
 import at.mateball.domain.gameinformation.core.GameInformation;
-import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -11,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface GameInformationRepositoryCustom {
     List<GameInformation> findByGameDate(LocalDate gameDate);
+
+    Optional<LocalDate> findGameDateById(Long gameId);
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
@@ -6,10 +6,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public class GameInformationRepositoryImpl implements GameInformationRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    QGameInformation game = QGameInformation.gameInformation;
 
     public GameInformationRepositoryImpl(JPAQueryFactory queryFactory) {
         this.queryFactory = queryFactory;
@@ -23,5 +25,14 @@ public class GameInformationRepositoryImpl implements GameInformationRepositoryC
                 .selectFrom(gameInformation)
                 .where(gameInformation.gameDate.eq(gameDate))
                 .fetch();
+    }
+
+    @Override
+    public Optional<LocalDate> findGameDateById(Long gameId) {
+        return Optional.ofNullable(queryFactory
+                .select(game.gameDate)
+                .from(game)
+                .where(game.id.eq(gameId))
+                .fetchFirst());
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -4,10 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
-import at.mateball.domain.group.api.dto.DirectCreateRes;
-import at.mateball.domain.group.api.dto.DirectGetListRes;
-import at.mateball.domain.group.api.dto.GroupCreateRes;
-import at.mateball.domain.group.api.dto.GroupGetListRes;
+import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.core.service.GroupService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -111,5 +108,18 @@ public class GroupController {
         groupService.rejectRequest(userId, matchId);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
+    }
+
+
+    @PostMapping("/match")
+    public ResponseEntity<MateballResponse<?>> createMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @RequestBody CreateMatchReq createMatchReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        CreateMatchRes createMatchRes = groupService.createMatch(userId, createMatchReq.gameId(), createMatchReq.matchType());
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, createMatchRes));
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupController.java
@@ -8,6 +8,7 @@ import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.core.service.GroupService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -114,7 +115,7 @@ public class GroupController {
     @PostMapping("/match")
     public ResponseEntity<MateballResponse<?>> createMatch(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @NotNull @RequestBody CreateMatchReq createMatchReq
+            @Valid @RequestBody CreateMatchReq createMatchReq
     ) {
         Long userId = customUserDetails.getUserId();
 

--- a/src/main/java/at/mateball/domain/group/api/dto/CreateMatchReq.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/CreateMatchReq.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.group.api.dto;
+
+public record CreateMatchReq(
+        Long gameId,
+        String matchType
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/CreateMatchReq.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/CreateMatchReq.java
@@ -1,7 +1,11 @@
 package at.mateball.domain.group.api.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record CreateMatchReq(
+        @NotNull
         Long gameId,
+        @NotNull
         String matchType
 ) {
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/CreateMatchRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/CreateMatchRes.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.group.api.dto;
+
+public record CreateMatchRes(
+        Long matchId
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/base/MatchingBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/MatchingBaseRes.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.group.api.dto.base;
 
 public record MatchingBaseRes(
-        long totalMatches,
+        Long totalMatches,
         boolean hasMatchOnDate
 ) {
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/base/MatchingBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/MatchingBaseRes.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.group.api.dto.base;
+
+public record MatchingBaseRes(
+        long totalMatches,
+        boolean hasMatchOnDate
+) {
+}

--- a/src/main/java/at/mateball/domain/group/core/MatchType.java
+++ b/src/main/java/at/mateball/domain/group/core/MatchType.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.group.core;
+
+public enum MatchType {
+    GROUP,
+    DIRECT;
+}

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -11,7 +11,10 @@ import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.group.core.validator.GroupValidator;
 import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
-import at.mateball.domain.groupmember.api.dto.base.*;
+import at.mateball.domain.groupmember.api.dto.base.DirectMatchBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.GroupMatchBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.PermitRequestBaseRes;
+import at.mateball.domain.groupmember.api.dto.base.RejectGroupMemberBaseRes;
 import at.mateball.domain.groupmember.core.GroupMember;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
@@ -30,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static at.mateball.domain.group.core.MatchType.DIRECT;
+import static at.mateball.domain.group.core.MatchType.GROUP;
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
 
 @Service
@@ -41,8 +46,6 @@ public class GroupService {
     private final static int DIRECT_LIMIT = 3;
     private final static int GROUP_LIMIT = 2;
     private final static int TOTAL_GROUP_MEMBER = 4;
-    private final static String GROUP = "GROUP";
-    private final static String DIRECT = "DIRECT";
 
     private final EntityManager entityManager;
 
@@ -283,9 +286,9 @@ public class GroupService {
     public CreateMatchRes createMatch(Long userId, Long gameId, String matchType) {
         validateMatchType(matchType);
 
-        boolean isGroup = matchType.equalsIgnoreCase(GROUP);
+        boolean isGroup = matchType.equalsIgnoreCase(String.valueOf(GROUP));
 
-       GroupMemberRes info = groupMemberRepository.getMatchingInfo(userId, gameId, isGroup)
+        GroupMemberRes info = groupMemberRepository.getMatchingInfo(userId, gameId, isGroup)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GAME_NOT_FOUND));
 
         if (LocalDate.now().isAfter(info.gameDate())) {
@@ -311,7 +314,7 @@ public class GroupService {
     }
 
     private void validateMatchType(String matchType) {
-        if (!GROUP.equalsIgnoreCase(matchType) && !DIRECT.equalsIgnoreCase(matchType)) {
+        if (!String.valueOf(GROUP).equalsIgnoreCase(matchType) && !String.valueOf(DIRECT).equalsIgnoreCase(matchType)) {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MATCH_TYPE);
         }
     }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -40,6 +40,8 @@ public class GroupService {
     private final static int DIRECT_LIMIT = 3;
     private final static int GROUP_LIMIT = 2;
     private final static int TOTAL_GROUP_MEMBER = 4;
+    private final static String GROUP = "GROUP";
+    private final static String DIRECT = "DIRECT";
 
     private final EntityManager entityManager;
 
@@ -281,7 +283,7 @@ public class GroupService {
     public CreateMatchRes createMatch(Long userId, Long gameId, String matchType) {
         validateMatchType(matchType);
 
-        boolean isGroup = matchType.equalsIgnoreCase("GROUP");
+        boolean isGroup = matchType.equalsIgnoreCase(GROUP);
 
        GroupMemberBaseRes info = groupMemberRepository.getMatchingInfo(userId, gameId, isGroup)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GAME_NOT_FOUND));
@@ -309,7 +311,7 @@ public class GroupService {
     }
 
     private void validateMatchType(String matchType) {
-        if (!"GROUP".equalsIgnoreCase(matchType) && !"DIRECT".equalsIgnoreCase(matchType)) {
+        if (!GROUP.equalsIgnoreCase(matchType) && !DIRECT.equalsIgnoreCase(matchType)) {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MATCH_TYPE);
         }
     }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMemberRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMemberRes.java
@@ -1,8 +1,8 @@
-package at.mateball.domain.groupmember.api.dto.base;
+package at.mateball.domain.groupmember.api.dto;
 
 import java.time.LocalDate;
 
-public record GroupMemberBaseRes(
+public record GroupMemberRes(
         LocalDate gameDate,
         Long totalMatches,
         boolean hasMatchOnSameDate

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupMemberBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupMemberBaseRes.java
@@ -1,6 +1,10 @@
 package at.mateball.domain.groupmember.api.dto.base;
 
+import java.time.LocalDate;
+
 public record GroupMemberBaseRes(
-    Long userId,
-    int status
-) {}
+        LocalDate gameDate,
+        Long totalMatches,
+        boolean hasMatchOnSameDate
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/RejectGroupMemberBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/RejectGroupMemberBaseRes.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+public record RejectGroupMemberBaseRes(
+        Long userId,
+        int status
+) {
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -12,6 +12,7 @@ import at.mateball.domain.groupmember.api.dto.base.PermitRequestBaseRes;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface GroupMemberRepositoryCustom {
     Map<Long, Integer> findGroupMemberCountMap(List<Long> groupIds);
@@ -54,9 +55,11 @@ public interface GroupMemberRepositoryCustom {
 
     List<GroupMatchBaseRes> findAllGroupMemberInfo(Long groupId);
 
-    List<GroupMemberBaseRes> getGroupMember(Long groupId);
+    List<RejectGroupMemberBaseRes> getGroupMember(Long groupId);
 
     void updateAllGroupMemberStatus(Long groupId, Long requesterId);
 
     boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId);
+
+    Optional<GroupMemberBaseRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -5,7 +5,7 @@ import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.base.*;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
-import at.mateball.domain.groupmember.api.dto.base.GroupMemberBaseRes;
+import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.base.PermitRequestBaseRes;
 
@@ -61,5 +61,5 @@ public interface GroupMemberRepositoryCustom {
 
     boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId);
 
-    Optional<GroupMemberBaseRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
+    Optional<GroupMemberRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -478,7 +478,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
         Tuple tuple = queryFactory
                 .select(
-                        groupMember.count(),
+                        groupMember.countDistinct(),
                         JPAExpressions.selectOne()
                                 .from(groupMember)
                                 .join(groupMember.group, group)
@@ -498,7 +498,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 )
                 .fetchOne();
 
-        Long totalMatches = tuple != null ? tuple.get(groupMember.count()) : 0L;
+        Long totalMatches = tuple != null ? tuple.get(groupMember.countDistinct()) : 0L;
         boolean hasMatchOnSameDate = tuple != null && Boolean.TRUE.equals(tuple.get(1, Boolean.class));
 
         return Optional.of(new GroupMemberBaseRes(gameDate, totalMatches, hasMatchOnSameDate));

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -17,11 +17,13 @@ public enum BusinessErrorCode implements ErrorCode {
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "그룹 매칭은 최대 2개까지만 가능합니다."),
     EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "1대1 매칭은 최대 3개까지만 가능합니다."),
     ALREADY_HAS_PENDING_REQUEST(HttpStatus.BAD_REQUEST, "이미 요청이 존재하는 매칭입니다."),
-    DUPLICATE_REQUEST_ON_SAME_DATE(HttpStatus.BAD_REQUEST, "같은 날짜의 경기에는 하나의 매칭 요청만 생성할 수 있습니다."),
+    DUPLICATE_MATCHING_ON_SAME_DATE(HttpStatus.BAD_REQUEST, "같은 날짜의 경기에는 하나의 매칭만 참여할 수 있습니다."),
     ALREADY_COMPLETED_GROUP(HttpStatus.BAD_REQUEST, "이미 매칭이 완료된 그룹입니다."),
     INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 2자 이상 6자 이하로 입력해야 합니다."),
     NICKNAME_CONTAINS_WHITESPACE(HttpStatus.BAD_REQUEST, "닉네임에 공백이 포함될 수 없습니다."),
     INVALID_NICKNAME_CHARACTER(HttpStatus.BAD_REQUEST, "닉네임은 한글 또는 영어만 사용할 수 있으며, 특수문자는 사용할 수 없습니다."),
+    BAD_REQUEST_MATCH_TYPE(HttpStatus.BAD_REQUEST, "요청 matchType이 잘못되었습니다."),
+    BAD_REQUEST_MATCHING_DATE(HttpStatus.BAD_REQUEST, "매칭생성은 경기 2일 전부터 가능합니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
@@ -40,6 +42,7 @@ public enum BusinessErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),
     REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 요청자입니다."),
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 경기입니다."),
 
     // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #91 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭 생성 api를 구현했습니다
- 예외상황
   - 게임이 존재하지 않음
   - 최대 개수를 초과함(그룹2+일대일3)
   - 과거 경기에 대한 요청
   - 2일보다 전날짜에 대한 요청
   - 같은 날짜에 다른 매칭이 있는 경우
- 데이터를 조회할때 BaseDto 를 통해 한 번에 받아오고, service안에서 각 예외상황을 판단하는 로직으로 설정했습니다
- getRefernce / persist 를 사용해서 테이블을 생성했습니다 


<br/>


### ❤️ To 다진 / To 헤음

---

- 마지막 api 구현 PR 이겠군요,,,,,,,,,,,,, 고생하셧읍니다,,, (아직 해야할게 남긴했지만,,,)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 그룹 매칭 생성 기능이 추가되어 인증된 사용자가 매칭을 생성할 수 있습니다.
  * 매칭 생성 요청 및 응답 데이터 구조가 도입되었습니다.
  * 사용자별 매칭 정보(총 매칭 횟수, 동일 날짜 매칭 여부 등) 조회 기능이 추가되었습니다.
  * 게임 날짜 조회 기능이 추가되었습니다.

* **버그 수정**
  * 동일 날짜 중복 매칭 관련 오류 코드 및 메시지가 개선되었습니다.

* **기타**
  * 매칭 타입(GROUP, DIRECT) 및 날짜 유효성 검사 관련 오류 코드가 추가되었습니다.
  * 그룹 멤버 및 매칭 관련 데이터 응답 구조가 변경 및 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->