### PR TITLE
[fix] 이미지 순서 고정

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -157,6 +157,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                         groupMember.group.id.eq(matchId),
                         groupMember.isParticipant.isTrue()
                 )
+                .orderBy(groupMember.createdAt.asc())
                 .fetch();
 
         return Optional.of(GroupCreateRes.from(base, count, imgUrls));

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -4,10 +4,15 @@ import at.mateball.domain.group.core.Group;
 import at.mateball.domain.user.core.User;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Table(name = "group_member")
+@EntityListeners(AuditingEntityListener.class)
 public class GroupMember {
 
     @Id
@@ -27,6 +32,10 @@ public class GroupMember {
 
     @Column(nullable = false)
     private int status;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
 
     protected GroupMember() {
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -82,6 +82,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         member.group.id.in(groupIds),
                         member.isParticipant.isTrue()
                 )
+                .orderBy(member.createdAt.asc())
                 .fetch()
                 .stream()
                 .collect(Collectors.groupingBy(
@@ -303,7 +304,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                                 )
                                 .exists()
                 )
-                .orderBy(groupMember.id.desc())
+                .orderBy(groupMember.createdAt.asc())
                 .fetch();
     }
 
@@ -354,7 +355,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         user.id.ne(userId),
                         alreadyJoined.not()
                 )
-                .orderBy(groupMember.id.desc())
+                .orderBy(groupMember.createdAt.asc())
                 .fetch();
     }
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #190 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 이미지 리스트 반환하는 쿼리문에 `.orderBy(groupMember.createdAt.asc())` 추가하여 오름차순으로 리스트 보장


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 그룹 이미지, 참여자, 요청 목록의 정렬을 생성일 기준 오름차순으로 통일하여 표시 순서가 불안정하거나 뒤바뀌는 현상을 개선했습니다.

- 리팩터링
  - 엔터티에 생성일 자동 기록을 도입해 데이터 생성 시각을 일관되게 관리합니다.
  - 기존 ID 기반 정렬 로직을 생성일 기반으로 정비하여 목록 표시의 일관성과 예측 가능성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->