### PR TITLE
[feat] 사용자 정보 관련 api 구현

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -3,9 +3,12 @@ package at.mateball.domain.user.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.user.api.dto.request.AcceptedReq;
+import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -42,5 +45,17 @@ public class UserV2Contrller {
         userV2Service.updateHasAccepted(userId, acceptedReq.hasAccepted());
 
         return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
+
+    @PostMapping("/info")
+    @Operation(summary = "사용자 정보 설정 api")
+    public ResponseEntity<MateballResponse<?>> createUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody UserInfoV2Req userInfoReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userV2Service.createUserInfo(userId, userInfoReq);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Contrller.java
@@ -3,6 +3,7 @@ package at.mateball.domain.user.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.user.api.dto.request.AcceptedReq;
+import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.service.UserV2Service;
@@ -12,10 +13,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/v2/users")
@@ -55,6 +53,18 @@ public class UserV2Contrller {
     ) {
         Long userId = customUserDetails.getUserId();
         userV2Service.createUserInfo(userId, userInfoReq);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
+    }
+
+    @PutMapping("/info")
+    @Operation(summary = "사용자 정보 수정 api")
+    public ResponseEntity<MateballResponse<?>> editUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody EditUserInfoReq editUserInfoReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userV2Service.editUserInfo(userId, editUserInfoReq);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
     }

--- a/src/main/java/at/mateball/domain/user/api/dto/request/EditUserInfoReq.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/EditUserInfoReq.java
@@ -1,0 +1,12 @@
+package at.mateball.domain.user.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EditUserInfoReq(
+        @NotNull
+        String field,
+
+        @NotNull
+        String value
+) {
+}

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
@@ -10,7 +10,7 @@ public record UserInfoV2Req(
         String introduction,
 
         @NotNull
-        int birthYear,
+        Integer birthYear,
 
         @NotNull
         String gender

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
@@ -1,0 +1,18 @@
+package at.mateball.domain.user.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserInfoV2Req(
+        @NotNull
+        String nickname,
+
+        @NotNull
+        String introduction,
+
+        @NotNull
+        int birthYear,
+
+        @NotNull
+        String gender
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/UserInfoField.java
+++ b/src/main/java/at/mateball/domain/user/core/UserInfoField.java
@@ -1,0 +1,24 @@
+package at.mateball.domain.user.core;
+
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+
+import java.util.Arrays;
+
+public enum UserInfoField {
+    NICKNAME("닉네임"),
+    INTRODUCTION("소개");
+
+    private final String label;
+
+    UserInfoField(String label) {
+        this.label = label;
+    }
+
+    public static UserInfoField fromLabel(String label) {
+        return Arrays.stream(values())
+                .filter(f -> f.label.equalsIgnoreCase(label))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -6,6 +6,7 @@ import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
@@ -23,8 +24,6 @@ public class UserV2Service {
     private final AlarmService alarmService;
 
     private static final Integer LIMIT_AGE = 19;
-    private static final Integer MIN_INTRODUCTION_LENGTH = 1;
-    private static final Integer MAX_INTRODUCTION_LENGTH = 50;
     private static final String DEFAULT_PROFILE_IMAGE_URL =
             "https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg";
 
@@ -72,9 +71,7 @@ public class UserV2Service {
     }
 
     private void validateIntroduction(String introduction) {
-        if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {
-            throw new BusinessException(BusinessErrorCode.INVALID_INTRODUCTION_LENGTH);
-        }
+        IntroductionValidator.validate(introduction);
     }
 
     private void validateAge(int birthYear) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -79,6 +79,7 @@ public class UserV2Service {
                 validateIntroduction(req.value());
                 user.updateIntroduction(req.value());
             }
+            default -> throw new BusinessException(BAD_REQUEST_ENUM);
         }
     }
 

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -54,6 +54,10 @@ public class UserV2Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
+        if (user.getNickname() != null || user.getIntroduction() != null || user.getBirthYear() != null || user.getGender() != null) {
+            throw new BusinessException(DUPLICATED_INFO);
+        }
+
         validateNickname(req.nickname());
         validateIntroduction(req.introduction());
         validateAge(req.birthYear());

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -2,6 +2,7 @@ package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
@@ -9,7 +10,6 @@ import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
-import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,6 +61,23 @@ public class UserV2Service {
         user.updateIntroduction(req.introduction());
         user.updateGenderAndBirthYear(Gender.fromLabel(req.gender()), req.birthYear());
         user.updateProfileImage(DEFAULT_PROFILE_IMAGE_URL);
+    }
+
+    @Transactional
+    public void editUserInfo(Long userId, @Valid EditUserInfoReq req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        switch (req.field()) {
+            case "닉네임" -> {
+                validateNickname(req.value());
+                user.updateNickname(req.value());
+            }
+            case "소개" -> {
+                validateIntroduction(req.value());
+                user.updateIntroduction(req.value());
+            }
+        }
     }
 
     private void validateNickname(String nickname) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -6,6 +6,7 @@ import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.UserInfoField;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
@@ -68,12 +69,13 @@ public class UserV2Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
-        switch (req.field()) {
-            case "닉네임" -> {
+        UserInfoField field = UserInfoField.fromLabel(req.field());
+        switch (field) {
+            case NICKNAME -> {
                 validateNickname(req.value());
                 user.updateNickname(req.value());
             }
-            case "소개" -> {
+            case INTRODUCTION -> {
                 validateIntroduction(req.value());
                 user.updateIntroduction(req.value());
             }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -1,18 +1,32 @@
 package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.alarm.core.service.AlarmService;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static at.mateball.exception.code.BusinessErrorCode.*;
 
 @Service
 public class UserV2Service {
     private final UserRepository userRepository;
     private final AlarmService alarmService;
+
+    private static final Integer LIMIT_AGE = 19;
+    private static final Integer MIN_INTRODUCTION_LENGTH = 1;
+    private static final Integer MAX_INTRODUCTION_LENGTH = 50;
+    private static final String DEFAULT_PROFILE_IMAGE_URL =
+            "https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg";
 
     public UserV2Service(UserRepository userRepository, AlarmService alarmService) {
         this.userRepository = userRepository;
@@ -33,5 +47,40 @@ public class UserV2Service {
         }
 
         user.updateHasAccepted(hasAccepted);
+    }
+
+    @Transactional
+    public void createUserInfo(Long userId, @Valid UserInfoV2Req req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        validateNickname(req.nickname());
+        validateIntroduction(req.introduction());
+        validateAge(req.birthYear());
+
+        user.updateNickname(req.nickname());
+        user.updateIntroduction(req.introduction());
+        user.updateGenderAndBirthYear(Gender.fromLabel(req.gender()), req.birthYear());
+        user.updateProfileImage(DEFAULT_PROFILE_IMAGE_URL);
+    }
+
+    private void validateNickname(String nickname) {
+        NicknameValidator.validate(nickname);
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(DUPLICATED_NICKNAME);
+        }
+    }
+
+    private void validateIntroduction(String introduction) {
+        if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {
+            throw new BusinessException(BusinessErrorCode.INVALID_INTRODUCTION_LENGTH);
+        }
+    }
+
+    private void validateAge(int birthYear) {
+        int age = LocalDate.now().getYear() - birthYear;
+        if (age < LIMIT_AGE) {
+            throw new BusinessException(AGE_NOT_APPROPRIATE);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
+++ b/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
@@ -4,8 +4,8 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 
 public class IntroductionValidator {
-    private static final Integer MIN_INTRODUCTION_LENGTH = 1;
-    private static final Integer MAX_INTRODUCTION_LENGTH = 50;
+    private static final int MIN_INTRODUCTION_LENGTH = 1;
+    private static final int MAX_INTRODUCTION_LENGTH = 50;
 
     public static void validate(String introduction) {
         if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {

--- a/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
+++ b/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
@@ -9,7 +9,7 @@ public class IntroductionValidator {
 
     public static void validate(String introduction) {
         if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {
-            throw new BusinessException(BusinessErrorCode.INVALID_NICKNAME_LENGTH);
+            throw new BusinessException(BusinessErrorCode.INVALID_INTRODUCTION_LENGTH);
         }
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
+++ b/src/main/java/at/mateball/domain/user/core/validator/IntroductionValidator.java
@@ -1,0 +1,15 @@
+package at.mateball.domain.user.core.validator;
+
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+
+public class IntroductionValidator {
+    private static final Integer MIN_INTRODUCTION_LENGTH = 1;
+    private static final Integer MAX_INTRODUCTION_LENGTH = 50;
+
+    public static void validate(String introduction) {
+        if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {
+            throw new BusinessException(BusinessErrorCode.INVALID_NICKNAME_LENGTH);
+        }
+    }
+}

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -53,6 +53,7 @@ public enum BusinessErrorCode implements ErrorCode {
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),
     ALREADY_FAILED_REQUEST(HttpStatus.CONFLICT, "이미 요청이 실패한 매칭입니다."),
     DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다."),
+    DUPLICATED_INFO(HttpStatus.BAD_REQUEST, "이미 사용자 정보가 존재합니다. 사용자 정보 설정은 최초 한 번만 가능합니다."),
 
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -24,6 +24,7 @@ public enum BusinessErrorCode implements ErrorCode {
     NOT_ALLOWED_AGE(HttpStatus.BAD_REQUEST, "매칭 가능한 나이가 아닙니다."),
     INVALID_GROUP_STATUS(HttpStatus.BAD_REQUEST, "매칭 완료 상태가 아닙니다."),
     GROUP_NOT_FOUND_OR_ALREADY_UPDATED(HttpStatus.BAD_REQUEST, "업데이트할 그룹이 없거나 이미 업데이트된 상태입니다."),
+    INVALID_INTRODUCTION_LENGTH(HttpStatus.BAD_REQUEST, "한줄소개는 1자 이상 50자 이하로 입력해야 합니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #152 
closed #154 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 온보딩에서 사용되는 사용자 정보 등록 api 와, 사용자 정보 수정에서 사용되는 한줄소개/닉네임 수정 api 를 한번에 구현했습니다.
- 한줄소개/닉네임 같은 경우 분리를 하려다가 일단 하나로 합쳤습니다(request body를 통해 enum 값을 받아오는 형식) 만약 웹분들이 분리된 버전이 편하다고 하시면 분리할 예정입니다!
- 두 api 모두 닉네임/한줄소개 검증이 필요하므로, validator 를 생성했습니다(닉네임은 원래 있었음. 한줄소개validator만 새로 생성)


<br/>


### ❤️ To 다진 / To 헤음

---

- 저희 스웨거는 안쓰지만.. 그래도 컨트롤러단에서 제목 달아주는 어노테이션 계속 쓰는 거 어떤가요? api 찾을때 간편해서 좋아요 ㅎㅎㅎㅎ
- `    @Operation(summary = "사용자 정보 설정 api")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 사용자 정보 생성/수정 API 추가 (POST/PUT /v2/users/info) — 인증 필요, 성공 시 본문 없는 응답
  * 닉네임·한줄소개·출생연도·성별 입력 지원 및 최초 등록 시 기본 프로필 이미지 자동 설정
  * 닉네임 중복 검사, 한줄소개 길이 제한(1~50자), 연령 제한(만 19세 이상) 적용
  * 선택적 수정 지원: 닉네임 또는 한줄소개만 부분 수정 가능
  * 유효성 실패 시 명확한 오류 반환(중복/길이/연령/잘못된 필드 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->