### PR TITLE
[feat] 이용약관 동의 정보 반환

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -29,4 +30,7 @@ public class UserV2Contrller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, infoCheckRes));
     }
+
+    @PostMapping("/consent")
+    public ResponseEntity<MateballResponse<?>> updateHasAccepted
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -2,6 +2,7 @@ package at.mateball.domain.user.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.user.api.dto.request.AcceptedReq;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
@@ -10,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -32,5 +34,13 @@ public class UserV2Contrller {
     }
 
     @PostMapping("/consent")
-    public ResponseEntity<MateballResponse<?>> updateHasAccepted
+    public ResponseEntity<MateballResponse<?>> updateHasAccepted(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestBody AcceptedReq acceptedReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userV2Service.updateHasAccepted(userId, acceptedReq.hasAccepted());
+
+        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/AcceptedReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/AcceptedReq.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.user.api.dto.request;
 
-public record ConsentReq(
+public record AcceptedReq(
         boolean hasAccepted
 ) {
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/ConsentReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/ConsentReq.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.user.api.dto.request;
+
+public record ConsentReq(
+        boolean hasAccepted
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -72,4 +72,8 @@ public class User {
         this.gender = gender.getRaw();
         this.birthYear = birthYear;
     }
+
+    public void updateHasAccepted(boolean hasAccepted) {
+        this.hasAccepted = hasAccepted;
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -1,8 +1,12 @@
 package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
+import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserV2Service {
@@ -14,5 +18,17 @@ public class UserV2Service {
 
     public InfoCheckRes getInfoCheck(Long userId) {
         return userRepository.infoCheck(userId);
+    }
+
+    @Transactional
+    public void updateHasAccepted(Long userId, boolean hasAccepted) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        if (user.isHasAccepted() == hasAccepted) {
+            return;
+        }
+
+        user.updateHasAccepted(hasAccepted);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #146 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- dto 생성 후 약관 동의 여부 정보 반환
- 더티채킹으로 해당 컬럼(user의 hasAccepted) 업데이트

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 동의 상태를 업데이트하는 새 엔드포인트(POST /v2/users/consent) 추가. 인증된 계정의 동의 여부를 요청 본문으로 전달하면 즉시 저장되며, 성공 시 생성 완료 응답을 반환합니다. 앱의 설정/동의 화면에서 변경 사항이 즉시 반영되어 동의 관리가 더 원활해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->