### PR TITLE
[refactor/#134] 그룹 매칭 리스트 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -193,6 +193,16 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                         groupMember.status.ne(1),
                                         groupMember.isParticipant.isTrue()
                                 )
+                                .notExists(),
+
+                        JPAExpressions
+                                .selectOne()
+                                .from(groupMember)
+                                .where(
+                                        groupMember.group.eq(group),
+                                        groupMember.user.id.eq(userId),
+                                        groupMember.isParticipant.isTrue()
+                                )
                                 .notExists()
                 )
                 .fetch();


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #134 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 그룹 매칭에서 내가 존재하는 매칭은 존재하지 않도록 수정
```
                        JPAExpressions
                                .selectOne()
                                .from(groupMember)
                                .where(
                                        groupMember.group.eq(group),
                                        groupMember.user.id.eq(userId),
                                        groupMember.isParticipant.isTrue()
                                )
                                .notExists()
```
- 예외가 터지지 않고 빈 리스트로 포함되어 내려가도록 수정


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자가 이미 참여 중인 그룹이 검색 결과에 포함되지 않도록 그룹 조회 조건이 개선되었습니다.
  * 연령 필터에 의해 그룹이 없을 경우에도 예외가 발생하지 않고 빈 결과가 반환되도록 동작이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->