### PR TITLE
[feat] 사용자 상태 반환

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserController.java
@@ -6,6 +6,7 @@ import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.user.api.dto.request.NicknameReq;
 import at.mateball.domain.user.api.dto.request.UserInfoReq;
+import at.mateball.domain.user.api.dto.response.CheckUserRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.core.service.UserService;
@@ -79,5 +80,15 @@ public class UserController {
         userService.createUserInfo(userId, userInfoReq.gender(), userInfoReq.birthYear());
 
         return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
+
+    @GetMapping("/info-check")
+    public ResponseEntity<MateballResponse<?>> getCheckUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        CheckUserRes checkUserRes = userService.getCheckUserInfo(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, checkUserRes));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/CheckUserRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/CheckUserRes.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record CheckUserRes(
+        boolean nickname,
+        boolean condition
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.user.core.repository;
 
+import at.mateball.domain.user.api.dto.response.CheckUserRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface UserRepositoryCustom {
     boolean existsByNickname(String nickname);
 
     Optional<User> getUser(final Long userId);
+
+    CheckUserRes fetchUserInfoCheck(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -3,6 +3,7 @@ package at.mateball.domain.user.core.service;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.user.api.dto.response.CheckUserRes;
 import at.mateball.domain.user.api.dto.response.KaKaoInformationRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
@@ -90,5 +91,9 @@ public class UserService {
         user.updateProfileImage("https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg");
         user.updateIntroduction("메잇볼이 선택한 너");
         user.updateGenderAndBirthYear(genderStatus, birthYear);
+    }
+
+    public CheckUserRes getCheckUserInfo(Long userId) {
+        return userRepository.fetchUserInfoCheck((userId));
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #110 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사용자 정보를 분석하여 nickname이 존재할때와 안할때, condition이 존재할때 안할때의 사용자 정보를 반환합니다.\
- leftJoin으로 1개의 쿼리에서 모든 조건 확인

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 닉네임 및 조건 입력 여부를 확인할 수 있는 `/v1/users/info-check` GET 엔드포인트가 추가되었습니다.  
  * 해당 엔드포인트를 통해 닉네임과 필수 조건 입력 여부를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->