### PR TITLE
[feat] 알림 전체 읽음

### DIFF
--- a/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
+++ b/src/main/java/at/mateball/domain/alarm/api/AlarmController.java
@@ -41,4 +41,15 @@ public class AlarmController {
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
     }
+
+    @PostMapping("/alarms")
+    public ResponseEntity<MateballResponse<?>> readAllAlarms(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        alarmService.readAllAlarms(userId);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.OK));
+    }
 }

--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -61,4 +61,13 @@ public class AlarmService {
             alarmRepository.save(alarm);
         }
     }
+    
+    public void readAllAlarms(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        List<Alarm> alarms = alarmRepository.findByUserIdAndIsReadFalse(userId);
+
+        alarms.forEach(Alarm::markAsRead);
+    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #186

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 해당하는 사용자의 정보를 통해 alarm테이블의 is_read=false를 찾아 모두 true로 변경하도록 처리
```
alarms.forEach(Alarm::markAsRead);
```


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 인증된 사용자의 모든 미읽은 알림을 한 번에 읽음 처리하는 새 API 엔드포인트가 추가되었습니다 (POST /v2/users/alarms). 호출 시 해당 사용자의 모든 미읽음 알림이 읽음으로 일괄 변경되며, 표준 성공 응답을 반환합니다.
  - 기존 알림 동작에는 영향이 없으며, 알림 관리가 보다 간편해집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->