### PR TITLE
[feat/#138] 정렬 및 닉네임

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DetailMatchingListRes.java
@@ -3,6 +3,7 @@ package at.mateball.domain.groupmember.api.dto;
 import java.util.List;
 
 public record DetailMatchingListRes(
+        String nickname,
         List<DetailMatchingRes> mates
 ) {
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -303,6 +303,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                                 )
                                 .exists()
                 )
+                .orderBy(groupMember.id.desc())
                 .fetch();
     }
 
@@ -353,6 +354,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         user.id.ne(userId),
                         alreadyJoined.not()
                 )
+                .orderBy(groupMember.id.desc())
                 .fetch();
     }
 

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
@@ -2,9 +2,13 @@ package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.user.core.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByKakaoUserId(Long kakaoUserId);
+    @Query("select u.nickname from User u where u.id = :id")
+    String findNicknameById(@Param("id") Long id);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #138 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

-  응답값 DTO에 사용자 닉네임 추가
- 그룹에 들어온순으로 매칭 정렬 


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 상세 매칭 리스트 응답에 사용자의 닉네임 정보가 추가되었습니다.

* **개선 사항**
  * 매칭 요청 및 참여자 목록이 최신순으로 정렬되어 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->