### PR TITLE
[fix] api호출 시, userId  반환되도록 수정

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV2Controller.java
@@ -6,12 +6,12 @@ import at.mateball.domain.user.api.dto.request.AcceptedReq;
 import at.mateball.domain.user.api.dto.request.EditUserInfoReq;
 import at.mateball.domain.user.api.dto.request.UserInfoV2Req;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
+import at.mateball.domain.user.api.dto.response.UserIdRes;
 import at.mateball.domain.user.core.service.UserV2Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -54,9 +54,10 @@ public class UserV2Controller {
             @Valid @RequestBody UserInfoV2Req userInfoReq
     ) {
         Long userId = customUserDetails.getUserId();
+        UserIdRes userIdRes = new UserIdRes(userId);
         userV2Service.createUserInfo(userId, userInfoReq);
 
-        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.CREATED, userIdRes));
     }
 
     @PutMapping("/info")

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserIdRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserIdRes.java
@@ -1,0 +1,7 @@
+package at.mateball.domain.user.api.dto.response;
+
+
+public record UserIdRes(
+        Long userId
+) {
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #181

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 클라 요청에 따라, 정보 설정 api 호출했을 때, userId 값이 함께 반환되도록 수정했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자 정보 생성(POST /info) 요청의 응답 본문에 userId가 포함됩니다.  
  - 새로운 응답 DTO가 추가되어 생성된 사용자 식별자를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->