### PR TITLE
[feat] 기본 프로필 이미지 처리 로직 구현

### DIFF
--- a/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.user.core.service;
 
-import at.mateball.domain.s3.api.dto.ImageUploadRes;
-import at.mateball.domain.s3.core.S3Service;
+import at.mateball.storage.dto.ImageUploadRes;
+import at.mateball.storage.S3Service;
 import at.mateball.domain.user.api.dto.response.ProfileImageUploadRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;

--- a/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.storage.FileStorage;
 import at.mateball.storage.dto.ImageUploadRes;
-import at.mateball.storage.S3Service;
 import at.mateball.domain.user.api.dto.response.ProfileImageUploadRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
@@ -17,18 +17,18 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserProfileImageService {
 
     private final UserRepository userRepository;
-    private final S3Service s3Service;
+    private final FileStorage fileStorage;
 
     @Transactional
     public ProfileImageUploadRes uploadProfileImage(Long userId, MultipartFile file) throws Exception {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
 
-        ImageUploadRes uploadResult = s3Service.uploadProfileImage(file);
+        ImageUploadRes uploadResult = fileStorage.uploadProfileImage(file);
 
         user.updateProfileImageKey(uploadResult.objectKey());
 
-        String profileImageUrl = s3Service.getImageUrl(uploadResult.objectKey());
+        String profileImageUrl = fileStorage.getImageUrl(uploadResult.objectKey());
 
         return new ProfileImageUploadRes(
                 user.getProfileImageKey(),
@@ -42,6 +42,6 @@ public class UserProfileImageService {
             return User.DEFAULT_PROFILE_IMAGE_URL;
         }
 
-        return s3Service.getImageUrl(user.getProfileImageKey());
+        return fileStorage.getImageUrl(user.getProfileImageKey());
     }
 }

--- a/src/main/java/at/mateball/storage/FileStorage.java
+++ b/src/main/java/at/mateball/storage/FileStorage.java
@@ -1,0 +1,13 @@
+package at.mateball.storage;
+
+import at.mateball.storage.dto.ImageUploadRes;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileStorage {
+
+    ImageUploadRes uploadProfileImage(MultipartFile file) throws IOException;
+
+    String getImageUrl(String objectKey);
+}

--- a/src/main/java/at/mateball/storage/S3FileStorage.java
+++ b/src/main/java/at/mateball/storage/S3FileStorage.java
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
-@Service
+@Component
 @RequiredArgsConstructor
-public class S3Service {
+public class S3FileStorage implements FileStorage {
 
     private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 
@@ -30,6 +30,7 @@ public class S3Service {
     private final S3Properties s3Properties;
     private final AmazonS3 amazonS3;
 
+    @Override
     public ImageUploadRes uploadProfileImage(MultipartFile file) throws IOException {
         validateImage(file);
 
@@ -54,6 +55,7 @@ public class S3Service {
         );
     }
 
+    @Override
     public String getImageUrl(String objectKey) {
         String key = (objectKey == null || objectKey.isBlank())
                 ? s3Properties.getDefaultProfileKey()

--- a/src/main/java/at/mateball/storage/S3Properties.java
+++ b/src/main/java/at/mateball/storage/S3Properties.java
@@ -1,15 +1,22 @@
 package at.mateball.storage;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
 
 @Getter
 @Setter
+@Validated
 @Configuration
 @ConfigurationProperties(prefix = "spring.cloud.aws.s3")
 public class S3Properties {
+
+    @NotBlank
     private String bucket;
+
+    @NotBlank
     private String defaultProfileKey;
 }

--- a/src/main/java/at/mateball/storage/S3Properties.java
+++ b/src/main/java/at/mateball/storage/S3Properties.java
@@ -1,0 +1,15 @@
+package at.mateball.storage;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.cloud.aws.s3")
+public class S3Properties {
+    private String bucket;
+    private String defaultProfileKey;
+}

--- a/src/main/java/at/mateball/storage/S3Service.java
+++ b/src/main/java/at/mateball/storage/S3Service.java
@@ -1,13 +1,12 @@
-package at.mateball.domain.s3.core;
+package at.mateball.storage;
 
-import at.mateball.domain.s3.api.dto.ImageUploadRes;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.dto.ImageUploadRes;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,10 +26,9 @@ public class S3Service {
             "image/png",
             "image/webp"
     );
-    private final AmazonS3 amazonS3;
 
-    @Value("${spring.cloud.aws.s3.bucket}")
-    private String bucket;
+    private final S3Properties s3Properties;
+    private final AmazonS3 amazonS3;
 
     public ImageUploadRes uploadProfileImage(MultipartFile file) throws IOException {
         validateImage(file);
@@ -45,7 +43,7 @@ public class S3Service {
         metadata.setContentType(contentType);
 
         PutObjectRequest putObjectRequest =
-                new PutObjectRequest(bucket, objectKey, file.getInputStream(), metadata);
+                new PutObjectRequest(s3Properties.getBucket(), objectKey, file.getInputStream(), metadata);
 
         amazonS3.putObject(putObjectRequest);
 
@@ -57,7 +55,11 @@ public class S3Service {
     }
 
     public String getImageUrl(String objectKey) {
-        return amazonS3.getUrl(bucket, objectKey).toString();
+        String key = (objectKey == null || objectKey.isBlank())
+                ? s3Properties.getDefaultProfileKey()
+                : objectKey;
+
+        return amazonS3.getUrl(s3Properties.getBucket(), key).toString();
     }
 
     private void validateImage(MultipartFile file) {

--- a/src/main/java/at/mateball/storage/dto/ImageUploadRes.java
+++ b/src/main/java/at/mateball/storage/dto/ImageUploadRes.java
@@ -1,4 +1,4 @@
-package at.mateball.domain.s3.api.dto;
+package at.mateball.storage.dto;
 
 public record ImageUploadRes(
         String objectKey,

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,6 +18,7 @@ spring:
         static: ${S3_REGION}
       s3:
         bucket: ${S3_BUCKET}
+        default-profile-key: profile.jpg
   servlet:
     multipart:
       max-file-size: 5MB


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #202 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

이번 작업에서는 프로필 이미지 기본 이미지 처리 로직을 구현하고,  기존 S3 업로드 로직에서 **도메인 의존성을 분리하도록 리팩토링**했습니다.

1. 기본 프로필 이미지 처리 로직 구현
- 사용자가 프로필 이미지를 업로드하지 않은 경우를 위해 기본 이미지 fallback 로직을 추가
- DB의 `profile_image_key` 값이 `null` 또는 blank일 경우, S3에 저장된 기본 이미지 key(`profile.jpg`)를 사용해 URL을 생성하도록 구현
- 이를 통해 클라이언트는 항상 유효한 프로필 이미지 URL을 받을 수 있도록 정리
- `profile_image_key = null` → 기본 이미지 URL 반환
- `profile_image_key = 사용자 업로드 key` → 해당 사용자 이미지 URL 반환

2. S3 업로드 구조 리팩토링
- 기존 S3 관련 로직이 특정 도메인에 직접 연결되지 않도록 구조를 정리했
- `FileStorage` 인터페이스를 도입하여 스토리지 계층을 추상화
- 업로드 및 URL 조회 기능을 인터페이스 기반으로 분리해 이후 S3 외 다른 저장소로 확장 가능하도록 기반

```java
public interface FileStorage {

    ImageUploadRes uploadProfileImage(MultipartFile file) throws IOException;

    String getImageUrl(String objectKey);
}
```

3. 설정 구조 정리
- S3 버킷명과 기본 이미지 key를 설정값으로 분리
- 하드코딩 대신 설정 기반으로 관리할 수 있도록 개선


<br/>


### ❤️ To 다진 / To 헤음

---

- 스토리지 계층을 인터페이스로 분리했긔!!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 프로필 이미지 저장소가 범용 저장소로 전환되어 백엔드 저장 방식이 일반화되었습니다. 기존 업로드 및 조회 흐름은 유지됩니다.
* **Chores**
  * 프로덕션용 기본 프로필 이미지 키 설정이 추가되어 기본 이미지 사용이 명시적으로 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->