### PR TITLE
[fix] 매칭 개수 쿼리문 수정

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -2,9 +2,9 @@ package at.mateball.domain.groupmember.core.repository.querydsl;
 
 import at.mateball.domain.gameinformation.core.QGameInformation;
 import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.groupmember.GroupMemberStatus;
-import at.mateball.domain.groupmember.api.dto.DetailMatchingListRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
 import at.mateball.domain.groupmember.api.dto.base.*;
@@ -13,7 +13,6 @@ import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -543,8 +542,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(groupMember.group, group)
                 .where(
                         groupMember.user.id.eq(userId),
-                        groupMember.status.ne(GroupMemberStatus.MATCH_FAILED.getValue()),
-                        groupMember.group.gameInformation.id.eq(gameId),
+                        group.status.eq(GroupStatus.PENDING.getValue()),
                         group.isGroup.eq(isGroup)
                 )
                 .fetchOne();
@@ -578,7 +576,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .where(
                         groupMember.group.id.in(groupIds),
                         groupMember.isParticipant.isTrue()
-                )                .fetch();
+                ).fetch();
 
         return results.stream()
                 .collect(Collectors.groupingBy(


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #121 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭 요청 관련 버그인줄 알았으나, 생성 관련 에러였습니다! 특정 게임 아이디 관련 개수만 count 하고 있어서 요청/생성한 매칭 개수가 제대로 세어지지 않고 있었습니다 : ).....
- 대기중인 매칭이 몇 개 있는지 세어야하므로, 기존 member status로 판단하던 로직도 group status 로 변경했습니다

<br/>


### ❤️ To 다진 / To 헤음

---

