### PR TITLE
[feat] 매칭현황에서 매칭생성자 여부 판단

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberV2Controller.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberV2Controller.java
@@ -1,0 +1,42 @@
+package at.mateball.domain.groupmember.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.core.service.GroupMemberV2Service;
+import at.mateball.exception.code.SuccessCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v2/users")
+public class GroupMemberV2Controller {
+    private final GroupMemberV2Service groupMemberV2Service;
+
+    public GroupMemberV2Controller(GroupMemberV2Service groupMemberV2Service) {
+        this.groupMemberV2Service = groupMemberV2Service;
+    }
+
+    @GetMapping("/match-stage/direct")
+    public ResponseEntity<MateballResponse<?>> getDirectStatusV2(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "status", required = false) String statusLabel
+    ) {
+        Long userId = customUserDetails.getUserId();
+        DirectStatusListRes result;
+
+        if (statusLabel == null || statusLabel.isBlank()) {
+            result = groupMemberV2Service.getAllDirectStatusV2(userId);
+        } else {
+            GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
+            result = groupMemberV2Service.getDirectStatusV2(userId, groupStatus);
+        }
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberV2Controller.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/controller/GroupMemberV2Controller.java
@@ -4,6 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
 import at.mateball.domain.groupmember.core.service.GroupMemberV2Service;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,24 @@ public class GroupMemberV2Controller {
         } else {
             GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
             result = groupMemberV2Service.getDirectStatusV2(userId, groupStatus);
+        }
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("/match-stage/group")
+    public ResponseEntity<MateballResponse<?>> getGroupStatusV2(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @RequestParam(value = "status", required = false) String statusLabel
+    ) {
+        Long userId = customUserDetails.getUserId();
+        GroupStatusListRes result;
+
+        if (statusLabel == null || statusLabel.isBlank()) {
+            result = groupMemberV2Service.getAllGroupStatusV2(userId);
+        } else {
+            GroupStatus groupStatus = GroupStatus.fromCode(statusLabel);
+            result = groupMemberV2Service.getGroupStatusV2(userId, groupStatus);
         }
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusListRes.java
@@ -2,7 +2,14 @@ package at.mateball.domain.groupmember.api.dto;
 
 import java.util.List;
 
-public record DirectStatusListRes(
-        List<DirectStatusRes> mates) {
+public class DirectStatusListRes<T> {
+    private final List<T> results;
 
+    public DirectStatusListRes(List<T> results) {
+        this.results = results;
+    }
+
+    public List<T> getResults() {
+        return results;
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusResV2.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/DirectStatusResV2.java
@@ -1,0 +1,51 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseResV2;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.team.core.TeamName;
+import at.mateball.util.AgeUtils;
+
+import java.time.LocalDate;
+
+public record DirectStatusResV2(
+        Long id,
+        String nickname,
+        String age,
+        String gender,
+        String team,
+        String style,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String status,
+        String imgUrl,
+        boolean isCreated
+) {
+    public static DirectStatusResV2 fromV2(DirectStatusBaseResV2 baseRes, Long userId) {
+        String age = null;
+        if (baseRes.birthYear() != null) {
+            age = AgeUtils.calculateAge(baseRes.birthYear());
+        }
+
+        boolean isCreated = baseRes.leaderId().equals(userId);
+
+        return new DirectStatusResV2(
+                baseRes.id(),
+                baseRes.nickname(),
+                age,
+                Gender.from(baseRes.gender()).getLabel(),
+                TeamName.from(baseRes.team()).getLabel(),
+                Style.from(baseRes.style()).getLabel(),
+                baseRes.awayTeam(),
+                baseRes.homeTeam(),
+                baseRes.stadium(),
+                baseRes.date(),
+                GroupMemberStatus.from(baseRes.status()).getLabel(),
+                baseRes.imgUrl(),
+                isCreated
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusListRes.java
@@ -2,7 +2,14 @@ package at.mateball.domain.groupmember.api.dto;
 
 import java.util.List;
 
-public record GroupStatusListRes(
-        List<GroupStatusRes> mates
-) {
+public class GroupStatusListRes<T> {
+    private final List<T> mates;
+
+    public GroupStatusListRes(List<T> mates) {
+        this.mates = mates;
+    }
+
+    public List<T> getMates() {
+        return mates;
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusResV2.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupStatusResV2.java
@@ -1,0 +1,39 @@
+package at.mateball.domain.groupmember.api.dto;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseResV2;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GroupStatusResV2(
+
+        Long id,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        String status,
+        Integer count,
+        List<String> imgUrl,
+        boolean isCreated
+) {
+    public static GroupStatusResV2 from(GroupStatusBaseResV2 base, Integer count, List<String> imgUrls, Long userId) {
+        boolean isCreated = base.leaderId().equals(userId);
+        return new GroupStatusResV2(
+                base.id(),
+                base.nickname(),
+                base.awayTeam(),
+                base.homeTeam(),
+                base.stadium(),
+                base.date(),
+                GroupMemberStatus.from(base.status()).getLabel(),
+                count,
+                imgUrls,
+                isCreated
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseResV2.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseResV2.java
@@ -1,0 +1,19 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+import java.time.LocalDate;
+
+public record DirectStatusBaseResV2(
+        Long id,
+        Long leaderId,
+        String nickname,
+        Integer birthYear,
+        String gender,
+        Integer team,
+        Integer style,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        Integer status,
+        String imgUrl
+) {}

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseResV2.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/GroupStatusBaseResV2.java
@@ -1,0 +1,14 @@
+package at.mateball.domain.groupmember.api.dto.base;
+
+import java.time.LocalDate;
+
+public record GroupStatusBaseResV2(
+        Long id,
+        Long leaderId,
+        String nickname,
+        String awayTeam,
+        String homeTeam,
+        String stadium,
+        LocalDate date,
+        Integer status
+) {}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -67,4 +67,8 @@ public interface GroupMemberRepositoryCustom {
     Optional<GroupMemberRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
     Map<Long, List<Long>> findUserIdsGroupedByGroupIds(List<Long> groupIds);
 
+    List<DirectStatusBaseResV2> findDirectMatchingsByUserAndGroupStatusV2(Long userId, int groupStatus);
+
+    List<DirectStatusBaseResV2> findAllDirectMatchingsByUserV2(Long userId);
+
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -71,4 +71,7 @@ public interface GroupMemberRepositoryCustom {
 
     List<DirectStatusBaseResV2> findAllDirectMatchingsByUserV2(Long userId);
 
+    List<GroupStatusBaseResV2> findGroupMatchingsByUserV2(Long userId);
+
+    List<GroupStatusBaseResV2> findGroupMatchingsByUserAndStatusV2(Long userId, int groupStatus);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -698,4 +698,77 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 )
                 .fetch();
     }
+
+    @Override
+    public List<GroupStatusBaseResV2> findGroupMatchingsByUserV2(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser leader = new QUser("leader");
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+        QMatchRequirement leaderMatchRequirement = new QMatchRequirement("leaderMatchRequirement");
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseResV2.class,
+                        group.id,
+                        leader.id,
+                        leader.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.leader, leader)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
+                .where(
+                        groupMember.user.id.eq(userId),
+                        group.isGroup.isTrue()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<GroupStatusBaseResV2> findGroupMatchingsByUserAndStatusV2(Long userId, int groupStatus) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser leader = new QUser("leader");
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+        QMatchRequirement leaderMatchRequirement = new QMatchRequirement("leaderMatchRequirement");
+
+        BooleanExpression statusCondition;
+        if (groupStatus == 3) {
+            statusCondition = (group.status.eq(3).and(groupMember.status.ne(6)))
+                    .or(groupMember.status.eq(6).and(groupMember.isParticipant.isFalse()));
+        } else {
+            statusCondition = group.status.eq(groupStatus)
+                    .and(groupMember.status.ne(6));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(GroupStatusBaseResV2.class,
+                        group.id,
+                        leader.id,
+                        leader.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.leader, leader)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
+                .where(
+                        group.isGroup.isTrue(),
+                        (groupMember.user.id.eq(userId)
+                                .or(group.leader.id.eq(userId))),
+                        statusCondition
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -616,4 +616,86 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         Collectors.mapping(tuple -> tuple.get(groupMember.user.id), Collectors.toList())
                 ));
     }
+
+    @Override
+    public List<DirectStatusBaseResV2> findDirectMatchingsByUserAndGroupStatusV2(Long userId, int groupStatus) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser leader = new QUser("leader");
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+        QMatchRequirement leaderMatchRequirement = new QMatchRequirement("leaderMatchRequirement");
+
+        BooleanExpression statusCondition;
+        if (groupStatus == 3) {
+            statusCondition = (group.status.eq(3).and(groupMember.status.ne(6)))
+                    .or(groupMember.status.eq(6).and(groupMember.isParticipant.isFalse()));
+        } else {
+            statusCondition = group.status.eq(groupStatus)
+                    .and(groupMember.status.ne(6));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(DirectStatusBaseResV2.class,
+                        group.id,
+                        leader.id,
+                        leader.nickname,
+                        leader.birthYear,
+                        leader.gender,
+                        leaderMatchRequirement.team,
+                        leaderMatchRequirement.style,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status,
+                        leader.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.leader, leader)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
+                .where(
+                        groupMember.user.id.eq(userId),
+                        group.isGroup.isFalse(),
+                        statusCondition
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<DirectStatusBaseResV2> findAllDirectMatchingsByUserV2(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroup group = QGroup.group;
+        QUser leader = new QUser("leader");
+        QGameInformation gameInformation = QGameInformation.gameInformation;
+        QMatchRequirement leaderMatchRequirement = new QMatchRequirement("leaderMatchRequirement");
+
+        return queryFactory
+                .select(Projections.constructor(DirectStatusBaseResV2.class,
+                        group.id,
+                        leader.id,
+                        leader.nickname,
+                        leader.birthYear,
+                        leader.gender,
+                        leaderMatchRequirement.team,
+                        leaderMatchRequirement.style,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status,
+                        leader.imgUrl
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.leader, leader)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
+                .where(
+                        groupMember.user.id.eq(userId),
+                        group.isGroup.isFalse()
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
@@ -3,11 +3,15 @@ package at.mateball.domain.groupmember.core.service;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
 import at.mateball.domain.groupmember.api.dto.DirectStatusResV2;
+import at.mateball.domain.groupmember.api.dto.GroupStatusListRes;
+import at.mateball.domain.groupmember.api.dto.GroupStatusResV2;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseResV2;
+import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseResV2;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class GroupMemberV2Service {
@@ -37,5 +41,49 @@ public class GroupMemberV2Service {
                 .toList();
 
         return new DirectStatusListRes(result);
+    }
+
+    public GroupStatusListRes getAllGroupStatusV2(Long userId) {
+        List<GroupStatusBaseResV2> baseResList = groupMemberRepository.findGroupMatchingsByUserV2(userId);
+
+        Map<Long, Integer> countMap = groupMemberRepository.findGroupMemberCountMap(
+                baseResList.stream().map(GroupStatusBaseResV2::id).toList()
+        );
+        Map<Long, List<String>> imgMap = groupMemberRepository.findGroupMemberImgMap(
+                baseResList.stream().map(GroupStatusBaseResV2::id).toList()
+        );
+
+        List<GroupStatusResV2> result = baseResList.stream()
+                .map(base -> GroupStatusResV2.from(
+                        base,
+                        countMap.getOrDefault(base.id(), 0) - 1,
+                        imgMap.getOrDefault(base.id(), List.of()),
+                        userId
+                ))
+                .toList();
+
+        return new GroupStatusListRes(result);
+    }
+
+    public GroupStatusListRes getGroupStatusV2(Long userId, GroupStatus status) {
+        List<GroupStatusBaseResV2> baseResList = groupMemberRepository.findGroupMatchingsByUserAndStatusV2(userId, status.getValue());
+
+        Map<Long, Integer> countMap = groupMemberRepository.findGroupMemberCountMap(
+                baseResList.stream().map(GroupStatusBaseResV2::id).toList()
+        );
+        Map<Long, List<String>> imgMap = groupMemberRepository.findGroupMemberImgMap(
+                baseResList.stream().map(GroupStatusBaseResV2::id).toList()
+        );
+
+        List<GroupStatusResV2> result = baseResList.stream()
+                .map(base -> GroupStatusResV2.from(
+                        base,
+                        countMap.getOrDefault(base.id(), 0) - 1,
+                        imgMap.getOrDefault(base.id(), List.of()),
+                        userId
+                ))
+                .toList();
+
+        return new GroupStatusListRes(result);
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
@@ -1,0 +1,41 @@
+package at.mateball.domain.groupmember.core.service;
+
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.groupmember.api.dto.DirectStatusListRes;
+import at.mateball.domain.groupmember.api.dto.DirectStatusResV2;
+import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseResV2;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class GroupMemberV2Service {
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupMemberV2Service(GroupMemberRepository groupMemberRepository) {
+        this.groupMemberRepository = groupMemberRepository;
+    }
+
+    public DirectStatusListRes getDirectStatusV2(Long userId, GroupStatus groupStatus) {
+        List<DirectStatusBaseResV2> baseResList =
+                groupMemberRepository.findDirectMatchingsByUserAndGroupStatusV2(userId, groupStatus.getValue());
+
+        List<DirectStatusResV2> result = baseResList.stream()
+                .map(baseRes -> DirectStatusResV2.fromV2(baseRes, userId))
+                .toList();
+
+        return new DirectStatusListRes(result);
+    }
+
+    public DirectStatusListRes getAllDirectStatusV2(Long userId) {
+        List<DirectStatusBaseResV2> baseResList =
+                groupMemberRepository.findAllDirectMatchingsByUserV2(userId);
+
+        List<DirectStatusResV2> result = baseResList.stream()
+                .map(baseRes -> DirectStatusResV2.fromV2(baseRes, userId))
+                .toList();
+
+        return new DirectStatusListRes(result);
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담당자를 표시해 주세요.
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #158 

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 매칭 현황 조회 API(일대일/그룹)에 `isCreated`(본인 생성 여부) 플래그를 추가
- `groupMemberRepository` 쿼리에서 `leaderId`를 함께 조회하도록 수정
- `DirectStatusBaseResV2`, `GroupStatusBaseResV2` DTO에 `leaderId` 필드를 추가
- `DirectStatusResV2.fromV2()`, `GroupStatusResV2.from()`에서 `userId == leaderId` 여부를 체크해 `isCreated` 값 세팅하도록 매핑했습니다.
- 기존 로직은 그대로 유지하면서, 응답 DTO에만 `isCreated` 값이 추가되도록 변경
- 이에 따라 프론트에서 `isCreated == true`인 경우 왕관 표시를 할 수 있습니다. 👑

<br/>

### ❤️ To 다진 / To 헤음

---

- V2 구조로 API를 정리하면서 공통 `ListRes<T>` 제네릭화까지 반영했어요. 앞으로 V3까지 확장성 있게 설계 가능할 듯
- 아으 리팩토링 할거 너무 많은데 어카지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 매칭 단계 상태 조회 V2 API 추가: 개인/그룹 목록 제공 및 상태별 필터링 지원.
  - 응답 정보 확장: 나이, 성별/팀/스타일 라벨, 경기 정보(원정/홈, 경기장, 날짜), 참여자 수, 썸네일 이미지, 방장 여부 포함.
  - 리스트 기반 응답 포맷으로 정비되어 일관성과 가독성 향상.
  - 인증 사용자 기준으로 본인 관련 매칭만 반환하며 성공 응답 코드로 전달.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->