### PR TITLE
[fix] 예외 순서 및 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -171,6 +171,10 @@ public class GroupService {
 
         List<GroupGetBaseRes> groupBases = groupRepository.findGroupsWithBaseInfo(userId, date);
 
+        if (groupBases.isEmpty()) {
+            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
+        }
+
         List<GroupGetBaseRes> ageFiltered = groupBases.stream()
                 .filter(groupBase -> ageValidator.isAgeWithinRange(userId, groupBase.birthYear()))
                 .toList();


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #125 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 해당하는 그룹이 없는 예외와 예외 처리 순서를 변경하여 뜬금없는 예외가 발생하지 않도록 합니다.
```
        if (groupBases.isEmpty()) {
            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
        }

        List<GroupGetBaseRes> ageFiltered = groupBases.stream()
                .filter(groupBase -> ageValidator.isAgeWithinRange(userId, groupBase.birthYear()))
                .toList();

        if (ageFiltered.isEmpty()) {
            throw new BusinessException(BusinessErrorCode.NOT_ALLOWED_AGE);
        }
```


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 그룹 정보 조회 시, 해당 날짜에 사용자가 속한 그룹이 없을 경우 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->