### PR TITLE
[fix] 매칭률 수정

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -62,4 +62,6 @@ public interface GroupMemberRepositoryCustom {
     boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId);
 
     Optional<GroupMemberRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
+    Map<Long, List<Long>> findUserIdsGroupedByGroupIds(List<Long> groupIds);
+
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #109

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 로그인 유저 기준으로 그룹 내 실제 멤버들과의 평균 매칭률로 반환하게 수정
- getGroups()는 데이터 흐름에만 집중
- 평균 매칭률 계산은 별도 책임 함수로 분리


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 각 그룹의 평균 매칭률이 보다 정확하게 계산되어 표시됩니다.

* **버그 수정**
  * 그룹별 매칭률 계산 오류가 수정되어, 멤버별 매칭 점수의 평균을 기반으로 그룹 평균 매칭률이 산출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->