### PR TITLE
[feat] 닉네임 중복 조회 api 구현

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -10,14 +10,11 @@ import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequestMapping("/v2/users")
@@ -71,5 +68,17 @@ public class UserV2Controller {
         userV2Service.editUserInfo(userId, editUserInfoReq);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "닉네임 중복 조회 api")
+    public ResponseEntity<MateballResponse<?>> createUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @RequestParam String nickname
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userV2Service.checkIsNicknameExists(nickname);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -10,6 +10,7 @@ import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -74,7 +75,7 @@ public class UserV2Controller {
     @Operation(summary = "닉네임 중복 조회 api")
     public ResponseEntity<MateballResponse<?>> createUserInfo(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @NotNull @RequestParam String nickname
+            @NotBlank @RequestParam String nickname
     ) {
         Long userId = customUserDetails.getUserId();
         userV2Service.checkIsNicknameExists(nickname);

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -13,6 +13,7 @@ import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -115,7 +116,7 @@ public class UserV2Service {
         }
     }
 
-    public void checkIsNicknameExists(@NotNull String nickname) {
+    public void checkIsNicknameExists(@NotBlank String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new BusinessException(DUPLICATED_NICKNAME);
         }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -13,6 +13,7 @@ import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -95,9 +96,7 @@ public class UserV2Service {
 
     private void validateNickname(String nickname) {
         NicknameValidator.validate(nickname);
-        if (userRepository.existsByNickname(nickname)) {
-            throw new BusinessException(DUPLICATED_NICKNAME);
-        }
+        checkIsNicknameExists(nickname);
     }
 
     private void validateIntroduction(String introduction) {
@@ -113,6 +112,12 @@ public class UserV2Service {
         int age = LocalDate.now().getYear() - birthYear;
         if (age < LIMIT_AGE) {
             throw new BusinessException(AGE_NOT_APPROPRIATE);
+        }
+    }
+
+    public void checkIsNicknameExists(@NotNull String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(DUPLICATED_NICKNAME);
         }
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #168 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 닉네임 중복 여부 확인 후, 중복 닉네임 존재시 409 에러 내려줍니당!

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GET /v2/users/info 엔드포인트 추가: 인증된 사용자가 쿼리 파라미터로 닉네임을 전달해 중복 여부를 즉시 확인할 수 있습니다. 중복인 경우 오류 응답, 중복이 아닐 경우 본문 없는 성공 응답을 반환하여 회원가입 및 프로필 수정 시 닉네임 확인 절차를 더 빠르고 명확하게 처리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->