### PR TITLE
[fix] 매칭 실패 로직 변경

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -344,7 +344,7 @@ public class GroupService {
         }
 
         Long requesterId = members.stream()
-                .filter(member -> member.status() == GroupMemberStatus.AWAITING_APPROVAL.getValue())
+                .filter(member -> !member.isParticipant())
                 .map(RejectGroupMemberBaseRes::userId)
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/RejectGroupMemberBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/RejectGroupMemberBaseRes.java
@@ -2,6 +2,7 @@ package at.mateball.domain.groupmember.api.dto.base;
 
 public record RejectGroupMemberBaseRes(
         Long userId,
-        int status
+        int status,
+        boolean isParticipant
 ) {
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -522,7 +522,8 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .select(Projections.constructor(
                         RejectGroupMemberBaseRes.class,
                         groupMember.user.id,
-                        groupMember.status
+                        groupMember.status,
+                        groupMember.isParticipant
                 ))
                 .from(groupMember)
                 .where(groupMember.group.id.eq(groupId))


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #177 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---



<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 그룹 멤버 관련 응답에 isParticipant 필드가 추가되어, 사용자 참여 여부를 함께 확인할 수 있습니다.
  - 조회 결과에 참여 여부가 포함되어 클라이언트 화면/로직에서 더 풍부한 상태 표시가 가능합니다.
- 버그 수정
  - 그룹 요청 거절 처리 시 요청자 식별 로직을 개선하여 잘못된 사용자 대상으로 처리되는 사례를 줄였습니다.
- 문서
  - API 응답 스키마 변화(필드 추가)에 대한 안내가 필요합니다. 클라이언트는 새 필드 처리에 대비해 업데이트하십시오.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->