### PR TITLE
[feat] API 누락 부분 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/GroupGetBaseRes.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public record GroupGetBaseRes(
         Long id,
+        Integer birthYear,
         String nickname,
         String awayTeam,
         String homeTeam,

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -16,7 +16,7 @@ public interface GroupRepositoryCustom {
 
     List<DirectGetBaseRes> findDirectGroupsByDate(Long userId, LocalDate date);
 
-    List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date);
+    List<GroupGetBaseRes> findGroupsWithBaseInfo(Long userId, LocalDate date);
 
     void updateGroupStatus(Long groupId, int status);
 

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -162,7 +162,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
     }
 
     @Override
-    public List<GroupGetBaseRes> findGroupsWithBaseInfo(LocalDate date) {
+    public List<GroupGetBaseRes> findGroupsWithBaseInfo(Long userId, LocalDate date) {
         QGroup group = QGroup.group;
         QUser leader = user;
         QGameInformation game = QGameInformation.gameInformation;
@@ -182,6 +182,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .join(game).on(group.gameInformation.eq(game))
                 .where(
                         group.isGroup.isTrue(),
+                        group.leader.id.ne(userId),
                         game.gameDate.eq(date),
                         JPAExpressions
                                 .selectOne()

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -167,7 +167,7 @@ public class GroupService {
     public GroupGetListRes getGroups(Long userId, LocalDate date) {
         validate(date);
 
-        List<GroupGetBaseRes> groupBases = groupRepository.findGroupsWithBaseInfo(date);
+        List<GroupGetBaseRes> groupBases = groupRepository.findGroupsWithBaseInfo(userId, date);
         List<Long> groupIds = groupBases.stream().map(GroupGetBaseRes::id).toList();
 
         Map<Long, List<Long>> groupToUserIds = groupMemberRepository.findUserIdsGroupedByGroupIds(groupIds);

--- a/src/main/java/at/mateball/domain/group/core/validator/AgeValidator.java
+++ b/src/main/java/at/mateball/domain/group/core/validator/AgeValidator.java
@@ -1,0 +1,34 @@
+package at.mateball.domain.group.core.validator;
+
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class AgeValidator {
+    private final UserRepository userRepository;
+
+    public AgeValidator(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public boolean isAgeWithinRange(Long baseUserId, Integer targetBirthYear) {
+        Integer baseBirthYear = userRepository.findById(baseUserId)
+                .map(User::getBirthYear)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.NOT_ALLOWED_AGE));
+
+        if (baseBirthYear == null || targetBirthYear == null) {
+            return false;
+        }
+
+        int thisYear = LocalDate.now().getYear();
+        int baseAge = thisYear - baseBirthYear + 1;
+        int targetAge = thisYear - targetBirthYear + 1;
+
+        return Math.abs(baseAge - targetAge) <= 5;
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -82,13 +82,14 @@ public class GroupMemberController {
 
     @CustomExceptionDescription(SwaggerResponseDescription.GROUP_DATE)
     @Operation(summary = "매칭 요청 상세 조회")
-    @GetMapping("/match-detail/{matchId}")
+    @GetMapping("/match/{matchId}")
     public ResponseEntity<MateballResponse<?>> getDetailMatching(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @NotNull @PathVariable Long matchId
+            @NotNull @PathVariable Long matchId,
+            @NotNull @RequestParam boolean newRequest
     ) {
         Long userId = userDetails.getUserId();
-        DetailMatchingListRes detailMatchingListRes = groupMemberService.getDetailMatching(userId, matchId);
+        DetailMatchingListRes detailMatchingListRes = groupMemberService.getDetailMatching(userId, matchId, newRequest);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, detailMatchingListRes));
     }

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberController.java
@@ -89,7 +89,10 @@ public class GroupMemberController {
             @NotNull @RequestParam boolean newRequest
     ) {
         Long userId = userDetails.getUserId();
-        DetailMatchingListRes detailMatchingListRes = groupMemberService.getDetailMatching(userId, matchId, newRequest);
+
+        DetailMatchingListRes detailMatchingListRes = newRequest
+                ? groupMemberService.getDetailMatchingForCreator(userId, matchId)
+                : groupMemberService.getDetailMatchingForRequester(userId, matchId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, detailMatchingListRes));
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -29,17 +29,11 @@ public interface GroupMemberRepositoryCustom {
 
     GroupMemberCountRes countGroupMember(Long groupId);
 
-    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId, boolean newRequest);
-
-    List<DetailMatchingBaseRes> findOnlySelf(Long userId, Long matchId);
-
-    List<DetailMatchingBaseRes> findParticipantsOnly(Long matchId);
-
     List<DirectMatchBaseRes> findDirectMatchMembers(Long groupId);
 
     void createGroupMember(Long userId, Long matchId);
 
-    List<DetailMatchingBaseRes> findNewRequestsForCreator(Long userId, Long matchId)
+    List<DetailMatchingBaseRes> findNewRequestsForCreator(Long userId, Long matchId);
 
     void updateLeaderStatus(Long userId, Long matchId, int status);
 

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
+import at.mateball.domain.groupmember.api.dto.DetailMatchingListRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.base.*;
 import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
@@ -34,6 +35,8 @@ public interface GroupMemberRepositoryCustom {
     void createGroupMember(Long userId, Long matchId);
 
     List<DetailMatchingBaseRes> findNewRequestsForCreator(Long userId, Long matchId);
+
+    List<DetailMatchingBaseRes> findParticipantsForRequester(Long userId, Long matchId);
 
     void updateLeaderStatus(Long userId, Long matchId, int status);
 

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -31,9 +31,15 @@ public interface GroupMemberRepositoryCustom {
 
     List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId, boolean newRequest);
 
+    List<DetailMatchingBaseRes> findOnlySelf(Long userId, Long matchId);
+
+    List<DetailMatchingBaseRes> findParticipantsOnly(Long matchId);
+
     List<DirectMatchBaseRes> findDirectMatchMembers(Long groupId);
 
     void createGroupMember(Long userId, Long matchId);
+
+    List<DetailMatchingBaseRes> findNewRequestsForCreator(Long userId, Long matchId)
 
     void updateLeaderStatus(Long userId, Long matchId, int status);
 

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -29,7 +29,7 @@ public interface GroupMemberRepositoryCustom {
 
     GroupMemberCountRes countGroupMember(Long groupId);
 
-    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId);
+    List<DetailMatchingBaseRes> findGroupMatesByMatchId(Long userId, Long matchId, boolean newRequest);
 
     List<DirectMatchBaseRes> findDirectMatchMembers(Long groupId);
 

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -234,12 +234,9 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         QGameInformation game = QGameInformation.gameInformation;
 
         BooleanBuilder condition = new BooleanBuilder();
-
         condition.and(group.id.eq(matchId));
-
-        condition.and(group.status.eq(1));
-
-        condition.and(groupMember.status.notIn(1, 6));
+        condition.and(group.status.in(0, 1));
+        /*condition.and(groupMember.status.notIn(1, 6));*/
 
         if (newRequest) {
             condition.and(groupMember.isParticipant.isFalse());
@@ -269,6 +266,81 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(group.gameInformation, game)
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
                 .where(condition)
+                .fetch();
+    }
+
+    public List<DetailMatchingBaseRes> findNewRequestsForCreator(Long userId, Long matchId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QUser user = QUser.user;
+        QGroup group = QGroup.group;
+        QGameInformation game = QGameInformation.gameInformation;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        return queryFactory
+                .select(Projections.constructor(DetailMatchingBaseRes.class,
+                        group.id,
+                        user.id,
+                        user.nickname,
+                        user.birthYear,
+                        user.gender,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        user.introduction,
+                        game.awayTeamName,
+                        game.homeTeamName,
+                        game.stadiumName,
+                        game.gameDate,
+                        user.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.user, user)
+                .join(groupMember.group, group)
+                .join(group.gameInformation, game)
+                .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
+                .where(
+                        group.id.eq(matchId),
+                        group.status.eq(1),
+                        group.id.eq(userId),
+                        groupMember.group.id.eq(group.id),
+                        groupMember.isParticipant.isFalse(),
+                        groupMember.status.eq(2)
+                )
+                .fetch();
+    }
+
+    public List<DetailMatchingBaseRes> findParticipantsOnly(Long matchId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QUser user = QUser.user;
+        QGroup group = QGroup.group;
+        QGameInformation game = QGameInformation.gameInformation;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        return queryFactory
+                .select(Projections.constructor(DetailMatchingBaseRes.class,
+                        group.id,
+                        user.id,
+                        user.nickname,
+                        user.birthYear,
+                        user.gender,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        user.introduction,
+                        game.awayTeamName,
+                        game.homeTeamName,
+                        game.stadiumName,
+                        game.gameDate,
+                        user.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.user, user)
+                .join(groupMember.group, group)
+                .join(group.gameInformation, game)
+                .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
+                .where(
+                        group.id.eq(matchId),
+                        groupMember.isParticipant.isTrue(),
+                        groupMember.status.notIn(1, 6)
+                )
                 .fetch();
     }
 

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -178,7 +178,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(group.gameInformation, gameInformation)
                 .where(
                         groupMember.user.id.eq(userId),
-                        groupMember.isParticipant.isTrue(),
                         group.isGroup.isTrue()
                 )
                 .fetch();
@@ -207,7 +206,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(group.gameInformation, gameInformation)
                 .where(
                         groupMember.user.id.eq(userId),
-                        groupMember.isParticipant.isTrue(),
                         group.isGroup.isTrue(),
                         group.status.eq(groupStatus)
                 )

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -114,7 +114,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
                 .where(
                         groupMember.user.id.eq(userId),
-                        groupMember.isParticipant.isTrue(),
                         group.isGroup.isFalse(),
                         group.status.eq(groupStatus)
                 )
@@ -151,7 +150,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(matchRequirement).on(matchRequirement.user.id.eq(user.id))
                 .where(
                         groupMember.user.id.eq(userId),
-                        groupMember.isParticipant.isTrue(),
                         group.isGroup.isFalse()
                 )
                 .fetch();

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -60,8 +60,8 @@ public class GroupMemberService {
         return mapWithCountsAndImages(baseResList);
     }
 
-    public DetailMatchingListRes getDetailMatching(Long userId, Long matchId) {
-        List<DetailMatchingBaseRes> baseResList = groupMemberRepository.findGroupMatesByMatchId(userId, matchId);
+    public DetailMatchingListRes getDetailMatching(Long userId, Long matchId, boolean newRequest) {
+        List<DetailMatchingBaseRes> baseResList = groupMemberRepository.findGroupMatesByMatchId(userId, matchId, newRequest);
 
         if (baseResList == null || baseResList.isEmpty()) {
             throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
@@ -74,7 +74,12 @@ public class GroupMemberService {
                 ));
 
         List<DetailMatchingRes> result = baseResList.stream()
-                .filter(base -> !base.userId().equals(userId))
+                .filter(base -> {
+                    if (newRequest) {
+                        return !base.userId().equals(userId);
+                    }
+                    return true;
+                })
                 .map(base -> {
                     Integer matchRate = matchRateMap.getOrDefault(base.userId(), 0);
                     return DetailMatchingRes.from(base, matchRate);

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -23,6 +23,7 @@ public enum BusinessErrorCode implements ErrorCode {
     NICKNAME_CONTAINS_WHITESPACE(HttpStatus.BAD_REQUEST, "닉네임에 공백이 포함될 수 없습니다."),
     INVALID_NICKNAME_CHARACTER(HttpStatus.BAD_REQUEST, "닉네임은 한글 또는 영어만 사용할 수 있으며, 특수문자는 사용할 수 없습니다."),
     BAD_REQUEST_MATCH_TYPE(HttpStatus.BAD_REQUEST, "요청 matchType이 잘못되었습니다."),
+    NOT_ALLOWED_AGE(HttpStatus.BAD_REQUEST, "매칭 가능한 나이가 아닙니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #115 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---
- service에서 사용자가 생성한 매칭이라면 보이지 않도록 추가
- is_participant제거
- 매칭 요청 상세 조회 분기처리
  1. newRequest=true는 새요청이 온 사용자의 상세 정보 반환, is_participant=false상태
  2. newRequest=false는 내가 포함된 그룹 제외 매칭에 참여중이 사람들의 상세정보를 반환. is_parricipant=true 상태


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 그룹 정보에 출생 연도(birthYear) 필드가 추가되었습니다.
  * 연령 기반 그룹 매칭 필터링이 도입되어, 사용자의 나이 차이가 5년 이내인 그룹만 조회할 수 있습니다.
  * 연령 제한에 부합하지 않을 경우, 관련 오류 메시지가 제공됩니다.

* **기능 개선**
  * 상세 매칭 조회 엔드포인트 경로 및 파라미터가 변경되었습니다.
  * 매칭 상세 조회 시, 요청자/생성자 구분에 따라 결과가 다르게 제공됩니다.
  * 그룹 매칭 결과에서 그룹 리더 본인이 제외됩니다.

* **버그 수정**
  * 매칭 참여자 및 신규 요청자 조회 로직이 개선되어, 더 정확한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->