### PR TITLE
[fix] 서버 1차 스프린트 자체 qa 수정

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/Style.java
@@ -8,9 +8,9 @@ import java.util.Arrays;
 
 @Getter
 public enum Style {
-    PASSIONATE_SUPPORTER(1, "열정응원러"),
-    FOCUSED_VIEWER(2, "경기집중러"),
-    FOODIE_VIEWER(3, "직관먹방러");
+    PASSIONATE_SUPPORTER(1, "열정 응원러"),
+    FOCUSED_VIEWER(2, "경기 집중러"),
+    FOODIE_VIEWER(3, "직관 먹방러");
 
     private final int value;
     private final String label;

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @Getter
 public enum TeamAllowed {
     SAME_TEAM_ONLY(1, "같은 팀 메이트와 보고 싶어요"),
-    NO_PREFERENCE(2, "상관 없어요");
+    NO_PREFERENCE(2, "상관없어요");
 
     private final int value;
     private final String label;

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -58,7 +58,7 @@ public class UserV2Controller {
         Long userId = customUserDetails.getUserId();
         userV2Service.createUserInfo(userId, userInfoReq);
 
-        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
     }
 
     @PutMapping("/info")


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #164 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---



<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 사용자 노출 라벨 표기 개선: “열정 응원러”, “경기 집중러”, “직관 먹방러”로 공백 정비
  - 팀 선호 라벨을 “상관없어요”로 통일

- 기타
  - 사용자 생성 응답 본문의 성공 코드를 CREATED로 조정(HTTP 상태 코드는 그대로 유지)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->