### PR TITLE
[feat] 카카오 프로필 가져오기

### DIFF
--- a/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
+++ b/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
@@ -43,7 +43,8 @@ public class OAuthController {
 
         LoginUserInfo userInfo = new LoginUserInfo(
                 result.userId(),
-                result.email()
+                result.email(),
+                result.profile_image()
         );
 
         return withCookies(cookies).body(MateballResponse.success(SuccessCode.OK, userInfo));
@@ -65,7 +66,7 @@ public class OAuthController {
         LoginResult result = reissueService.reissue(request);
         List<ResponseCookie> cookies = jwtCookieProvider.createAllCookies(result);
 
-        LoginUserInfo userInfo = new LoginUserInfo(result.userId(), result.email());
+        LoginUserInfo userInfo = new LoginUserInfo(result.userId(), result.email(), result.profile_image());
 
         return withCookies(cookies).body(MateballResponse.success(SuccessCode.OK, userInfo));
     }

--- a/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
+++ b/src/main/java/at/mateball/domain/auth/api/controller/OAuthController.java
@@ -44,7 +44,7 @@ public class OAuthController {
         LoginUserInfo userInfo = new LoginUserInfo(
                 result.userId(),
                 result.email(),
-                result.profile_image()
+                result.profileImage()
         );
 
         return withCookies(cookies).body(MateballResponse.success(SuccessCode.OK, userInfo));
@@ -66,7 +66,7 @@ public class OAuthController {
         LoginResult result = reissueService.reissue(request);
         List<ResponseCookie> cookies = jwtCookieProvider.createAllCookies(result);
 
-        LoginUserInfo userInfo = new LoginUserInfo(result.userId(), result.email(), result.profile_image());
+        LoginUserInfo userInfo = new LoginUserInfo(result.userId(), result.email(), result.profileImage());
 
         return withCookies(cookies).body(MateballResponse.success(SuccessCode.OK, userInfo));
     }

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
@@ -6,7 +6,7 @@ public record LoginResult(
         String kakaoAccessToken,
         Long userId,
         String email,
-        String profile_image
+        String profileImage
 ) {
 
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
@@ -5,7 +5,8 @@ public record LoginResult(
         String refreshToken,
         String kakaoAccessToken,
         Long userId,
-        String email
+        String email,
+        String profile_image
 ) {
 
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
@@ -3,5 +3,5 @@ package at.mateball.domain.auth.api.dto;
 public record LoginUserInfo(
         Long userId,
         String email,
-        String profile_image
+        String profileImage
 ) {}

--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginUserInfo.java
@@ -2,5 +2,6 @@ package at.mateball.domain.auth.api.dto;
 
 public record LoginUserInfo(
         Long userId,
-        String email
+        String email,
+        String profile_image
 ) {}

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record KakaoAccount(
 /*        String gender,
         @JsonProperty("birthyear") String birthyear*/
-        String email
+        String email,
+        @JsonProperty("profile_image_url") String profileImage
 ) {
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
@@ -6,6 +6,6 @@ public record KakaoAccount(
 /*        String gender,
         @JsonProperty("birthyear") String birthyear*/
         String email,
-        @JsonProperty("profile_image_url") String profileImage
+        KakaoProfile profile
 ) {
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoProfile.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoProfile.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.auth.api.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoProfile(
+        @JsonProperty("profile_image_url") String profileImageUrl
+) {
+
+}

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
@@ -28,15 +28,15 @@ import java.util.Optional;
 }*/
 public record KakaoUserRes(
         Long id,
-        @JsonProperty("kakao_account") KakaoAccount kakaoAccount,
-        String email,
-        String profileImage
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
 ) {
     public User toEntity() {
         return new User(
                 id,
-                kakaoAccount.email(),
-                kakaoAccount.profileImage()
+                kakaoAccount != null ? kakaoAccount.email() : null,
+                (kakaoAccount != null && kakaoAccount.profile() != null)
+                        ? kakaoAccount.profile().profileImageUrl()
+                        : null
         );
     }
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
@@ -28,12 +28,15 @@ import java.util.Optional;
 }*/
 public record KakaoUserRes(
         Long id,
-        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount,
+        String email,
+        String profileImage
 ) {
     public User toEntity() {
         return new User(
                 id,
-                kakaoAccount.email()
+                kakaoAccount.email(),
+                kakaoAccount.profileImage()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
@@ -48,6 +48,8 @@ public class LoginService {
         String accessToken = jwtTokenGenerator.generateAccessToken(user.getId());
         String refreshToken = jwtTokenGenerator.generateRefreshToken(user.getId());
 
+        user.updateProfileImage(kakaoUser.kakaoAccount().profileImage());
+
         tokenService.save(user.getId(), refreshToken);
         log.info("카카오 로그인 성공 - userId: {}", user.getId());
 
@@ -56,7 +58,8 @@ public class LoginService {
                 refreshToken,
                 kakaoToken.accessToken(),
                 user.getId(),
-                user.getEmail()
+                user.getEmail(),
+                user.getImgUrl()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
@@ -48,7 +48,11 @@ public class LoginService {
         String accessToken = jwtTokenGenerator.generateAccessToken(user.getId());
         String refreshToken = jwtTokenGenerator.generateRefreshToken(user.getId());
 
-        user.updateProfileImage(kakaoUser.kakaoAccount().profileImage());
+        String profileImageUrl = (kakaoUser.kakaoAccount() != null && kakaoUser.kakaoAccount().profile() != null)
+                ? kakaoUser.kakaoAccount().profile().profileImageUrl()
+                : null;
+
+        user.updateProfileImage(profileImageUrl);
 
         tokenService.save(user.getId(), refreshToken);
         log.info("카카오 로그인 성공 - userId: {}", user.getId());

--- a/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
@@ -55,7 +55,8 @@ public class ReissueService {
                 newRefreshToken,
                 null,
                 user.getId(),
-                user.getEmail()
+                user.getEmail(),
+                user.getImgUrl()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -12,6 +12,9 @@ import java.util.List;
 @Getter
 @Table(name = "`user`")
 public class User {
+    public static final String DEFAULT_PROFILE_IMAGE_URL =
+            "https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg";
+
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,24 +51,22 @@ public class User {
 
     }
 
-    public User(Long kakaoUserId, String email) {
+    public User(Long kakaoUserId, String email, String imgUrl) {
         this.kakaoUserId = kakaoUserId;
         this.email = email;
+        this.imgUrl = (imgUrl != null) ? imgUrl : DEFAULT_PROFILE_IMAGE_URL;
     }
 
     public void updateNickname(final String nickname) {
         this.nickname = nickname;
     }
 
-    public void updateProfileImage(String imgUrl) {
-        this.imgUrl = imgUrl;
-    }
-    public void updateIntroduction(final String introduction) {
-        this.introduction = introduction;
+    public void updateProfileImage(final String imgUrl) {
+        this.imgUrl = (imgUrl != null) ? imgUrl : DEFAULT_PROFILE_IMAGE_URL;
     }
 
-    public void updateImgUrl(final String imgUrl) {
-        this.imgUrl = imgUrl;
+    public void updateIntroduction(final String introduction) {
+        this.introduction = introduction;
     }
 
     public void updateGenderAndBirthYear(Gender gender, int birthYear) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -88,8 +88,6 @@ public class UserService {
         }
         Gender genderStatus = Gender.fromLabel(gender);
 
-        user.updateProfileImage("https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg");
-        user.updateIntroduction("메잇볼이 선택한 너");
         user.updateGenderAndBirthYear(genderStatus, birthYear);
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,9 +26,7 @@ kakao:
     authorization-grant-type: authorization_code
     redirect-uri: ${CLIENT_URL_PROD}
     scope:
-      - birthday
-      - gender
-      - email
+      - account_email
       - profile_image
 
 jwt:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,6 +28,8 @@ kakao:
     scope:
       - birthday
       - gender
+      - email
+      - profile_image
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #184

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 카카오 디벨로퍼에서 프로필 선택 동의로 설정
- 기존 로그인에서 profile_image가져올수있도록 처리
- 만약 동읨하지 않는 사용자의 경우. 기존 메잇볼 프로필 사용할수있도록 정의


<br/>


### ❤️ To 다진 / To 헤음

---

이거 테스트 하는거 찾을 갔다올게

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 로그인 및 토큰 재발급 응답에 사용자 프로필 이미지 URL이 포함됩니다.
  - 카카오 로그인 시 사용자 프로필 이미지가 자동으로 동기화되어 최신 이미지를 반영합니다.
  - 프로필 이미지가 없으면 기본 프로필 이미지가 자동 적용됩니다.
- Chores
  - 카카오 OAuth 동의 항목에 이메일과 프로필 이미지 요청을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->