### PR TITLE
[feat] 로그아웃

### DIFF
--- a/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
+++ b/src/main/java/at/mateball/common/jwt/JwtCookieProvider.java
@@ -87,6 +87,26 @@ public class JwtCookieProvider {
                 .build();
     }
 
+    private ResponseCookie expireCookie(String name) {
+        return ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .domain(".mateball.co.kr")
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+
+    public List<ResponseCookie> expireAllCookies() {
+        return List.of(
+                expireCookie(ACCESS_TOKEN_NAME),
+                expireCookie(REFRESH_TOKEN_NAME),
+                expireCookie(KAKAO_TOKEN_NAME)
+        );
+    }
+
+
     private ResponseCookie deleteCookie(String name, HttpServletRequest request) {
         return ResponseCookie.from(name, "")
                 .httpOnly(true)

--- a/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
+++ b/src/main/java/at/mateball/common/jwt/JwtTokenGenerator.java
@@ -55,4 +55,21 @@ public class JwtTokenGenerator {
             throw new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN);
         }
     }
+
+    public Long getRemainingExpiration(String accessToken) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+
+            Date expiration = claims.getExpiration();
+            Long now = System.currentTimeMillis();
+
+            return expiration.getTime() - now;
+        } catch (Exception exception) {
+            throw new BusinessException(BusinessErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
 }

--- a/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
+++ b/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
@@ -54,7 +54,7 @@ public class OAuthController {
         List<ResponseCookie> expiredCookies = jwtCookieProvider.expireAllCookies();
 
         return withCookies(expiredCookies)
-                .body(MateballResponse.successWithNoData(SuccessCode.CREATED));
+                .body(MateballResponse.successWithNoData(SuccessCode.OK));
     }
 
     private ResponseEntity.BodyBuilder withCookies(List<ResponseCookie> cookies) {

--- a/src/main/java/at/mateball/domain/auth/core/service/LogoutService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LogoutService.java
@@ -1,6 +1,8 @@
 package at.mateball.domain.auth.core.service;
 
 import at.mateball.common.jwt.JwtTokenGenerator;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -13,5 +15,26 @@ public class LogoutService {
     public LogoutService(TokenService tokenService, JwtTokenGenerator jwtTokenGenerator) {
         this.tokenService = tokenService;
         this.jwtTokenGenerator = jwtTokenGenerator;
+    }
+
+    public void logout(String accessToken) {
+        Long userId;
+
+        try {
+            userId = jwtTokenGenerator.extractUserId(accessToken);
+        } catch (Exception exception) {
+            log.warn("잘못된 AccessToken - 사용자 ID 추출 실패: {}", exception.getMessage());
+            throw new BusinessException(BusinessErrorCode.INVALID_SERVER_JWT);
+        }
+
+        tokenService.delete(userId);
+
+        try {
+            Long expiration = jwtTokenGenerator.getRemainingExpiration(accessToken);
+            tokenService.addToBlacklist(accessToken, expiration);
+        } catch (Exception exception) {
+            log.warn("AccessToken 만료 시간 계산 실패: {}", exception.getMessage());
+            throw new BusinessException(BusinessErrorCode.INVALID_SERVER_JWT);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/LogoutService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LogoutService.java
@@ -1,0 +1,17 @@
+package at.mateball.domain.auth.core.service;
+
+import at.mateball.common.jwt.JwtTokenGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class LogoutService {
+    private final TokenService tokenService;
+    private final JwtTokenGenerator jwtTokenGenerator;
+
+    public LogoutService(TokenService tokenService, JwtTokenGenerator jwtTokenGenerator) {
+        this.tokenService = tokenService;
+        this.jwtTokenGenerator = jwtTokenGenerator;
+    }
+}

--- a/src/main/java/at/mateball/domain/auth/core/service/TokenService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/TokenService.java
@@ -30,13 +30,13 @@ public class TokenService {
 
     public void delete(Long userId) {
         refreshTokenRepository.deleteById("RT:" + userId);
-    }\
+    }
 
     public void addToBlacklist(String accessToken, Long expirationMillis) {
         redisTemplate.opsForValue().set("BL:" + accessToken, "logout", expirationMillis, TimeUnit.MILLISECONDS);
     }
 
-    public boolean  isBlacklisted(String accessToken) {
+    public boolean isBlacklisted(String accessToken) {
         return Boolean.TRUE.equals(redisTemplate.hasKey("BL:" + accessToken));
     }
 }

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -30,6 +30,7 @@ public enum BusinessErrorCode implements ErrorCode {
     INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "Kakao Access Token이 유효하지 않습니다."),
     INVALID_SERVER_JWT(HttpStatus.UNAUTHORIZED, "유효하지 않은 서버 JWT입니다."),
     KAKAO_CLIENT_ERROR(HttpStatus.UNAUTHORIZED, "카카오 JWT 파싱 중 오류가 발생했습니다."),
+    LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED,"이미 로그아웃된 토큰입니다."),
 
     // 403 FORBIDDEN
     AGE_NOT_APPROPRIATE(HttpStatus.FORBIDDEN, "만 19세 이상부터 가입이 가능합니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #127 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- accessToken 기반 로그아웃 기능. JWT 토큰에서 사용자 ID 추출 후, 관련 RefreshToken을 Redis에서 제거
- accessToken은 남은 만료 시간만큼 Redis 블랙리스트에 저장하여 재사용 방지
- 쿠키 만료 응답도 함께 내려서 클라이언트 측에서 쿠키가 제거되도록 처리


<br/>


### ❤️ To 다진 / To 헤음

---

- 필터단에서 블랙리스트 체크하는 로직이 있나 한번만 더 확인해주오..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 기능이 추가되어, 사용자가 로그아웃 시 모든 인증 쿠키가 만료되고, 토큰이 블랙리스트에 등록되어 재사용이 차단됩니다.
  * 토큰의 남은 만료 시간을 확인할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 이미 로그아웃된 토큰 사용 시 적절한 에러 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->