### PR TITLE
[add] user 테이블에 시즌 평균 직관 수 컬럼 추가

### DIFF
--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -49,8 +49,8 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
-    @Column(nullable = true)
-    private Integer avgSeason = 0;
+    @Column(nullable = false)
+    private int avgSeason = 0;
 
     protected User() {
 

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -50,7 +50,7 @@ public class User {
     private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
     @Column(nullable = true)
-    private Integer avgSeason = 0;
+    private Integer avgSeason;
 
     protected User() {
 

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -49,6 +49,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
+    @Column(nullable = true)
+    private Integer avgSeason = 0;
+
     protected User() {
 
     }

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -95,4 +95,8 @@ public class User {
     public void updateHasAccepted(boolean hasAccepted) {
         this.hasAccepted = hasAccepted;
     }
+
+    public void updateAvgSeason(int avgSeason) {
+        this.avgSeason = avgSeason;
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -50,7 +50,7 @@ public class User {
     private List<MatchRequirement> matchRequirements = new ArrayList<>();
 
     @Column(nullable = true)
-    private Integer avgSeason;
+    private Integer avgSeason = 0;
 
     protected User() {
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #198

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- user 테이블에 시즌 평균 직관 수 를 추가했습니다. 온보딩에서 매칭 조건 입력 플로우에 존재하기는 하나 매칭률 계산에 들어가지 않는 로직이기에  매칭 조건 대신 유저 테이블에 위치하도록 했습니다. 
- 스프린트 이전 유저의 경우, 어떻게 값을 내려줄지 정해지지 않아, 기획측 의견 살펴본 후 관련 대안 코드 추가할 예정입니다!  **-> 기본값 0으로 추가되었습니다.**

<br/>


### ❤️ To 다진 / To 헤음

---

나 의 작 고 소 중 한 PR 입니다......


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새 기능**
  * 사용자 프로필에 시즌 평균(avgSeason) 항목이 추가되어 시즌별 평균값을 기록합니다.

* **기술 개선**
  * 해당 필드가 항상 값(초기값 0)을 가지도록 설정되어 데이터 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->