### PR TITLE
[feat] 이미지 수정

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserImgController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserImgController.java
@@ -2,6 +2,7 @@ package at.mateball.domain.user.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.user.api.dto.response.ProfileImageUpdateRes;
 import at.mateball.domain.user.api.dto.response.ProfileImageUploadRes;
 import at.mateball.domain.user.core.service.UserProfileImageService;
 import at.mateball.exception.code.SuccessCode;
@@ -29,6 +30,19 @@ public class UserImgController {
         Long userId = userDetails.getUserId();
 
         ProfileImageUploadRes data = userProfileImageService.uploadProfileImage(userId, file);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
+    }
+
+    @PatchMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 수정 api")
+    public ResponseEntity<MateballResponse<?>> updateProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestPart("file") MultipartFile file
+    ) throws Exception {
+        Long userId = userDetails.getUserId();
+
+        ProfileImageUpdateRes data = userProfileImageService.updateProfileImage(userId, file);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/ProfileImageUpdateRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/ProfileImageUpdateRes.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record ProfileImageUpdateRes(
+        String imageUrl
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -76,6 +76,10 @@ public class User {
         this.profileImageKey = profileImageKey;
     }
 
+    public void clearProfileImageKey() {
+        this.profileImageKey = null;
+    }
+
     public void updateIntroduction(final String introduction) {
         this.introduction = introduction;
     }

--- a/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.domain.user.api.dto.response.ProfileImageUpdateRes;
 import at.mateball.storage.FileStorage;
 import at.mateball.storage.dto.ImageUploadRes;
 import at.mateball.domain.user.api.dto.response.ProfileImageUploadRes;
@@ -8,12 +9,14 @@ import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserProfileImageService {
 
     private final UserRepository userRepository;
@@ -36,6 +39,25 @@ public class UserProfileImageService {
         );
     }
 
+    @Transactional
+    public ProfileImageUpdateRes updateProfileImage(Long userId, MultipartFile file) throws Exception {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        String oldProfileImageKey = user.getProfileImageKey();
+
+        ImageUploadRes uploadRes = fileStorage.uploadProfileImage(file);
+        String newProfileImageKey = uploadRes.objectKey();
+
+        user.updateProfileImageKey(newProfileImageKey);
+
+        deleteOldProfileImageQuietly(oldProfileImageKey);
+
+        String imageUrl = fileStorage.getImageUrl(newProfileImageKey);
+
+        return new ProfileImageUpdateRes(imageUrl);
+    }
+
     // objectKey 기반 구조로 변경 예정
     public String getProfileImageUrl(User user) {
         if (user.getProfileImageKey() == null || user.getProfileImageKey().isBlank()) {
@@ -43,5 +65,17 @@ public class UserProfileImageService {
         }
 
         return fileStorage.getImageUrl(user.getProfileImageKey());
+    }
+
+    private void deleteOldProfileImageQuietly(String oldProfileImageKey) {
+        if (oldProfileImageKey == null || oldProfileImageKey.isBlank()) {
+            return;
+        }
+
+        try {
+            fileStorage.deleteObject(oldProfileImageKey);
+        } catch (Exception e) {
+            log.warn("기존 프로필 이미지 삭제 실패. objectKey={}", oldProfileImageKey, e);
+        }
     }
 }

--- a/src/main/java/at/mateball/storage/FileStorage.java
+++ b/src/main/java/at/mateball/storage/FileStorage.java
@@ -10,4 +10,6 @@ public interface FileStorage {
     ImageUploadRes uploadProfileImage(MultipartFile file) throws IOException;
 
     String getImageUrl(String objectKey);
+
+    void deleteObject(String objectKey);
 }

--- a/src/main/java/at/mateball/storage/S3FileStorage.java
+++ b/src/main/java/at/mateball/storage/S3FileStorage.java
@@ -64,6 +64,15 @@ public class S3FileStorage implements FileStorage {
         return amazonS3.getUrl(s3Properties.getBucket(), key).toString();
     }
 
+    @Override
+    public void deleteObject(String objectKey) {
+        if (objectKey == null || objectKey.isBlank()) {
+            return;
+        }
+
+        amazonS3.deleteObject(s3Properties.getBucket(), objectKey);
+    }
+
     private void validateImage(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new BusinessException(BusinessErrorCode.EMPTY_PROFILE_IMAGE);


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #203 

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

사용자가 업로드한 프로필 이미지를 수정할 수 있도록 프로필 이미지 수정 API를 구현했습니다.

- 사용자의 기존 `profile_image_key` 조회
- 새로운 프로필 이미지를 S3에 업로드
- 업로드된 이미지의 `objectKey`를 DB의 `profile_image_key` 컬럼에 업데이트
- 기존 프로필 이미지가 존재할 경우 S3에서 해당 object 삭제
 수정된 프로필 이미지 URL을 생성하여 응답 반환

<br/>

### ❤️ To 다진 / To 헤음

---

이미지 삭제 기능 하러 가볼게요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 프로필 사진 업데이트 기능 추가: 사용자가 새로운 프로필 이미지를 업로드할 수 있습니다.
* 새 프로필 사진 업로드 시 기존 이미지는 자동으로 삭제되고 새 이미지로 대체됩니다.
* 프로필 이미지가 없는 경우 기본 이미지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->