### PR TITLE
[fix] 플로우 수정

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -260,9 +260,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
                 .where(
                         group.id.eq(matchId),
-                        groupMember.isParticipant.isTrue(),
-                        groupMember.status.eq(1),
-                        user.id.ne(userId)
+                        groupMember.status.notIn(1, 6)
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -74,6 +74,7 @@ public class GroupMemberService {
                 ));
 
         List<DetailMatchingRes> result = baseResList.stream()
+                .filter(base -> !base.userId().equals(userId))
                 .map(base -> {
                     Integer matchRate = matchRateMap.getOrDefault(base.userId(), 0);
                     return DetailMatchingRes.from(base, matchRate);


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #113 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 내가 생성한 그룹의 경우 내의 상세정보는 보이지 않도록 수정
```
.filter(base -> !base.userId().equals(userId))
```

- 요청 대기중일 시 매칭 상세 정보 반환하지 않음


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매칭 상세 정보 조회 시, 현재 사용자가 결과 목록에서 제외되도록 수정되었습니다.
  * 그룹 멤버 조회 시, 특정 상태(1, 6)를 가진 멤버만 제외하고, 참가자 여부와 사용자 제외 조건이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->