### PR TITLE
[fix] 리스트 조회 시 인원수 -1 로직 삭제

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
@@ -56,7 +56,7 @@ public class GroupMemberV2Service {
         List<GroupStatusResV2> result = baseResList.stream()
                 .map(base -> GroupStatusResV2.from(
                         base,
-                        countMap.getOrDefault(base.id(), 0) - 1,
+                        countMap.getOrDefault(base.id(), 0),
                         imgMap.getOrDefault(base.id(), List.of()),
                         userId
                 ))
@@ -78,7 +78,7 @@ public class GroupMemberV2Service {
         List<GroupStatusResV2> result = baseResList.stream()
                 .map(base -> GroupStatusResV2.from(
                         base,
-                        countMap.getOrDefault(base.id(), 0) - 1,
+                        countMap.getOrDefault(base.id(), 0),
                         imgMap.getOrDefault(base.id(), List.of()),
                         userId
                 ))


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #179 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 `전체 인원수-1` 로직을 전체 인원수로 내려주도록 변경했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 그룹 상태 화면(V2)에서 표시되는 인원 수가 실제와 일치하도록 수정했습니다. 이전에 1명 적게 표시되던 문제가 해결되었습니다.
  * 전체 상태 보기와 특정 상태별 보기 모두에서 인원 수가 정확히 계산되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->