### PR TITLE
[fix] 다른 사용자가 대기 중일때, 예외 처리

### DIFF
--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryCustom.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 @Repository
 public interface GameInformationRepositoryCustom {
     List<GameInformation> findByGameDate(LocalDate gameDate);
-
-    Optional<LocalDate> findGameDateById(Long gameId);
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepositoryImpl.java
@@ -26,13 +26,4 @@ public class GameInformationRepositoryImpl implements GameInformationRepositoryC
                 .where(gameInformation.gameDate.eq(gameDate))
                 .fetch();
     }
-
-    @Override
-    public Optional<LocalDate> findGameDateById(Long gameId) {
-        return Optional.ofNullable(queryFactory
-                .select(game.gameDate)
-                .from(game)
-                .where(game.id.eq(gameId))
-                .fetchFirst());
-    }
 }

--- a/src/main/java/at/mateball/domain/group/core/GroupStatus.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupStatus.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 @Getter
 public enum GroupStatus {
-    PENDING(1, "대기중"),
+    PENDING(1, "대기 중"),
     COMPLETED(2, "완료"),
     FAILED(3, "실패");
 

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -134,13 +134,14 @@ public class GroupService {
 
         if (groupInformationRes.stream().anyMatch(dto ->
                 dto.groupId().equals(group.getId()) &&
-                        dto.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue()
+                        dto.groupStatus() == GroupStatus.PENDING.getValue()
         )) {
             throw new BusinessException(BusinessErrorCode.DUPLICATED_REQUEST);
         }
 
         if (groupInformationRes.stream().anyMatch(dto ->
                 dto.status() != GroupMemberStatus.MATCH_FAILED.getValue()
+                        && dto.gameDate().equals(gameDate)
         )) {
             throw new BusinessException(BusinessErrorCode.DUPLICATE_MATCHING_ON_SAME_DATE);
         }
@@ -157,7 +158,7 @@ public class GroupService {
         }
 
         if (groupMemberRepository.findAllGroupMemberInfo(group.getId()).stream()
-                .anyMatch(m -> m.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue())) {
+                .anyMatch(m -> m.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue() || m.status() == GroupMemberStatus.NEW_REQUEST.getValue())) {
             throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
         }
     }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -140,13 +140,6 @@ public class GroupService {
         }
 
         if (groupInformationRes.stream().anyMatch(dto ->
-                dto.groupId().equals(group.getId()) &&
-                        dto.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue()
-        )) {
-            throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
-        }
-
-        if (groupInformationRes.stream().anyMatch(dto ->
                 dto.status() != GroupMemberStatus.MATCH_FAILED.getValue()
         )) {
             throw new BusinessException(BusinessErrorCode.DUPLICATE_MATCHING_ON_SAME_DATE);
@@ -161,6 +154,11 @@ public class GroupService {
                     isGroup ? BusinessErrorCode.EXCEED_GROUP_MATCHING_LIMIT
                             : BusinessErrorCode.EXCEED_DIRECT_MATCHING_LIMIT
             );
+        }
+
+        if (groupMemberRepository.findAllGroupMemberInfo(group.getId()).stream()
+                .anyMatch(m -> m.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue())) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
         }
     }
 

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -140,7 +140,7 @@ public class GroupService {
         }
 
         if (groupInformationRes.stream().anyMatch(dto ->
-                !dto.groupId().equals(group.getId()) &&
+                dto.groupId().equals(group.getId()) &&
                         dto.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue()
         )) {
             throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -42,8 +42,8 @@ public class GroupService {
 
     private final GroupExecutor groupExecutor;
 
-    private final static int DIRECT_LIMIT = 3;
-    private final static int GROUP_LIMIT = 2;
+    private final static int MAX_DIRECT_COUNT = 3;
+    private final static int MAX_GROUP_COUNT = 2;
     private final static int TOTAL_GROUP_MEMBER = 4;
 
     public GroupService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, GroupExecutor groupExecutor) {
@@ -148,7 +148,7 @@ public class GroupService {
         long pendingRequestCount = groupInformationRes.stream()
                 .filter(dto -> dto.isGroup() == isGroup && dto.groupStatus() == GroupStatus.PENDING.getValue())
                 .count();
-        int requestLimit = isGroup ? GROUP_LIMIT : DIRECT_LIMIT;
+        int requestLimit = isGroup ? MAX_GROUP_COUNT : MAX_DIRECT_COUNT;
         if (pendingRequestCount >= requestLimit) {
             throw new BusinessException(
                     isGroup ? BusinessErrorCode.EXCEED_GROUP_MATCHING_LIMIT
@@ -330,7 +330,7 @@ public class GroupService {
             throw new BusinessException(BusinessErrorCode.DUPLICATE_MATCHING_ON_SAME_DATE);
         }
 
-        if (isGroup ? info.totalMatches() >= GROUP_LIMIT : info.totalMatches() >= DIRECT_LIMIT) {
+        if (isGroup ? info.totalMatches() >= MAX_GROUP_COUNT : info.totalMatches() >= MAX_DIRECT_COUNT) {
             throw new BusinessException(
                     isGroup ? BusinessErrorCode.EXCEED_GROUP_MATCHING_LIMIT
                             : BusinessErrorCode.EXCEED_DIRECT_MATCHING_LIMIT

--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @Getter
 public enum GroupMemberStatus {
     PENDING_REQUEST(1, "요청 대기 중"),
-    NEW_REQUEST(2, "새요청"),
+    NEW_REQUEST(2, "새 요청"),
     AWAITING_APPROVAL(3, "승인 대기 중"),
     APPROVED(4, "승인 완료"),
     MATCHED(5, "매칭 완료"),

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -387,8 +387,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(groupMember.group, group)
                 .join(group.gameInformation, gameInfo)
                 .where(
-                        groupMember.user.id.eq(userId),
-                        gameInfo.gameDate.eq(date)
+                        groupMember.user.id.eq(userId)
                 )
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 
 @Getter
 public enum Style {
-    PASSIONATE_SUPPORTER(1, "열정 응원러"),
-    FOCUSED_VIEWER(2, "경기 집중러"),
-    FOODIE_VIEWER(3, "직관 먹방러");
+    PASSIONATE_SUPPORTER(1, "열정응원러"),
+    FOCUSED_VIEWER(2, "경기집중러"),
+    FOODIE_VIEWER(3, "직관먹방러");
 
     private final int value;
     private final String label;

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -42,7 +42,7 @@ public enum BusinessErrorCode implements ErrorCode {
     GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 매칭입니다."),
     REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 요청자입니다."),
     GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 경기입니다."),
-    MATCH_REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭정보가 존재하지 않습니다."),
+    MATCH_REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭 조건 정보가 존재하지 않습니다."),
 
     // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #116 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭 요청 관련한 예외처리를 수정했습니다...
- 사용하지 않는 코드를 삭제했습니다
- 더 직관적인 네이밍의 상수로 변경했습니다


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 동일 그룹에 대해 승인 대기 중인 요청이 있을 때만 중복 요청 오류가 발생하도록 로직이 수정되었습니다.
  * 게임 정보 관련 기능에서 특정 게임 ID로 게임 날짜를 조회하는 기능이 제거되었습니다.
* **UI/문구 개선**
  * 그룹 상태 및 멤버 상태의 일부 라벨에 띄어쓰기가 추가되어 가독성이 향상되었습니다.
  * 스타일 관련 라벨의 띄어쓰기가 제거되어 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->