### PR TITLE
[refactor] 그룹매칭 알림

### DIFF
--- a/src/main/java/at/mateball/domain/alarm/core/Alarm.java
+++ b/src/main/java/at/mateball/domain/alarm/core/Alarm.java
@@ -44,4 +44,8 @@ public class Alarm {
     public void markAsRead() {
         this.isRead = true;
     }
+
+    public void markAsUnread() {
+        this.isRead = false;
+    }
 }

--- a/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
+++ b/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
@@ -24,4 +24,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     boolean existsByUserIdAndIsReadFalse(Long userId);
 
     List<Alarm> findAllByUserIdAndGroupId(Long userId, Long groupId);
+
+    Optional<Alarm> findByUserIdAndGroupIdAndType(Long userId, Long groupId, AlarmType type);
 }

--- a/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
+++ b/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
@@ -20,6 +20,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
             "WHERE a.user.id = :userId AND a.type IN :types AND a.isRead = false")
     void markAsReadByUserAndTypes(@Param("userId") Long userId,
                                   @Param("types") List<AlarmType> types);
-    
+
+    boolean existsByUserIdAndIsReadFalse(Long userId);
+
     List<Alarm> findAllByUserIdAndGroupId(Long userId, Long groupId);
 }

--- a/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
+++ b/src/main/java/at/mateball/domain/alarm/core/repository/AlarmRepository.java
@@ -20,8 +20,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
             "WHERE a.user.id = :userId AND a.type IN :types AND a.isRead = false")
     void markAsReadByUserAndTypes(@Param("userId") Long userId,
                                   @Param("types") List<AlarmType> types);
-
-    boolean existsByUserIdAndIsReadFalse(Long userId);
-
+    
     List<Alarm> findAllByUserIdAndGroupId(Long userId, Long groupId);
 }

--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -33,23 +33,6 @@ public class AlarmService {
         alarmRepository.save(alarm);
     }
 
-
-    @Transactional
-    public void markAsRead(Long alarmId) {
-        Alarm alarm = alarmRepository.findById(alarmId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.ALARM_NOT_FOUND));
-        alarm.markAsRead();
-    }
-
-    @Transactional(readOnly = true)
-    public List<Alarm> getUnreadAlarms(Long userId) {
-        return alarmRepository.findByUserIdAndIsReadFalse(userId);
-    }
-
-    public boolean hasUnreadAlarm(Long userId) {
-        return alarmRepository.existsByUserIdAndIsReadFalse(userId);
-    }
-
     @Transactional
     public void updateAlarm(Long userId, Long matchId) {
         List<Alarm> alarms = alarmRepository.findAllByUserIdAndGroupId(userId, matchId);

--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -45,4 +45,20 @@ public class AlarmService {
         }
         alarms.forEach(Alarm::markAsRead);
     }
+
+    @Transactional
+    public void createOrUpdateAlarm(Long userId, AlarmType type, Long groupId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        Alarm alarm = alarmRepository.findByUserIdAndGroupIdAndType(userId, groupId, type)
+                .orElse(null);
+
+        if (alarm != null) {
+            alarm.markAsUnread();
+        } else {
+            alarm = new Alarm(user, type, groupId);
+            alarmRepository.save(alarm);
+        }
+    }
 }

--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -33,6 +33,10 @@ public class AlarmService {
         alarmRepository.save(alarm);
     }
 
+    public boolean hasUnreadAlarm(Long userId) {
+        return alarmRepository.existsByUserIdAndIsReadFalse(userId);
+    }
+
     @Transactional
     public void updateAlarm(Long userId, Long matchId) {
         List<Alarm> alarms = alarmRepository.findAllByUserIdAndGroupId(userId, matchId);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -122,13 +122,13 @@ public class GroupService {
         if (group.isGroup()) {
             groupMemberRepository.updateStatusForAllParticipants(group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
         } else {
+            alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
+            alarmService.createAlarm(userId, AlarmType.MATCHED, group.getId());
+            
             groupMemberRepository.updateLeaderStatus(
                     group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue()
             );
         }
-
-        alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
-        alarmService.createAlarm(userId, AlarmType.MATCHED, group.getId());
     }
 
     private void validateRequest(Long userId, Group group) {

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -120,11 +120,19 @@ public class GroupService {
         groupMemberRepository.createGroupMember(userId, matchId);
 
         if (group.isGroup()) {
+            List<Long> participantIds = groupMemberRepository.findParticipantUserIdsByGroupId(group.getId());
+
+            if (participantIds.size() < 3) {
+                for (Long participantId : participantIds) {
+                    alarmService.createOrUpdateAlarm(participantId, AlarmType.NEW_REQUEST, group.getId());
+                }
+            }
+
             groupMemberRepository.updateStatusForAllParticipants(group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
         } else {
             alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
             alarmService.createAlarm(userId, AlarmType.MATCHED, group.getId());
-            
+
             groupMemberRepository.updateLeaderStatus(
                     group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue()
             );

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.group.core.service;
 
+import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.chatting.core.Chatting;
@@ -247,8 +248,27 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
         if (!group.isGroup()) {
             processDirect(userId, groupId);
         } else {
-
             processGroup(userId, groupId);
+
+            Long requesterId = groupMemberRepository.findApprovedRequesterUserId(groupId)
+                    .orElse(null);
+
+            if (requesterId != null) {
+                alarmService.createOrUpdateAlarm(requesterId, AlarmType.APPROVED, groupId);
+            }
+
+            Long matchedRequesterId = groupMemberRepository.findMatchedRequesterUserId(groupId)
+                    .orElse(null);
+
+            if (matchedRequesterId != null) {
+                List<Long> participantIds = groupMemberRepository.findAllParticipantUserIds(groupId);
+
+                for (Long participantId : participantIds) {
+                    if (!participantId.equals(matchedRequesterId)) {
+                        alarmService.createOrUpdateAlarm(participantId, AlarmType.MATCHED, groupId);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -261,7 +261,7 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
                     .orElse(null);
 
             if (matchedRequesterId != null) {
-                List<Long> participantIds = groupMemberRepository.findAllParticipantUserIds(groupId);
+                List<Long> participantIds = groupMemberRepository.findParticipantUserIdsByGroupId(groupId);
 
                 for (Long participantId : participantIds) {
                     if (!participantId.equals(matchedRequesterId)) {

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -244,11 +244,10 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
 
         GroupValidator.validate(group);
 
-        alarmService.updateAlarm(userId, groupId);
-
         if (!group.isGroup()) {
             processDirect(userId, groupId);
         } else {
+
             processGroup(userId, groupId);
         }
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -80,7 +80,4 @@ public interface GroupMemberRepositoryCustom {
 
     Optional<Long> findApprovedRequesterUserId(Long groupId);
 
-    Optional<Long> findMatchedRequesterUserId(Long groupId);
-
-    List<Long> findAllParticipantUserIds(Long groupId);
-}
+    Optional<Long> findMatchedRequesterUserId(Long groupId);}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -65,6 +65,7 @@ public interface GroupMemberRepositoryCustom {
     boolean updateMyStatusFromApprovedToRequest(Long userId, Long matchId);
 
     Optional<GroupMemberRes> getMatchingInfo(Long userId, Long gameId, boolean isGroup);
+
     Map<Long, List<Long>> findUserIdsGroupedByGroupIds(List<Long> groupIds);
 
     List<DirectStatusBaseResV2> findDirectMatchingsByUserAndGroupStatusV2(Long userId, int groupStatus);
@@ -76,4 +77,10 @@ public interface GroupMemberRepositoryCustom {
     List<GroupStatusBaseResV2> findGroupMatchingsByUserAndStatusV2(Long userId, int groupStatus);
 
     List<Long> findParticipantUserIdsByGroupId(Long groupId);
+
+    Optional<Long> findApprovedRequesterUserId(Long groupId);
+
+    Optional<Long> findMatchedRequesterUserId(Long groupId);
+
+    List<Long> findAllParticipantUserIds(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -74,4 +74,6 @@ public interface GroupMemberRepositoryCustom {
     List<GroupStatusBaseResV2> findGroupMatchingsByUserV2(Long userId);
 
     List<GroupStatusBaseResV2> findGroupMatchingsByUserAndStatusV2(Long userId, int groupStatus);
+
+    List<Long> findParticipantUserIdsByGroupId(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -772,4 +772,15 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 )
                 .fetch();
     }
+
+    @Override
+    public List<Long> findParticipantUserIdsByGroupId(Long groupId) {
+
+        return queryFactory
+                .select(groupMember.user.id)
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId)
+                        .and(groupMember.isParticipant.isTrue()))
+                .fetch();
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -809,14 +809,4 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
         return Optional.ofNullable(requesterId);
     }
-
-    @Override
-    public List<Long> findAllParticipantUserIds(Long groupId) {
-        return queryFactory
-                .select(groupMember.user.id)
-                .from(groupMember)
-                .where(groupMember.group.id.eq(groupId)
-                        .and(groupMember.isParticipant.isTrue()))
-                .fetch();
-    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -783,4 +783,40 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         .and(groupMember.isParticipant.isTrue()))
                 .fetch();
     }
+
+    @Override
+    public Optional<Long> findApprovedRequesterUserId(Long groupId) {
+        Long requesterId = queryFactory
+                .select(groupMember.user.id)
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId)
+                        .and(groupMember.isParticipant.isTrue())
+                        .and(groupMember.status.eq(GroupMemberStatus.APPROVED.getValue())))
+                .fetchFirst();
+
+        return Optional.ofNullable(requesterId);
+    }
+
+    @Override
+    public Optional<Long> findMatchedRequesterUserId(Long groupId) {
+        Long requesterId = queryFactory
+                .select(groupMember.user.id)
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId)
+                        .and(groupMember.isParticipant.isTrue())
+                        .and(groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())))
+                .fetchFirst();
+
+        return Optional.ofNullable(requesterId);
+    }
+
+    @Override
+    public List<Long> findAllParticipantUserIds(Long groupId) {
+        return queryFactory
+                .select(groupMember.user.id)
+                .from(groupMember)
+                .where(groupMember.group.id.eq(groupId)
+                        .and(groupMember.isParticipant.isTrue()))
+                .fetch();
+    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #176 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 그룹 매칭의 경우 매칭 요청자의 상태가 approved인 사람에세 요청 알림 생성
```
            if (requesterId != null) {
                alarmService.createOrUpdateAlarm(requesterId, AlarmType.APPROVED, groupId);
            }
```

- 매칭 요청자의 상태가 매칭완료로 된다면 요청자 제외 3명모두에게 매칭 알림 생성
```

            Long matchedRequesterId = groupMemberRepository.findMatchedRequesterUserId(groupId)
                    .orElse(null);

            if (matchedRequesterId != null) {
                List<Long> participantIds = groupMemberRepository.findAllParticipantUserIds(groupId);

                for (Long participantId : participantIds) {
                    if (!participantId.equals(matchedRequesterId)) {
                        alarmService.createOrUpdateAlarm(participantId, AlarmType.MATCHED, groupId);
                    }
                }
            }
```


### ❤️ To 다진 / To 헤음

---
내가 잘 한건지 잘모르게떠여...확인해주세요ㅠㅠ 엉엉엉엉엉엉슨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 그룹 요청·승인·매칭 흐름에서 대상자별로 알림이 자동 생성·업데이트됩니다.
  - 사용자·그룹·타입 조합으로 단일 알림을 조회해 처리하는 방식이 추가되었습니다.
- 개선
  - 알림을 읽음에서 읽지 않음으로 되돌리는 기능이 추가되어 상태 관리가 유연해졌습니다.
  - 참가자 수와 역할에 따라 불필요한 중복 알림이 줄어들고, 승인·매칭 시 정밀한 알림 전송이 이루어집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->