### PR TITLE
[feat] 매칭 제거

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV2Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV2Controller.java
@@ -35,4 +35,16 @@ public class GroupV2Controller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "클라이언트용 사용자 매칭 모두 제거하는 api")
+    public ResponseEntity<MateballResponse<?>> deleteMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        groupV2Service.delelteMatch(userId);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
+    }
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
@@ -3,8 +3,18 @@ package at.mateball.domain.group.core.repository;
 import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.repository.querydsl.GroupRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long>, GroupRepositoryCustom {
+    /**
+     * leader(User) 엔티티 내부의 id(user_id) 기준으로 삭제
+     * 실제 SQL: delete from match_group where user_id = ?
+     */
+    @Modifying
+    @Query("delete from Group g where g.leader.id = :userId")
+    void deleteAllByLeaderId(@Param("userId") Long userId);
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -390,4 +390,9 @@ public class GroupV2Service {
         Chatting chatting = group.getChatting();
         return new ChattingRes(chatting.getChattingUrl());
     }
+
+    @Transactional
+    public void delelteMatch(Long userId) {
+        groupRepository.deleteAllByLeaderId(userId);
+    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #174 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 사용자가 생성한 매칭만 디비에서 지우도록 설정


<br/>


### ❤️ To 다진 / To 헤음

---

- 정말 잠시잠간 쓸거라 쿼리 dsl까지 사용하지 않고 jpa로 해결했슴당!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 인증된 사용자가 본인의 매칭 기록을 일괄 삭제할 수 있는 삭제 기능이 추가되었습니다.
  - 전용 삭제 엔드포인트를 통해 즉시 처리되며, 성공 여부만 간단히 응답합니다.
  - 기존 기능에는 영향이 없으며, 동일한 인증 흐름을 따릅니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->