### PR TITLE
[feat] 토큰 재발급

### DIFF
--- a/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
+++ b/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
@@ -8,6 +8,7 @@ import at.mateball.domain.auth.core.service.LoginService;
 import at.mateball.domain.auth.api.dto.LoginResult;
 import at.mateball.domain.auth.api.dto.LoginUserInfo;
 import at.mateball.domain.auth.core.service.LogoutService;
+import at.mateball.domain.auth.core.service.ReissueService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,11 +25,13 @@ public class OAuthController {
     private final JwtCookieProvider jwtCookieProvider;
     private final LoginService loginService;
     private final LogoutService logoutService;
+    private final ReissueService reissueService;
 
-    public OAuthController(JwtCookieProvider jwtCookieProvider, LoginService loginService, LogoutService logoutService) {
+    public OAuthController(JwtCookieProvider jwtCookieProvider, LoginService loginService, LogoutService logoutService, ReissueService reissueService) {
         this.jwtCookieProvider = jwtCookieProvider;
         this.loginService = loginService;
         this.logoutService = logoutService;
+        this.reissueService = reissueService;
     }
 
     @CustomExceptionDescription(SwaggerResponseDescription.POST_KAKAO_LOGIN)
@@ -55,6 +58,16 @@ public class OAuthController {
 
         return withCookies(expiredCookies)
                 .body(MateballResponse.successWithNoData(SuccessCode.OK));
+    }
+
+    @PostMapping("/auth/reissue")
+    public ResponseEntity<MateballResponse<?>> reissue(HttpServletRequest request) {
+        LoginResult result = reissueService.reissue(request);
+        List<ResponseCookie> cookies = jwtCookieProvider.createAllCookies(result);
+
+        LoginUserInfo userInfo = new LoginUserInfo(result.userId(), result.email());
+
+        return withCookies(cookies).body(MateballResponse.success(SuccessCode.OK, userInfo));
     }
 
     private ResponseEntity.BodyBuilder withCookies(List<ResponseCookie> cookies) {

--- a/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
@@ -1,0 +1,61 @@
+package at.mateball.domain.auth.core.service;
+
+import at.mateball.common.jwt.JwtCookieProvider;
+import at.mateball.common.jwt.JwtTokenGenerator;
+import at.mateball.domain.auth.api.dto.LoginResult;
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ReissueService {
+    private final JwtCookieProvider jwtCookieProvider;
+    private final JwtTokenGenerator jwtTokenGenerator;
+    private final TokenService tokenService;
+    private final UserRepository userRepository;
+
+    public ReissueService(JwtCookieProvider jwtCookieProvider, JwtTokenGenerator jwtTokenGenerator, TokenService tokenService, UserRepository userRepository) {
+        this.jwtCookieProvider = jwtCookieProvider;
+        this.jwtTokenGenerator = jwtTokenGenerator;
+        this.tokenService = tokenService;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public LoginResult reissue(HttpServletRequest request) {
+        String refreshToken = jwtCookieProvider.extractRefreshToken(request);
+
+        Long userId;
+
+        try {
+            userId = jwtTokenGenerator.extractUserId(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(BusinessErrorCode.EXPIRED_TOKEN);
+        }
+
+        if (!tokenService.validate(userId, refreshToken)) {
+            throw new BusinessException(BusinessErrorCode.EXPIRED_TOKEN);
+        }
+
+        String newAccessToken = jwtTokenGenerator.generateAccessToken(userId);
+        String newRefreshToken = jwtTokenGenerator.generateRefreshToken(userId);
+
+        tokenService.save(userId, newRefreshToken);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        return new LoginResult(
+                newAccessToken,
+                newRefreshToken,
+                null,
+                user.getId(),
+                user.getEmail()
+        );
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담당자를 표시해 주세요.
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #161 

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

- RefreshToken 기반 재발급 API(`/auth/reissue`) 추가
- RefreshToken 검증 후 새로운 AccessToken/RefreshToken 발급 및 쿠키 재세팅
- 만료된 RefreshToken인 경우 `401 Unauthorized` 반환 → 재로그인 강제
- TokenService/Redis 저장 로직 분리 및 ReissueService에서 토큰 재발급 책임 담당

<br/>

### ❤️ To 다진 / To 헤음

---

- 클라이언트는 API 요청 시 `EXPIRED_TOKEN` 응답을 받으면,  
  1) 먼저 `/auth/reissue` 호출 시도  
  2) `/auth/reissue` 마저 실패한다면 → 자동으로 `/auth/login` 페이지로 redirect  
- 이렇게 하면 AccessToken 만료는 갱신되고, RefreshToken 만료는 재로그인으로 이어져 UX가 매끄럽게 유지됩니다.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 세션 갱신 기능 추가: /auth/reissue 엔드포인트를 통해 만료(예정) 시 새 액세스/리프레시 토큰을 발급하고 쿠키를 자동 갱신합니다.
  - 재로그인 없이 로그인 상태를 유지할 수 있으며, 표준 응답 형식으로 사용자 정보가 함께 제공됩니다.
  - 기존 로그인/로그아웃 흐름에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->