### PR TITLE
[feat] 매칭 생성 및 요청 에러 코드 변경

### DIFF
--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -49,8 +49,8 @@ public enum BusinessErrorCode implements ErrorCode {
     DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다."),
 
     // 429 TOO MANY REQUESTS
-    EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "그룹 매칭은 최대 2개까지만 가능합니다."),
-    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "1대1 매칭은 최대 3개까지만 가능합니다.");
+    EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),
+    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "1대1 매칭은 최대 3개까지만 가능합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -14,8 +14,6 @@ public enum BusinessErrorCode implements ErrorCode {
     BAD_REQUEST_MONDAY(HttpStatus.BAD_REQUEST, "월요일은 경기가 없습니다."),
     BAD_REQUEST_PAST(HttpStatus.BAD_REQUEST, "과거에 머물러있지 마십쇼. 이미 종료된 경기입니다."),
     BAD_REQUEST_DATE(HttpStatus.BAD_REQUEST, "매칭생성 및 신청은 2일 전까지 가능합니다."),
-    EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "그룹 매칭은 최대 2개까지만 가능합니다."),
-    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "1대1 매칭은 최대 3개까지만 가능합니다."),
     ALREADY_HAS_PENDING_REQUEST(HttpStatus.BAD_REQUEST, "이미 요청이 존재하는 매칭입니다."),
     DUPLICATE_MATCHING_ON_SAME_DATE(HttpStatus.BAD_REQUEST, "같은 날짜의 경기에는 하나의 매칭만 참여할 수 있습니다."),
     ALREADY_COMPLETED_GROUP(HttpStatus.BAD_REQUEST, "이미 매칭이 완료된 그룹입니다."),
@@ -48,7 +46,11 @@ public enum BusinessErrorCode implements ErrorCode {
     // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     ALREADY_FAILED_REQUEST(HttpStatus.CONFLICT, "이미 요청이 실패한 매칭입니다."),
-    DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다.");
+    DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다."),
+
+    // 429 TOO MANY REQUESTS
+    EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "그룹 매칭은 최대 2개까지만 가능합니다."),
+    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.BAD_REQUEST, "1대1 매칭은 최대 3개까지만 가능합니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #123 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 400으로 내려주던 개수 제한 예외처리를 429로 변경하여 내려주기로 변경했습니다
- 429는 특정 시간안에 요청이 많이 들어올 경우 주로 사용하는 에러 코드이지만, 우리 서비스의 비즈니스적인 흐름에서 딱히 적절하진 않을 것 같아 다음과 같이 적용하게 되었습니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 매칭 제한 초과 시 반환되는 오류 코드의 HTTP 상태 코드가 400(BAD_REQUEST)에서 429(TOO_MANY_REQUESTS)로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->