### PR TITLE
[fix] "같은 팀 메이트" 를 입력하면 기존 enum 값과 매칭되도록 로직 추가

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
@@ -27,20 +27,11 @@ public enum TeamAllowed {
     }
 
     public static TeamAllowed fromLabel(String label) {
+        if ("같은 팀 메이트".equalsIgnoreCase(label)) {
+            return SAME_TEAM_ONLY;
+        }
         return Arrays.stream(values())
                 .filter(e -> e.label.equalsIgnoreCase(label))
-                .findFirst()
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
-    }
-
-    public static TeamAllowed fromLabelStrict(String input) {
-        return Arrays.stream(values())
-                .filter(e -> {
-                    if (e == SAME_TEAM_ONLY) {
-                        return "같은 팀 메이트".equalsIgnoreCase(input.strip());
-                    }
-                    return false;
-                })
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
@@ -31,7 +31,7 @@ public enum TeamAllowed {
             return SAME_TEAM_ONLY;
         }
         return Arrays.stream(values())
-                .filter(e -> e.label.equalsIgnoreCase(label))
+                .filter(e -> e.label.equals(label))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/constant/TeamAllowed.java
@@ -32,4 +32,16 @@ public enum TeamAllowed {
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
+
+    public static TeamAllowed fromLabelStrict(String input) {
+        return Arrays.stream(values())
+                .filter(e -> {
+                    if (e == SAME_TEAM_ONLY) {
+                        return "같은 팀 메이트".equalsIgnoreCase(input.strip());
+                    }
+                    return false;
+                })
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -47,14 +47,14 @@ public class MatchRequirementV2Service {
             matchRequirement.updateTeam(selectedTeam.getValue());
 
             if (req.teamAllowed() != null) {
-                TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+                TeamAllowed selectedAllowed = TeamAllowed.fromLabelStrict(req.teamAllowed());
                 if (selectedTeam == TeamName.NONE && selectedAllowed != TeamAllowed.NO_PREFERENCE) {
                     throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
                 }
                 matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
             }
         } else if (req.teamAllowed() != null) {
-            TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+            TeamAllowed selectedAllowed = TeamAllowed.fromLabelStrict(req.teamAllowed());
             matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
         }
 

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV2Service.java
@@ -47,14 +47,14 @@ public class MatchRequirementV2Service {
             matchRequirement.updateTeam(selectedTeam.getValue());
 
             if (req.teamAllowed() != null) {
-                TeamAllowed selectedAllowed = TeamAllowed.fromLabelStrict(req.teamAllowed());
+                TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
                 if (selectedTeam == TeamName.NONE && selectedAllowed != TeamAllowed.NO_PREFERENCE) {
                     throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
                 }
                 matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
             }
         } else if (req.teamAllowed() != null) {
-            TeamAllowed selectedAllowed = TeamAllowed.fromLabelStrict(req.teamAllowed());
+            TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
             matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
         }
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #170

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- `fromLabelStrict` 메서드를 통해 "같은 팀 메이트" 를 입력하면 기존 enum 값과 매칭될 수 있도록 수정했습니다!
- 기존 enum 값을 수정하지 않은 이유는, 온보딩에서 매칭 조건 설정 시에는 기존 enum 값이 그대로 활용되고 있기 때문입니다!


<br/>


### ❤️ To 다진 / To 헤음

---
- 로직이 너무.. 1차원적인가 싶은데 리드님이 보시기엔 어떠신가요..? 원래는 startWith 를 사용하려했는데 이렇게 되면 "같은 팀" 만 입력해도 기존 enum 값에 매칭되므로 해당 방법을 사용했습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 한국어 라벨 "같은 팀 메이트"가 항상 올바르게 같은 팀 전용 옵션으로 매핑되도록 수정했습니다.
  * 나머지 라벨 비교는 이제 대소문자를 구분하여 더 엄격하게 처리되어, 선택·검색·필터 동작이 일관되게 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->