### PR TITLE
[refactor] 매칭 거절 리스트 포함

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -72,6 +72,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         QGameInformation game = QGameInformation.gameInformation;
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
         QGroupMember groupMember = QGroupMember.groupMember;
+
         return queryFactory
                 .select(Projections.constructor(DirectGetBaseRes.class,
                         group.id,
@@ -101,7 +102,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                 .from(groupMember)
                                 .where(
                                         groupMember.group.id.eq(group.id),
-                                        groupMember.status.ne(1)
+                                        groupMember.status.in(2, 3, 4, 5)
                                 )
                                 .notExists()
 
@@ -167,6 +168,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
         QUser leader = user;
         QGameInformation game = QGameInformation.gameInformation;
         QGroupMember groupMember = QGroupMember.groupMember;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
 
         return queryFactory
                 .select(Projections.constructor(GroupGetBaseRes.class,
@@ -190,7 +192,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                 .from(groupMember)
                                 .where(
                                         groupMember.group.id.eq(group.id),
-                                        groupMember.status.ne(1),
+                                        groupMember.status.in(2, 3, 4, 5),
                                         groupMember.isParticipant.isTrue()
                                 )
                                 .notExists(),

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/GroupMemberRepository.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/GroupMemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberRepositoryCustom {
+    boolean existsByGroupIdAndUserIdAndStatus(Long matchId, Long userId, int status);
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #142 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사요자는 매칭 거절 당했지만, 아직 매칭 완료가 되지 않았으므로 해당 매칭이 다시 홈화면에 보여져야함
```
        List<DirectGetBaseRes> filtered = result.stream()
                .filter(res -> res.team() != null && res.style() != null)
                .filter(res -> ageValidator.isAgeWithinRange(userId, res.birthYear()))
                .filter(res -> !groupMemberRepository.existsByGroupIdAndUserIdAndStatus(res.id(), userId, 6))
                .toList();
```

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매칭 목록에서 사용자의 상태가 "매칭 실패"인 경우 해당 그룹 또는 다이렉트 매칭이 제외되어 더 정확한 결과를 제공합니다.

* **신규 기능**
  * 그룹 멤버의 상태가 특정 값(2, 3, 4, 5)인 경우에만 그룹 필터링이 적용되어 더욱 정밀한 그룹 조회가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->