### PR TITLE
[chore/#128] DTO 경기장 정보 추가

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusRes.java
@@ -37,6 +37,9 @@ public record DirectStatusRes(
         @Schema(description = "홈 팀")
         String homeTeam,
         @NotNull
+        @Schema(description = "경기장")
+        String stadium,
+        @NotNull
         @Schema(description = "경기 날짜")
         LocalDate date,
         @NotNull
@@ -60,6 +63,7 @@ public record DirectStatusRes(
                 Style.from(baseRes.style()).getLabel(),
                 baseRes.awayTeam(),
                 baseRes.homeTeam(),
+                baseRes.stadium(),
                 baseRes.date(),
                 GroupMemberStatus.from(baseRes.status()).getLabel(),
                 baseRes.imgUrl()


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #129 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 일대일 매칭 현황 DTO에 경기장 정보 추가

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 응답에 경기장(stadium) 정보가 추가되어 사용자에게 경기장 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->