### PR TITLE
[fix] 월요일 예외처리 로직 주석처리 및 plusDays 월요일로 조정

### DIFF
--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -22,19 +22,16 @@ public class GameInformationService {
 
     public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
         validate(date);
-        validateGameExists(date);
 
         List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
                 .stream()
                 .map(GameInformationRes::from)
                 .toList();
 
-        return new GameInformationsRes(list);
-    }
-
-    private void validateGameExists(LocalDate date) {
-        if (!gameInformationRepository.existsByGameDate(date)) {
+        if (list.isEmpty()) {
             throw new BusinessException(NO_GAME_SCHEDULED);
         }
+
+        return new GameInformationsRes(list);
     }
 }

--- a/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
+++ b/src/main/java/at/mateball/domain/gameinformation/core/service/GameInformationService.java
@@ -3,6 +3,7 @@ package at.mateball.domain.gameinformation.core.service;
 import at.mateball.domain.gameinformation.api.dto.response.GameInformationRes;
 import at.mateball.domain.gameinformation.api.dto.response.GameInformationsRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
+import at.mateball.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
+import static at.mateball.exception.code.BusinessErrorCode.NO_GAME_SCHEDULED;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,7 @@ public class GameInformationService {
 
     public GameInformationsRes getGameInformation(Long userId, LocalDate date) {
         validate(date);
+        validateGameExists(date);
 
         List<GameInformationRes> list = gameInformationRepository.findByGameDate(date)
                 .stream()
@@ -27,5 +30,11 @@ public class GameInformationService {
                 .toList();
 
         return new GameInformationsRes(list);
+    }
+
+    private void validateGameExists(LocalDate date) {
+        if (!gameInformationRepository.existsByGameDate(date)) {
+            throw new BusinessException(NO_GAME_SCHEDULED);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
+++ b/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
@@ -14,9 +14,9 @@ public class DateValidator {
     public static void validate(LocalDate date) {
         LocalDate today = LocalDate.now();
 
-        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
-        }
+//        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
+//            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
+//        }
 
         if (date.isBefore(today)) {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
@@ -24,7 +24,8 @@ public class DateValidator {
 
         LocalDate minAvailableDate = today.plusDays(2);
         if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
-            minAvailableDate = today.plusDays(3);
+            minAvailableDate = today.plusDays(2);
+//                        minAvailableDate = today.plusDays(3);
         }
 
         if (date.isBefore(minAvailableDate)) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #172 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- `DateValidator` 에서 사용되던 월요일 예외처리 코드를 주석처리했습니다.
- 경기정보 조회 api 에 선택한 날짜에 경기가 존재하지 않습니다. 예외를 추가했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---

- 아으 급하게 하려니 헷갈리네요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 게임 정보 조회 시 해당 날짜에 일정이 없으면 빈 결과 대신 명확한 오류를 반환합니다.

- 버그 수정
  - 월요일 선택 제한을 해제했습니다.
  - 최소 예약 가능일 계산을 요일과 무관하게 ‘오늘+2일’로 일관 적용합니다.
  - 날짜 검증 흐름을 개선해 잘못된 요청에 대한 예외 처리를 명확히 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->