### PR TITLE
[feat] 이미지 삭제

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserImgController.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserImgController.java
@@ -46,4 +46,16 @@ public class UserImgController {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }
+
+    @DeleteMapping("/profile-image")
+    @Operation(summary = "프로필 이미지 삭제 api")
+    public ResponseEntity<MateballResponse<?>> deleteProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        ProfileImageUpdateRes data = userProfileImageService.deleteProfileImage(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.user.api.dto.response.ProfileImageUpdateRes;
+import at.mateball.domain.user.event.ProfileImageDeleteEvent;
 import at.mateball.storage.FileStorage;
 import at.mateball.storage.dto.ImageUploadRes;
 import at.mateball.domain.user.api.dto.response.ProfileImageUploadRes;
@@ -10,6 +11,7 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,41 +23,53 @@ public class UserProfileImageService {
 
     private final UserRepository userRepository;
     private final FileStorage fileStorage;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public ProfileImageUploadRes uploadProfileImage(Long userId, MultipartFile file) throws Exception {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+        User user = getUser(userId);
 
         ImageUploadRes uploadResult = fileStorage.uploadProfileImage(file);
+        String newProfileImageKey = uploadResult.objectKey();
 
-        user.updateProfileImageKey(uploadResult.objectKey());
+        try {
+            user.updateProfileImageKey(newProfileImageKey);
 
-        String profileImageUrl = fileStorage.getImageUrl(uploadResult.objectKey());
+            String profileImageUrl = fileStorage.getImageUrl(newProfileImageKey);
 
-        return new ProfileImageUploadRes(
-                user.getProfileImageKey(),
-                profileImageUrl
-        );
+            return new ProfileImageUploadRes(
+                    user.getProfileImageKey(),
+                    profileImageUrl
+            );
+        } catch (Exception e) {
+            deleteNewProfileImageQuietly(newProfileImageKey);
+            throw e;
+        }
     }
 
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public ProfileImageUpdateRes updateProfileImage(Long userId, MultipartFile file) throws Exception {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+        User user = getUser(userId);
 
         String oldProfileImageKey = user.getProfileImageKey();
 
         ImageUploadRes uploadRes = fileStorage.uploadProfileImage(file);
         String newProfileImageKey = uploadRes.objectKey();
 
-        user.updateProfileImageKey(newProfileImageKey);
+        try {
+            user.updateProfileImageKey(newProfileImageKey);
 
-        deleteOldProfileImageQuietly(oldProfileImageKey);
+            if (hasText(oldProfileImageKey)) {
+                eventPublisher.publishEvent(new ProfileImageDeleteEvent(oldProfileImageKey));
+            }
 
-        String imageUrl = fileStorage.getImageUrl(newProfileImageKey);
+            String imageUrl = fileStorage.getImageUrl(newProfileImageKey);
+            return new ProfileImageUpdateRes(imageUrl);
 
-        return new ProfileImageUpdateRes(imageUrl);
+        } catch (Exception e) {
+            deleteNewProfileImageQuietly(newProfileImageKey);
+            throw e;
+        }
     }
 
     // objectKey 기반 구조로 변경 예정
@@ -67,15 +81,24 @@ public class UserProfileImageService {
         return fileStorage.getImageUrl(user.getProfileImageKey());
     }
 
-    private void deleteOldProfileImageQuietly(String oldProfileImageKey) {
-        if (oldProfileImageKey == null || oldProfileImageKey.isBlank()) {
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+    }
+
+    private void deleteNewProfileImageQuietly(String objectKey) {
+        if (!hasText(objectKey)) {
             return;
         }
 
         try {
-            fileStorage.deleteObject(oldProfileImageKey);
+            fileStorage.deleteObject(objectKey);
         } catch (Exception e) {
-            log.warn("기존 프로필 이미지 삭제 실패. objectKey={}", oldProfileImageKey, e);
+            log.warn("보상 삭제 실패. newProfileImageKey={}", objectKey, e);
         }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserProfileImageService.java
@@ -72,6 +72,22 @@ public class UserProfileImageService {
         }
     }
 
+    @Transactional(rollbackFor = Exception.class)
+    public ProfileImageUpdateRes deleteProfileImage(Long userId) {
+        User user = getUser(userId);
+
+        String oldProfileImageKey = user.getProfileImageKey();
+
+        user.clearProfileImageKey();
+
+        if (hasText(oldProfileImageKey)) {
+            eventPublisher.publishEvent(new ProfileImageDeleteEvent(oldProfileImageKey));
+        }
+
+        String defaultImageUrl = fileStorage.getImageUrl(null);
+        return new ProfileImageUpdateRes(defaultImageUrl);
+    }
+
     // objectKey 기반 구조로 변경 예정
     public String getProfileImageUrl(User user) {
         if (user.getProfileImageKey() == null || user.getProfileImageKey().isBlank()) {

--- a/src/main/java/at/mateball/domain/user/event/ProfileImageDeleteEvent.java
+++ b/src/main/java/at/mateball/domain/user/event/ProfileImageDeleteEvent.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.user.event;
+
+public record ProfileImageDeleteEvent(
+        String objectKey
+) {
+}

--- a/src/main/java/at/mateball/domain/user/event/ProfileImageDeleteEventListener.java
+++ b/src/main/java/at/mateball/domain/user/event/ProfileImageDeleteEventListener.java
@@ -1,0 +1,25 @@
+package at.mateball.domain.user.event;
+
+import at.mateball.storage.FileStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+class ProfileImageDeleteEventListener {
+
+    private final FileStorage fileStorage;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ProfileImageDeleteEvent event) {
+        try {
+            fileStorage.deleteObject(event.objectKey());
+        } catch (Exception e) {
+            log.warn("기존 프로필 이미지 삭제 실패. objectKey={}", event.objectKey(), e);
+        }
+    }
+}


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #206

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

사용자가 업로드한 **프로필 이미지를 삭제할 수 있는 API**를 구현했습니다.

- 사용자 조회 및 기존 `profile_image_key` 확인
- DB의 `profile_image_key` 값을 `null`로 업데이트
- 기존 이미지 key가 존재할 경우 삭제 이벤트 발행
- 트랜잭션 커밋 이후 `AFTER_COMMIT` 이벤트 리스너에서 S3 object 삭제

S3 삭제를 트랜잭션 내부에서 직접 수행하지 않고, Transaction Event Listener (`AFTER_COMMIT`) 기반으로 처리하여 DB 롤백 상황에서 실제 파일이 먼저 삭제되는 문제를 방지했습니다.

또한 기존 프로필 이미지가 없는 사용자(`profile_image_key = null`)의 경우 삭제 요청이 들어와도 S3 삭제 이벤트가 발생하지 않도록 처리하여 API의 멱등성을 유지했습니다.

<br/>

### ❤️ To 다진 / To 헤음

---

- s3 ㅇl ㅁ ㅣ ㅈ ㅣ ㄲㅡㅌ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 프로필 이미지 삭제 기능: 사용자가 언제든지 프로필 이미지를 삭제할 수 있으며, 삭제 후 기본 이미지로 자동 복원됩니다.

* **개선 사항**
  * 업로드 안정성 강화: 이미지 업로드 또는 수정 중 오류 발생 시 문제가 되는 임시 파일이 자동으로 정리되어 저장 공간이 낭비되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->