### PR TITLE
[feat] 매칭 조건 관련 api 구현

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementController.java
@@ -5,7 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.common.swagger.CustomExceptionDescription;
 import at.mateball.common.swagger.SwaggerResponseDescription;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
-import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementReq;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
@@ -40,7 +40,7 @@ public class MatchRequirementV2Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        matchRequirementV2Service.setMatchRequirement(userId, matchRequirementReq);
+        matchRequirementV2Service.updateMatchRequirement(userId, matchRequirementReq);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
@@ -2,16 +2,14 @@ package at.mateball.domain.matchrequirement.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementReq;
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementRes;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV2Service;
-import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v2/users/")
@@ -20,6 +18,18 @@ public class MatchRequirementV2Controller {
 
     public MatchRequirementV2Controller(MatchRequirementV2Service matchRequirementV2Service) {
         this.matchRequirementV2Service = matchRequirementV2Service;
+    }
+
+    @GetMapping("/match-condition")
+    @Operation(summary = "매칭 조건 조회 api")
+    public ResponseEntity<MateballResponse<?>> getMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        MatchRequirementRes result = matchRequirementV2Service.getMatchRequirement(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
 
     @PatchMapping("/match-condition")

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV2Controller.java
@@ -1,0 +1,37 @@
+package at.mateball.domain.matchrequirement.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.matchrequirement.core.service.MatchRequirementV2Service;
+import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
+import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v2/users/")
+public class MatchRequirementV2Controller {
+    private final MatchRequirementV2Service matchRequirementV2Service;
+
+    public MatchRequirementV2Controller(MatchRequirementV2Service matchRequirementV2Service) {
+        this.matchRequirementV2Service = matchRequirementV2Service;
+    }
+
+    @PatchMapping("/match-condition")
+    @Operation(summary = "매칭 조건 수정 api")
+    public ResponseEntity<MateballResponse<?>> updateMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MatchRequirementReq matchRequirementReq
+    ) {
+        Long userId = userDetails.getUserId();
+
+        matchRequirementV2Service.setMatchRequirement(userId, matchRequirementReq);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
+    }
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementReq.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementReq.java
@@ -1,4 +1,4 @@
-package at.mateball.domain.user.api.dto.request;
+package at.mateball.domain.matchrequirement.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementRes.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementRes.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.matchrequirement.api.dto.response;
+
+public record MatchRequirementRes(
+        String team,
+        String teamAllowed,
+        String style,
+        String genderPreference
+) {
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
@@ -40,14 +40,26 @@ public class MatchRequirement {
         this.genderPreference = genderPreference;
     }
 
-    public void getMatchRequirement(){
-
-    }
-
     public void updateAll(Integer team, Integer teamAllowed, Integer style, Integer genderPreference) {
         this.team = team;
         this.teamAllowed = teamAllowed;
         this.style = style;
+        this.genderPreference = genderPreference;
+    }
+
+    public void updateTeam(Integer team) {
+        this.team = team;
+    }
+
+    public void updateTeamAllowed(Integer teamAllowed) {
+        this.teamAllowed = teamAllowed;
+    }
+
+    public void updateStyle(Integer style) {
+        this.style = style;
+    }
+
+    public void updateGenderPreference(Integer genderPreference) {
         this.genderPreference = genderPreference;
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/Gender.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/Gender.java
@@ -29,6 +29,13 @@ public enum Gender {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
 
+    public static Gender from(int value) {
+        return Arrays.stream(values())
+                .filter(g -> g.value == value)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
     public static Gender fromLabel(String label) {
         return Arrays.stream(values())
                 .filter(e -> e.label.equalsIgnoreCase(label))

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementService.java
@@ -8,6 +8,8 @@ import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.User;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,22 +36,17 @@ public class MatchRequirementService {
         User user = entityManager.getReference(User.class, userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
-        if (matchRequirement == null) {
-            matchRequirement = new MatchRequirement(
-                    user,
-                    TeamName.fromLabel(team).getValue(),
-                    teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
-                    Style.fromLabel(style).getValue(),
-                    Gender.fromLabel(genderPreference).getValue()
-            );
-            entityManager.persist(matchRequirement);
-        } else {
-            matchRequirement.updateAll(
-                    TeamName.fromLabel(team).getValue(),
-                    teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
-                    Style.fromLabel(style).getValue(),
-                    Gender.fromLabel(genderPreference).getValue()
-            );
+        if (matchRequirement != null) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUIREMENT);
         }
+
+        matchRequirement = new MatchRequirement(
+                user,
+                TeamName.fromLabel(team).getValue(),
+                teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
+                Style.fromLabel(style).getValue(),
+                Gender.fromLabel(genderPreference).getValue()
+        );
+        entityManager.persist(matchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -1,13 +1,14 @@
 package at.mateball.domain.matchrequirement.core.service;
 
 
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementReq;
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementRes;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
-import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,17 @@ public class MatchRequirementV2Service {
 
     public MatchRequirementV2Service(MatchRequirementRepository matchRequirementRepository) {
         this.matchRequirementRepository = matchRequirementRepository;
+    }
+
+    public MatchRequirementRes getMatchRequirement(Long userId) {
+        MatchRequirement requirement = matchRequirementRepository.findUserMatchRequirement(userId);
+
+        return new MatchRequirementRes(
+                TeamName.from(requirement.getTeam()).getLabel(),
+                TeamAllowed.from(requirement.getTeamAllowed()).getLabel(),
+                Style.from(requirement.getStyle()).getLabel(),
+                Gender.from(requirement.getGenderPreference()).getLabel()
+        );
     }
 
     @Transactional

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -10,6 +10,7 @@ import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,11 +43,21 @@ public class MatchRequirementV2Service {
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
         if (req.team() != null) {
-            matchRequirement.updateTeam(TeamName.fromLabel(req.team()).getValue());
+            TeamName selectedTeam = TeamName.fromLabel(req.team());
+            matchRequirement.updateTeam(selectedTeam.getValue());
+
+            if (req.teamAllowed() != null) {
+                TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+                if (selectedTeam == TeamName.NONE && selectedAllowed != TeamAllowed.NO_PREFERENCE) {
+                    throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
+                }
+                matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
+            }
+        } else if (req.teamAllowed() != null) {
+            TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+            matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
         }
-        if (req.teamAllowed() != null) {
-            matchRequirement.updateTeamAllowed(TeamAllowed.fromLabel(req.teamAllowed()).getValue());
-        }
+
         if (req.style() != null) {
             matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
         }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -9,8 +9,13 @@ import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
+import at.mateball.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static at.mateball.exception.code.BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND;
 
 @Service
 public class MatchRequirementV2Service {
@@ -21,7 +26,8 @@ public class MatchRequirementV2Service {
     }
 
     public MatchRequirementRes getMatchRequirement(Long userId) {
-        MatchRequirement requirement = matchRequirementRepository.findUserMatchRequirement(userId);
+        MatchRequirement requirement = Optional.ofNullable(matchRequirementRepository.findUserMatchRequirement(userId))
+                .orElseThrow(() -> new BusinessException(MATCH_REQUIREMENT_NOT_FOUND));
 
         return new MatchRequirementRes(
                 TeamName.from(requirement.getTeam()).getLabel(),

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -39,7 +39,7 @@ public class MatchRequirementV2Service {
     }
 
     @Transactional
-    public void setMatchRequirement(Long userId, MatchRequirementReq req) {
+    public void updateMatchRequirement(Long userId, MatchRequirementReq req) {
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
         if (req.team() != null) {

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -1,0 +1,39 @@
+package at.mateball.domain.matchrequirement.core.service;
+
+
+import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
+import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.team.core.TeamName;
+import at.mateball.domain.user.api.dto.request.MatchRequirementReq;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MatchRequirementV2Service {
+    private final MatchRequirementRepository matchRequirementRepository;
+
+    public MatchRequirementV2Service(MatchRequirementRepository matchRequirementRepository) {
+        this.matchRequirementRepository = matchRequirementRepository;
+    }
+
+    @Transactional
+    public void setMatchRequirement(Long userId, MatchRequirementReq req) {
+        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
+
+        if (req.team() != null) {
+            matchRequirement.updateTeam(TeamName.fromLabel(req.team()).getValue());
+        }
+        if (req.teamAllowed() != null) {
+            matchRequirement.updateTeamAllowed(TeamAllowed.fromLabel(req.teamAllowed()).getValue());
+        }
+        if (req.style() != null) {
+            matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
+        }
+        if (req.genderPreference() != null) {
+            matchRequirement.updateGenderPreference(Gender.fromLabel(req.genderPreference()).getValue());
+        }
+    }
+}

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -55,6 +55,7 @@ public enum BusinessErrorCode implements ErrorCode {
     ALREADY_FAILED_REQUEST(HttpStatus.CONFLICT, "이미 요청이 실패한 매칭입니다."),
     DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다."),
     DUPLICATED_INFO(HttpStatus.BAD_REQUEST, "이미 사용자 정보가 존재합니다. 사용자 정보 설정은 최초 한 번만 가능합니다."),
+    DUPLICATED_MATCH_REQUIREMENT(HttpStatus.CONFLICT, "이미 매칭 조건이 존재합니다."),
 
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -25,6 +25,7 @@ public enum BusinessErrorCode implements ErrorCode {
     INVALID_GROUP_STATUS(HttpStatus.BAD_REQUEST, "매칭 완료 상태가 아닙니다."),
     GROUP_NOT_FOUND_OR_ALREADY_UPDATED(HttpStatus.BAD_REQUEST, "업데이트할 그룹이 없거나 이미 업데이트된 상태입니다."),
     INVALID_INTRODUCTION_LENGTH(HttpStatus.BAD_REQUEST, "한줄소개는 1자 이상 50자 이하로 입력해야 합니다."),
+    INVALID_TEAM_ALLOWED(HttpStatus.BAD_REQUEST, "'응원하는 팀이 없어요'는 '상관 없어요'만 선택가능합니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #153 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭 조건 수정뷰에서 보이는 매칭 조건 불러오기 api를 구현했습니다!
- 매칭 조건 수정에서, 사용자가 선호 팀이 없는 경우 -> 상관없어요 를 택하지 않으면 예외 처리를 하도록 설정했습니다.
- 기존 최초 매칭 조건 설정에서 중복 설정이 불가능하도록, 이미 조건이 존재하는 경우 api 를 호출하면 예외 처리를 하도록 수정했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---

- 끝? 아마도?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - v2 사용자 매치 조건 조회/수정 API 추가: 현재 설정 조회와 항목별 부분 수정 지원.
  - 응답에 팀, 팀 허용 여부, 플레이 스타일, 성별 선호가 라벨 형태로 제공되며 API 문서 한글 요약 추가.

- 리팩터
  - 매치 조건의 업데이트가 항목별 메서드로 분리되어 부분 수정이 가능해짐.

- 버그 수정
  - 특정 팀/팀 허용 조합에 대한 유효성 검사 및 관련 오류 코드/메시지 추가.
  - 동일 사용자에 대한 중복 매치 조건 생성 방지(중복 시 예외 처리).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->