### PR TITLE
[feat] 일대일/그룹 매칭 조회에서 경기가 없을 경우 예외 처리

### DIFF
--- a/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/repository/GameInformationRepository.java
@@ -7,4 +7,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface GameInformationRepository extends JpaRepository<GameInformation, Long>, GameInformationRepositoryCustom {
+    boolean existsByGameDate(LocalDate date);
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -368,7 +368,7 @@ public class GroupService {
     }
 
     private void validateGameExists(LocalDate date) {
-        if (gameInformationRepository.findByGameDate(date).isEmpty()) {
+        if (!gameInformationRepository.existsByGameDate(date)) {
             throw new BusinessException(NO_GAME_SCHEDULED);
         }
     }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.group.core.service;
 
+import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
@@ -35,12 +36,14 @@ import static at.mateball.domain.group.core.MatchType.DIRECT;
 import static at.mateball.domain.group.core.MatchType.GROUP;
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
 import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
+import static at.mateball.exception.code.BusinessErrorCode.NO_GAME_SCHEDULED;
 
 @Service
 public class GroupService {
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final MatchRequirementService matchRequirementService;
+    private final GameInformationRepository gameInformationRepository;
     private final GroupExecutor groupExecutor;
     private final AgeValidator ageValidator;
 
@@ -48,10 +51,11 @@ public class GroupService {
     private final static int MAX_GROUP_COUNT = 2;
     private final static int TOTAL_GROUP_MEMBER = 4;
 
-    public GroupService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, GroupExecutor groupExecutor, AgeValidator ageValidator) {
+    public GroupService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, GameInformationRepository gameInformationRepository, GroupExecutor groupExecutor, AgeValidator ageValidator) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.matchRequirementService = matchRequirementService;
+        this.gameInformationRepository = gameInformationRepository;
         this.groupExecutor = groupExecutor;
         this.ageValidator = ageValidator;
     }
@@ -71,6 +75,7 @@ public class GroupService {
     }
 
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
+        validateGameExists(date);
         validate(date);
 
         List<DirectGetBaseRes> result = groupRepository.findDirectGroupsByDate(userId, date);
@@ -169,10 +174,10 @@ public class GroupService {
     }
 
     public GroupGetListRes getGroups(Long userId, LocalDate date) {
+        validateGameExists(date);
         validate(date);
 
         List<GroupGetBaseRes> groupBases = groupRepository.findGroupsWithBaseInfo(userId, date);
-
         List<GroupGetBaseRes> filtered = groupBases.stream()
                 .filter(groupBase -> ageValidator.isAgeWithinRange(userId, groupBase.birthYear()))
                 .filter(groupBase ->
@@ -359,6 +364,12 @@ public class GroupService {
     private void validateMatchType(String matchType) {
         if (!String.valueOf(GROUP).equalsIgnoreCase(matchType) && !String.valueOf(DIRECT).equalsIgnoreCase(matchType)) {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MATCH_TYPE);
+        }
+    }
+
+    private void validateGameExists(LocalDate date) {
+        if (gameInformationRepository.findByGameDate(date).isEmpty()) {
+            throw new BusinessException(NO_GAME_SCHEDULED);
         }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -75,8 +75,8 @@ public class GroupService {
     }
 
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
-        validateGameExists(date);
         validate(date);
+        validateGameExists(date);
 
         List<DirectGetBaseRes> result = groupRepository.findDirectGroupsByDate(userId, date);
 
@@ -174,8 +174,8 @@ public class GroupService {
     }
 
     public GroupGetListRes getGroups(Long userId, LocalDate date) {
-        validateGameExists(date);
         validate(date);
+        validateGameExists(date);
 
         List<GroupGetBaseRes> groupBases = groupRepository.findGroupsWithBaseInfo(userId, date);
         List<GroupGetBaseRes> filtered = groupBases.stream()

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -49,6 +49,7 @@ public enum BusinessErrorCode implements ErrorCode {
     MATCH_REQUIREMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "매칭 조건 정보가 존재하지 않습니다."),
     CHATTING_NOT_FOUND(HttpStatus.NOT_FOUND, "오픈채팅이 존재하지 않습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
+    NO_GAME_SCHEDULED(HttpStatus.NOT_FOUND, "선택한 날짜에 경기가 존재하지 않습니다."),
 
     // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #166 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 일대일/그룹 매칭 조회 api 에서 경기가 없을 경우 예외처리가 되도록 로직을 추가했습니다.
- 경기 없을 경우 404 에러가 내려가도록 설정했는데, 클라에서 분기처리할 때 괜찮은지 디코에 질문 남긴 상태이여요!!

<br/>


### ❤️ To 다진 / To 헤음

---

- 이..이것만 하면 되는게 맞나.. 불안불안..핑...
- 진짜 기존 api 에 로직 하나만 추가된거라서 굳이 v2 로 안옮겼는데 옮겨야할가요???

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 그룹 조회 및 직접 매칭 조회 시 선택한 날짜에 경기가 없으면 요청을 즉시 거부하고 404 Not Found를 반환합니다. 오류 메시지: “선택한 날짜에 경기가 존재하지 않습니다.”
  - 조회 전 경기 존재 여부를 확인하는 사전 검증이 도입되어 일관된 응답을 제공합니다.
- 버그 수정
  - 일정이 없는 날짜로 조회할 때의 불명확한 처리 흐름을 제거하여 실패 응답이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->