### PR TITLE
[feat] 알림 읽음 처리

### DIFF
--- a/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
+++ b/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
@@ -7,9 +7,7 @@ import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.exception.code.SuccessCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v2/users")
@@ -30,5 +28,17 @@ public class AlarmController {
         AlarmRes alarmRes = new AlarmRes(hasUnreadAlarm);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, alarmRes));
+    }
+
+    @PostMapping("/alarm/{matchId}")
+    public ResponseEntity<MateballResponse<?>> updateAlarm(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        alarmService.updateAlarm(userId, matchId);
+
+        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.OK));
     }
 }

--- a/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
+++ b/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
@@ -39,6 +39,6 @@ public class AlarmController {
 
         alarmService.updateAlarm(userId, matchId);
 
-        return ResponseEntity.ofNullable(MateballResponse.successWithNoData(SuccessCode.OK));
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
     }
 }

--- a/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
+++ b/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
@@ -21,4 +22,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
                                   @Param("types") List<AlarmType> types);
 
     boolean existsByUserIdAndIsReadFalse(Long userId);
+
+    List<Alarm> findAllByUserIdAndGroupId(Long userId, Long groupId);
 }

--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -49,4 +49,13 @@ public class AlarmService {
     public boolean hasUnreadAlarm(Long userId) {
         return alarmRepository.existsByUserIdAndIsReadFalse(userId);
     }
+
+    @Transactional
+    public void updateAlarm(Long userId, Long matchId) {
+        List<Alarm> alarms = alarmRepository.findAllByUserIdAndGroupId(userId, matchId);
+        if (alarms.isEmpty()) {
+            throw new BusinessException(BusinessErrorCode.ALARM_NOT_FOUND);
+        }
+        alarms.forEach(Alarm::markAsRead);
+    }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -14,6 +14,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/v2/users")

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -17,10 +17,10 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/v2/users")
-public class UserV2Contrller {
+public class UserV2Controller {
     private final UserV2Service userV2Service;
 
-    public UserV2Contrller(UserV2Service userV2Service) {
+    public UserV2Controller(UserV2Service userV2Service) {
         this.userV2Service = userV2Service;
     }
 

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller

--- a/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/request/UserInfoV2Req.java
@@ -10,7 +10,11 @@ public record UserInfoV2Req(
         String introduction,
 
         @NotNull
+<<<<<<< HEAD
         Integer birthYear,
+=======
+        int birthYear,
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
 
         @NotNull
         String gender

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -3,9 +3,13 @@ package at.mateball.domain.user.core.service;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
 <<<<<<< HEAD
+<<<<<<< HEAD
 import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
 =======
 >>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
+=======
+import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
+>>>>>>> 837ff2c ([feat/#152] 사용자 정보 수정 api 구현)
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
@@ -15,11 +19,14 @@ import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
+<<<<<<< HEAD
 =======
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 >>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
+=======
+>>>>>>> 837ff2c ([feat/#152] 사용자 정보 수정 api 구현)
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,11 +93,15 @@ public class UserV2Service {
     }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 837ff2c ([feat/#152] 사용자 정보 수정 api 구현)
     @Transactional
     public void editUserInfo(Long userId, @Valid EditUserInfoReq req) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
+<<<<<<< HEAD
         UserInfoField field = UserInfoField.fromLabel(req.field());
         switch (field) {
             case NICKNAME -> {
@@ -107,6 +118,20 @@ public class UserV2Service {
 
 =======
 >>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
+=======
+        switch (req.field()) {
+            case "닉네임" -> {
+                validateNickname(req.value());
+                user.updateNickname(req.value());
+            }
+            case "소개" -> {
+                validateIntroduction(req.value());
+                user.updateIntroduction(req.value());
+            }
+        }
+    }
+
+>>>>>>> 837ff2c ([feat/#152] 사용자 정보 수정 api 구현)
     private void validateNickname(String nickname) {
         NicknameValidator.validate(nickname);
         if (userRepository.existsByNickname(nickname)) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -2,15 +2,24 @@ package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
+<<<<<<< HEAD
 import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
+=======
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.UserInfoField;
 import at.mateball.domain.user.core.repository.UserRepository;
+<<<<<<< HEAD
 import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
+=======
+import at.mateball.domain.user.core.validator.NicknameValidator;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
 import jakarta.validation.Valid;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +34,11 @@ public class UserV2Service {
     private final AlarmService alarmService;
 
     private static final Integer LIMIT_AGE = 19;
+<<<<<<< HEAD
+=======
+    private static final Integer MIN_INTRODUCTION_LENGTH = 1;
+    private static final Integer MAX_INTRODUCTION_LENGTH = 50;
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
     private static final String DEFAULT_PROFILE_IMAGE_URL =
             "https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg";
 
@@ -54,10 +68,13 @@ public class UserV2Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
+<<<<<<< HEAD
         if (user.getNickname() != null || user.getIntroduction() != null || user.getBirthYear() != null || user.getGender() != null) {
             throw new BusinessException(DUPLICATED_INFO);
         }
 
+=======
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
         validateNickname(req.nickname());
         validateIntroduction(req.introduction());
         validateAge(req.birthYear());
@@ -68,6 +85,7 @@ public class UserV2Service {
         user.updateProfileImage(DEFAULT_PROFILE_IMAGE_URL);
     }
 
+<<<<<<< HEAD
     @Transactional
     public void editUserInfo(Long userId, @Valid EditUserInfoReq req) {
         User user = userRepository.findById(userId)
@@ -87,6 +105,8 @@ public class UserV2Service {
         }
     }
 
+=======
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
     private void validateNickname(String nickname) {
         NicknameValidator.validate(nickname);
         if (userRepository.existsByNickname(nickname)) {
@@ -95,7 +115,13 @@ public class UserV2Service {
     }
 
     private void validateIntroduction(String introduction) {
+<<<<<<< HEAD
         IntroductionValidator.validate(introduction);
+=======
+        if (introduction == null || introduction.isBlank() || introduction.length() < MIN_INTRODUCTION_LENGTH || introduction.length() > MAX_INTRODUCTION_LENGTH) {
+            throw new BusinessException(BusinessErrorCode.INVALID_INTRODUCTION_LENGTH);
+        }
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
     }
 
     private void validateAge(int birthYear) {

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -25,7 +25,10 @@ public enum BusinessErrorCode implements ErrorCode {
     INVALID_GROUP_STATUS(HttpStatus.BAD_REQUEST, "매칭 완료 상태가 아닙니다."),
     GROUP_NOT_FOUND_OR_ALREADY_UPDATED(HttpStatus.BAD_REQUEST, "업데이트할 그룹이 없거나 이미 업데이트된 상태입니다."),
     INVALID_INTRODUCTION_LENGTH(HttpStatus.BAD_REQUEST, "한줄소개는 1자 이상 50자 이하로 입력해야 합니다."),
+<<<<<<< HEAD
     INVALID_TEAM_ALLOWED(HttpStatus.BAD_REQUEST, "'응원하는 팀이 없어요'는 '상관 없어요'만 선택가능합니다."),
+=======
+>>>>>>> 29c4d6b ([feat/#152] 온보딩 회원 정보 설정 api 구현)
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담당자를 표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---
closed #157 

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---
- 컨트롤러에서 받은 사용자 ID와 매치 ID를 기준으로 알람 조회
- 동일한 조건의 알람이 여러 개 존재할 수 있어(일대일의 경우 새요청과 매칭완료가 동시에 일어나서 같은 그룹에 2개의 알림 상태가 존재) `findAllByUserIdAndGroupId`로 조회 후 일괄 `isRead = true` 처리
- 조회된 알람이 없으면 `BusinessException(ALARM_NOT_FOUND)` 발생

<br/>

### ❤️ To 다진 / To 헤음

---

- 아자아자....


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 특정 경기와 관련된 알림을 한 번에 ‘읽음’으로 처리할 수 있도록 기능을 추가했습니다. 로그인한 사용자가 해당 경기에 대한 모든 알림을 간편하게 정리할 수 있습니다.
  * 알림이 존재하지 않는 경우 적절한 안내가 제공되어, 알림 상태 관리의 일관성과 사용 편의성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->