### PR TITLE
[fix] 매칭현황 그룹에서 상태 지정시 중복 리스트로 내려가는 오류 해결

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -799,6 +799,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         group.isGroup.isTrue(),
                         (groupMember.user.id.eq(userId)
                                 .or(group.leader.id.eq(userId))),
+                        groupMember.user.id.ne(group.leader.id),
                         statusCondition
                 )
                 .fetch();

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -789,6 +789,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.gameDate,
                         groupMember.status
                 ))
+                .distinct()
                 .from(groupMember)
                 .join(groupMember.group, group)
                 .join(group.leader, leader)


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #194 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- distinct 로 중복 제거

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 그룹 매칭 조회에서 중복 결과가 표시되던 문제를 해결하여 동일 매칭이 한 번만 노출됩니다.
  - 사용자가 그룹 리더인 경우, 구성원 측 결과에 해당 그룹이 함께 노출되던 사례를 제외해 결과 정확성과 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->