### PR TITLE
[refactor] 카카오 프로필

### DIFF
--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoAccount.java
@@ -6,6 +6,9 @@ public record KakaoAccount(
 /*        String gender,
         @JsonProperty("birthyear") String birthyear*/
         String email,
-        KakaoProfile profile
+        @JsonProperty("profile") KakaoProfile profile,
+        @JsonProperty("profile_nickname_needs_agreement") boolean profileNicknameNeedsAgreement,
+        @JsonProperty("profile_image_needs_agreement") boolean profileImageNeedsAgreement
 ) {
+
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoProfile.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoProfile.java
@@ -3,7 +3,10 @@ package at.mateball.domain.auth.api.dto.kakao;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record KakaoProfile(
-        @JsonProperty("profile_image_url") String profileImageUrl
+        @JsonProperty("nickname") String nickname,
+        @JsonProperty("profile_image_url") String profileImageUrl,
+        @JsonProperty("thumbnail_image_url") String thumbnailImageUrl,
+        @JsonProperty("is_default_image") boolean isDefaultImage
 ) {
 
 }

--- a/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/kakao/KakaoUserRes.java
@@ -31,12 +31,21 @@ public record KakaoUserRes(
         @JsonProperty("kakao_account") KakaoAccount kakaoAccount
 ) {
     public User toEntity() {
-        return new User(
-                id,
-                kakaoAccount != null ? kakaoAccount.email() : null,
-                (kakaoAccount != null && kakaoAccount.profile() != null)
-                        ? kakaoAccount.profile().profileImageUrl()
-                        : null
-        );
+        String imgUrl = null;
+        if (kakaoAccount != null && kakaoAccount.profile() != null) {
+            imgUrl = kakaoAccount.profile().profileImageUrl();
+        }
+        return new User(id, kakaoAccount != null ? kakaoAccount.email() : null, imgUrl);
+    }
+
+    public String extractProfileImageUrl() {
+        if (kakaoAccount != null && kakaoAccount.profile() != null) {
+            return kakaoAccount.profile().profileImageUrl();
+        }
+        return null;
+    }
+
+    public boolean isProfileImageAgreed() {
+        return kakaoAccount != null && kakaoAccount.profileImageNeedsAgreement();
     }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
@@ -48,11 +48,12 @@ public class LoginService {
         String accessToken = jwtTokenGenerator.generateAccessToken(user.getId());
         String refreshToken = jwtTokenGenerator.generateRefreshToken(user.getId());
 
-        String profileImageUrl = (kakaoUser.kakaoAccount() != null && kakaoUser.kakaoAccount().profile() != null)
-                ? kakaoUser.kakaoAccount().profile().profileImageUrl()
-                : null;
-
-        user.updateProfileImage(profileImageUrl);
+        if (kakaoUser.isProfileImageAgreed()) {
+            String profileImageUrl = kakaoUser.extractProfileImageUrl();
+            user.updateProfileImage(profileImageUrl);
+        } else {
+            user.updateProfileImage(null);
+        }
 
         tokenService.save(user.getId(), refreshToken);
         log.info("카카오 로그인 성공 - userId: {}", user.getId());


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #188 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 카카오 JSON응답에 맞춰 로직 변경

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 시 수집 정보 확장: 닉네임, 프로필 이미지, 썸네일, 기본 이미지 여부를 지원합니다.
  - 프로필 이미지 동의 여부를 확인해, 동의한 경우에만 이미지가 반영됩니다.

- 버그 수정
  - 로그인 과정에서 동의하지 않은 프로필 이미지가 반영되던 동작을 개선했습니다. 이제 동의가 없으면 프로필 이미지를 적용하지 않거나 기존 이미지를 제거합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->