### PR TITLE
[feat] 디스코드 회원가입 연동

### DIFF
--- a/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV2Service.java
@@ -10,6 +10,7 @@ import at.mateball.domain.user.core.UserInfoField;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.domain.user.core.validator.IntroductionValidator;
 import at.mateball.domain.user.core.validator.NicknameValidator;
+import at.mateball.domain.webhook.WebhookService;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.validation.Valid;
@@ -25,15 +26,14 @@ import static at.mateball.exception.code.BusinessErrorCode.*;
 @Service
 public class UserV2Service {
     private final UserRepository userRepository;
-    private final AlarmService alarmService;
-
+    private final WebhookService webhookService;
     private static final Integer LIMIT_AGE = 19;
     private static final Integer MIN_INTRODUCTION_LENGTH = 1;
     private static final Integer MAX_INTRODUCTION_LENGTH = 50;
 
-    public UserV2Service(UserRepository userRepository, AlarmService alarmService) {
+    public UserV2Service(UserRepository userRepository, WebhookService webhookService) {
         this.userRepository = userRepository;
-        this.alarmService = alarmService;
+        this.webhookService = webhookService;
     }
 
     public InfoCheckRes getInfoCheck(Long userId) {
@@ -71,6 +71,22 @@ public class UserV2Service {
         user.updateNickname(req.nickname());
         user.updateIntroduction(req.introduction());
         user.updateGenderAndBirthYear(Gender.fromLabel(req.gender()), req.birthYear());
+
+        Long totalMembers = userRepository.count();
+        String message = String.format(
+                "✉️ 메잇볼의 %d번째 메이트 정보가 도착했어요! \n\n" +
+                        "✔️ 닉네임: %s\n" +
+                        "✔️ 성별: %s\n" +
+                        "✔️ 출생연도: %d\n" +
+                        "✔️ 소개: %s",
+                totalMembers,
+                user.getNickname(),
+                user.getGender(),
+                user.getBirthYear(),
+                user.getIntroduction()
+        );
+
+        webhookService.sendDiscordNotification(message);
     }
 
     @Transactional

--- a/src/main/java/at/mateball/domain/webhook/WebhookService.java
+++ b/src/main/java/at/mateball/domain/webhook/WebhookService.java
@@ -1,0 +1,4 @@
+package at.mateball.domain.webhook;
+
+public class WebhookService {
+}

--- a/src/main/java/at/mateball/domain/webhook/WebhookService.java
+++ b/src/main/java/at/mateball/domain/webhook/WebhookService.java
@@ -1,4 +1,45 @@
 package at.mateball.domain.webhook;
 
+import at.mateball.domain.user.core.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class WebhookService {
+
+    @Value("${discord.webhook.url}")
+    private String discordWebhookUrl;
+
+    public void sendDiscordNotification(String message) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = new HashMap<>();
+        body.put("content", message);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        try {
+            restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+            log.info("Discord Webhook 전송 성공: {}", message);
+        } catch (Exception e) {
+            log.error("Discord Webhook 전송 실패", e);
+        }
+    }
 }
+

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,3 +51,7 @@ cloud:
       instance-profile: true
     stack:
       auto: false
+
+discord:
+  webhook:
+    url: ${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #196 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- yaml에 웹훅 주소 추가
- 웹훅서비스 추가 후 온보딩 시 사용자 생성 알림


### ❤️ To 다진 / To 헤음

---

- yaml파일이 변경되었습니다
- To.me 재배포할때 env파일 바꿔서 배포하기!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 새 사용자 생성 시 디스코드 채널로 환영/프로필 요약 알림 전송(닉네임, 성별, 출생연도, 소개, 총 회원수 포함).

- 리팩터
  - 내부 알림 의존성을 웹훅 기반 알림으로 교체하여 외부 채널 연동을 단순화.

- 작업
  - 프로덕션 설정에 웹훅 URL 환경변수 지원 추가(DISCORD_WEBHOOK_URL).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->