### PR TITLE
[feat] 이용약관 동의 정보 반환

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -1,0 +1,33 @@
+package at.mateball.domain.user.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
+import at.mateball.domain.user.core.service.UserService;
+import at.mateball.domain.user.core.service.UserV2Service;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/v2/users")
+public class UserV2Contrller {
+    private final UserV2Service userV2Service;
+
+    public UserV2Contrller(UserV2Service userV2Service) {
+        this.userV2Service = userV2Service;
+    }
+
+    @GetMapping("/info-check")
+    public ResponseEntity<MateballResponse<?>> getInfoCheck(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        CheckUserV2Res checkUserV2Res = userV2Service.getInfoCheck(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, checkUserV2Res));
+    }
+}

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -2,8 +2,7 @@ package at.mateball.domain.user.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
-import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
-import at.mateball.domain.user.core.service.UserService;
+import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
@@ -26,8 +25,8 @@ public class UserV2Contrller {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         Long userId = customUserDetails.getUserId();
-        CheckUserV2Res checkUserV2Res = userV2Service.getInfoCheck(userId);
+        InfoCheckRes infoCheckRes = userV2Service.getInfoCheck(userId);
 
-        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, checkUserV2Res));
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, infoCheckRes));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/CheckUserV2Res.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/CheckUserV2Res.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record CheckUserV2Res(
+        boolean nickname,
+        boolean condition,
+        boolean hasAccepted
+) {
+}

--- a/src/main/java/at/mateball/domain/user/api/dto/response/InfoCheckRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/InfoCheckRes.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.user.api.dto.response;
 
-public record CheckUserV2Res(
+public record InfoCheckRes(
         boolean nickname,
         boolean condition,
         boolean hasAccepted

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -38,18 +38,15 @@ public class User {
     @Column(nullable = true)
     private String email;
 
+    @Column(nullable = true)
+    private boolean hasAccepted;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
     protected User() {
 
     }
-
-/*    public User(Long kakaoUserId, String gender, int birthYear) {
-        this.kakaoUserId = kakaoUserId;
-        this.gender = gender;
-        this.birthYear = birthYear;
-    }*/
 
     public User(Long kakaoUserId, String email) {
         this.kakaoUserId = kakaoUserId;

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
+import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
@@ -16,4 +17,6 @@ public interface UserRepositoryCustom {
     Optional<User> getUser(final Long userId);
 
     CheckUserRes fetchUserInfoCheck(Long userId);
+
+    CheckUserV2Res infoCheck(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
-import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
+import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
@@ -18,5 +18,5 @@ public interface UserRepositoryCustom {
 
     CheckUserRes fetchUserInfoCheck(Long userId);
 
-    CheckUserV2Res infoCheck(Long userId);
+    InfoCheckRes infoCheck(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -2,7 +2,7 @@ package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
-import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
+import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.api.dto.response.UserInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.QUser;
@@ -100,7 +100,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     @Override
-    public CheckUserV2Res infoCheck(Long userId) {
+    public InfoCheckRes infoCheck(Long userId) {
         QUser user = QUser.user;
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
 
@@ -131,6 +131,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         Boolean hasAccepted = result.get(user.hasAccepted);
         boolean accepted = hasAccepted != null && hasAccepted;
 
-        return new CheckUserV2Res(nicknameExists, allConditionsPresent, accepted);
+        return new InfoCheckRes(nicknameExists, allConditionsPresent, accepted);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
+import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
 import at.mateball.domain.user.api.dto.response.UserInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
 import at.mateball.domain.user.core.QUser;
@@ -96,4 +97,40 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         result.get(matchRequirement.genderPreference) != null;
 
         return new CheckUserRes(nicknameExists, allConditionsPresent);
-    }}
+    }
+
+    @Override
+    public CheckUserV2Res infoCheck(Long userId) {
+        QUser user = QUser.user;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+
+        Tuple result = queryFactory
+                .select(user.nickname,
+                        matchRequirement.team,
+                        matchRequirement.teamAllowed,
+                        matchRequirement.style,
+                        matchRequirement.genderPreference,
+                        user.hasAccepted)
+                .from(user)
+                .leftJoin(matchRequirement).on(matchRequirement.user.id.eq(user.id))
+                .where(user.id.eq(userId))
+                .fetchOne();
+
+        if (result == null) {
+            throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);
+        }
+
+        boolean nicknameExists = result.get(user.nickname) != null;
+
+        boolean allConditionsPresent =
+                result.get(matchRequirement.team) != null &&
+                        result.get(matchRequirement.teamAllowed) != null &&
+                        result.get(matchRequirement.style) != null &&
+                        result.get(matchRequirement.genderPreference) != null;
+
+        Boolean hasAccepted = result.get(user.hasAccepted);
+        boolean accepted = hasAccepted != null && hasAccepted;
+
+        return new CheckUserV2Res(nicknameExists, allConditionsPresent, accepted);
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -1,0 +1,18 @@
+package at.mateball.domain.user.core.service;
+
+import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
+import at.mateball.domain.user.core.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserV2Service {
+    private final UserRepository userRepository;
+
+    public UserV2Service(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public CheckUserV2Res getInfoCheck(Long userId) {
+        return userRepository.infoCheck(userId);
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.user.core.service;
 
-import at.mateball.domain.user.api.dto.response.CheckUserV2Res;
+import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +12,7 @@ public class UserV2Service {
         this.userRepository = userRepository;
     }
 
-    public CheckUserV2Res getInfoCheck(Long userId) {
+    public InfoCheckRes getInfoCheck(Long userId) {
         return userRepository.infoCheck(userId);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #145 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 이용약관 동의 여부 저장을 위한 컬럼 추가
- 기존 `fetchUserInfoCheck`에서 이용약관 동의 여부 hasAccepted 추가
```
                .select(user.nickname,
                        matchRequirement.team,
                        matchRequirement.teamAllowed,
                        matchRequirement.style,
                        matchRequirement.genderPreference,
                        user.hasAccepted)
```

<br/>


### ❤️ To 다진 / To 헤음

---

- api 공장 가동
- 아으 누가 해킹했냐

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 인증 사용자용 프로필 상태 확인 엔드포인트 추가(/v2/users/info-check). 닉네임 등록 여부, 필수 정보·조건 충족 여부, 약관 동의 여부를 한 번에 반환합니다. 이를 통해 마이페이지/온보딩에서 현재 상태 표시와 다음 단계 안내가 가능해졌습니다. 응답은 표준 성공 형식으로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->