### PR TITLE
[feat] 매칭 정렬 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/calculator/common/GroupMatchAggregator.java
+++ b/src/main/java/at/mateball/domain/group/core/calculator/common/GroupMatchAggregator.java
@@ -7,10 +7,7 @@ import at.mateball.domain.group.infrastructure.dto.GroupMatchCandidateFlatDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 @Component
 @RequiredArgsConstructor
@@ -55,6 +52,12 @@ public class GroupMatchAggregator {
 
         return aggregateMap.values().stream()
                 .map(GroupMatchAggregate::toResponse)
+                .sorted(
+                        Comparator.comparing(
+                                GroupMatchBaseRes::matchRate,
+                                Comparator.nullsLast(Comparator.reverseOrder())
+                        )
+                )
                 .toList();
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #214 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

특정 경기 기준 매칭 조회 API에서 반환되는 결과에 대해 매칭률 기준 정렬 로직을 추가했습니다.

현재 매칭 조회 API에서는 로그인 사용자가 직접 생성한 매칭의 경우 매칭률을 계산하지 않기 때문에 matchRate = null로 반환하고 있습니다.
정렬 정책을 적용하면서 이러한 항목이 자연스럽게 목록 하단으로 이동하도록 처리했습니다.

구현 시 정렬 로직은 GroupMatchAggregator 계층에 추가했습니다.

매칭률은 DB 컬럼이 아니라 애플리케이션에서 계산되는 값이기 때문에 Repository 계층에서 정렬을 처리하는 것은 적절하지 않다고 판단했습니다.
또한 Service 계층은 조회 흐름을 조합하는 orchestration 역할에 집중하도록 유지하고, 응답 데이터의 집계 및 변환 책임은 Aggregator에 두는 것이 더 적절하다고 판단했습니다.

따라서 현재 구조에서 Repository → 데이터 조회, Aggregator → 집계 및 응답 데이터 생성, Service → 조회 흐름 orchestration이라는 책임 분리를 유지하면서 최종 응답 리스트 정렬을 Aggregator에서 처리하도록 구현했습니다.

서비스 계층의 책임이 증가하지 않도록 유지하면서 매칭 결과 집계 로직과 정렬 정책을 동일한 계층에서 관리할 수 있도록 했습니다.


<br/>


### ❤️ To 다진 / To 헤음

---

GroupMatchAggregate는 단일 그룹에 대한 누적 상태를 표현하는 객체이고, 전체 결과 리스트를 생성하는 책임은 GroupMatchAggregator가 가지고 있기 때문에 최종 응답 리스트 정렬 정책 역시 Aggregator 계층에 위치시키는 것이 구조적으로 자연스럽다고 판단했긔!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 일치 결과가 이제 일치율 기준으로 내림차순으로 정렬되어 더욱 일관성 있는 결과 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->