### PR TITLE
[fix] 매칭완료시 생성자 카드 중복 처리

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static at.mateball.domain.matchrequirement.core.QMatchRequirement.matchRequirement;
 
@@ -709,7 +710,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         QGameInformation gameInformation = QGameInformation.gameInformation;
         QMatchRequirement leaderMatchRequirement = new QMatchRequirement("leaderMatchRequirement");
 
-        return queryFactory
+        List<GroupStatusBaseResV2> asMember = queryFactory
                 .select(Projections.constructor(GroupStatusBaseResV2.class,
                         group.id,
                         leader.id,
@@ -726,10 +727,38 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                 .join(group.gameInformation, gameInformation)
                 .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
                 .where(
+                        group.isGroup.isTrue(),
                         groupMember.user.id.eq(userId),
-                        group.isGroup.isTrue()
+                        groupMember.user.id.ne(group.leader.id)
                 )
                 .fetch();
+
+        List<GroupStatusBaseResV2> asLeader = queryFactory
+                .select(Projections.constructor(GroupStatusBaseResV2.class,
+                        group.id,
+                        leader.id,
+                        leader.nickname,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.stadiumName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.leader, leader)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
+                .where(
+                        group.isGroup.isTrue(),
+                        leader.id.eq(userId),
+                        groupMember.user.id.eq(leader.id)
+                )
+                .fetch();
+
+        return Stream.concat(asMember.stream(), asLeader.stream())
+                .distinct()
+                .toList();
     }
 
     @Override

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -744,11 +744,11 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.gameDate,
                         groupMember.status
                 ))
+                .distinct()
                 .from(groupMember)
                 .join(groupMember.group, group)
                 .join(group.leader, leader)
                 .join(group.gameInformation, gameInformation)
-                .join(leaderMatchRequirement).on(leaderMatchRequirement.user.id.eq(leader.id))
                 .where(
                         group.isGroup.isTrue(),
                         leader.id.eq(userId),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #192 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 매칭 생성자와 요청자 분리
- 매칭 생성자의 경우 그룹 멤버의 자신의 상태 하나반 반환하도록 설정
```
// 매칭 요청자
                .where(
                        group.isGroup.isTrue(),
                        groupMember.user.id.eq(userId),
                        groupMember.user.id.ne(group.leader.id)
                )

// 매칭 생성자
                .where(
                        group.isGroup.isTrue(),
                        leader.id.eq(userId),
                        groupMember.user.id.eq(leader.id)
                )
```

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 버그 수정
  * 그룹 매칭 목록이 그룹장·일반 구성원 역할 모두에서 정확히 집계되도록 개선했습니다.
  * 그룹장과 일반 구성원에서 중복으로 표시되던 항목을 제거해 목록을 정리했습니다.
  * 비활성/유효하지 않은 그룹이 노출되던 문제를 해결해 유효한 그룹만 표시합니다.
  * 그룹 상태와 경기 정보(홈/원정 팀, 경기장, 경기 일시, 그룹원 상태)가 일관되게 표시되도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->