### PR TITLE
[fix] 매칭 조건 설정에 avgSeason 추가

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -1,7 +1,16 @@
 package at.mateball.domain.matchrequirement.api.controller;
 
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
 import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,5 +23,22 @@ public class MatchRequirementV3Controller {
         this.matchRequirementV3Service = matchRequirementV3Service;
     }
 
+    @PostMapping
+    @Operation(summary = "매칭 조건 설정 api")
+    public ResponseEntity<MateballResponse<?>> setMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MatchRequirementV3Req matchRequirementV3Req
+    ) {
+        Long userId = userDetails.getUserId();
 
+        matchRequirementV3Service.setMatchRequirement(
+                userId,
+                matchRequirementV3Req.team(),
+                matchRequirementV3Req.teamAllowed(),
+                matchRequirementV3Req.avgSeason(),
+                matchRequirementV3Req.style()
+        );
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -3,8 +3,7 @@ package at.mateball.domain.matchrequirement.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
-import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
-import at.mateball.domain.user.core.service.UserV3Service;
+import at.mateball.domain.matchrequirement.core.service.OnboardingService;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -19,22 +18,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
-    private final MatchRequirementV3Service matchRequirementV3Service;
+    private final OnboardingService onboardingService;
 
     @PostMapping
     @Operation(summary = "매칭 조건 설정 api")
-    public ResponseEntity<MateballResponse<?>> setMatchRequirement(
+    public ResponseEntity<MateballResponse<?>> setOnboardingInformation(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody MatchRequirementV3Req matchRequirementV3Req
+            @RequestBody MatchRequirementV3Req onboardingReq
     ) {
         Long userId = userDetails.getUserId();
 
-        matchRequirementV3Service.setAvgSeasonAndMatchRequirement(
+        onboardingService.setOnboardingInformation(
                 userId,
-                matchRequirementV3Req.team(),
-                matchRequirementV3Req.teamAllowed(),
-                matchRequirementV3Req.style(),
-                matchRequirementV3Req.avgSeason()
+                onboardingReq.team(),
+                onboardingReq.teamAllowed(),
+                onboardingReq.style(),
+                onboardingReq.avgSeason()
         );
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
     private final MatchRequirementV3Service matchRequirementV3Service;
-    private final UserV3Service userV3Service;
 
     @PostMapping
     @Operation(summary = "매칭 조건 설정 api")
@@ -30,12 +29,12 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        userV3Service.setAvgSeason(userId, matchRequirementV3Req.avgSeason());
-        matchRequirementV3Service.setMatchRequirement(
+        matchRequirementV3Service.setAvgSeasonAndMatchRequirement(
                 userId,
                 matchRequirementV3Req.team(),
                 matchRequirementV3Req.teamAllowed(),
-                matchRequirementV3Req.style()
+                matchRequirementV3Req.style(),
+                matchRequirementV3Req.avgSeason()
         );
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -1,0 +1,18 @@
+package at.mateball.domain.matchrequirement.api.controller;
+
+import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
+import at.mateball.domain.user.core.repository.UserRepository;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v3/users/match-condition")
+public class MatchRequirementV3Controller {
+    private final MatchRequirementV3Service matchRequirementV3Service;
+
+    public MatchRequirementV3Controller(MatchRequirementV3Service matchRequirementV3Service, UserRepository userRepository) {
+        this.matchRequirementV3Service = matchRequirementV3Service;
+    }
+
+
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -7,6 +7,7 @@ import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Servic
 import at.mateball.domain.user.core.service.UserV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,15 +16,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
     private final MatchRequirementV3Service matchRequirementV3Service;
     private final UserV3Service userV3Service;
-
-    public MatchRequirementV3Controller(MatchRequirementV3Service matchRequirementV3Service, UserV3Service userV3Service) {
-        this.matchRequirementV3Service = matchRequirementV3Service;
-        this.userV3Service = userV3Service;
-    }
 
     @PostMapping
     @Operation(summary = "매칭 조건 설정 api")

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -4,7 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
-import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.domain.user.core.service.UserV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
     private final MatchRequirementV3Service matchRequirementV3Service;
+    private final UserV3Service userV3Service;
 
-    public MatchRequirementV3Controller(MatchRequirementV3Service matchRequirementV3Service, UserRepository userRepository) {
+    public MatchRequirementV3Controller(MatchRequirementV3Service matchRequirementV3Service, UserV3Service userV3Service) {
         this.matchRequirementV3Service = matchRequirementV3Service;
+        this.userV3Service = userV3Service;
     }
 
     @PostMapping
@@ -31,11 +33,11 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
+        userV3Service.setAvgSeason(userId, matchRequirementV3Req.avgSeason());
         matchRequirementV3Service.setMatchRequirement(
                 userId,
                 matchRequirementV3Req.team(),
                 matchRequirementV3Req.teamAllowed(),
-                matchRequirementV3Req.avgSeason(),
                 matchRequirementV3Req.style()
         );
 

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementV3Req.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementV3Req.java
@@ -1,0 +1,16 @@
+package at.mateball.domain.matchrequirement.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+// 네이밍 고민
+public record MatchRequirementV3Req(
+        @Schema(description = "응원하는 팀 이름")
+        String team,
+        @Schema(description = "응원 팀 허용 여부")
+        String teamAllowed,
+        @Schema(description = "시즌 평균 직관 수")
+        int avgSeason,
+        @Schema(description = "관람스타일")
+        String style
+) {
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
@@ -40,6 +40,13 @@ public class MatchRequirement {
         this.genderPreference = genderPreference;
     }
 
+    public MatchRequirement(User user, Integer team, Integer teamAllowed, Integer style) {
+        this.user = user;
+        this.team = team;
+        this.teamAllowed = teamAllowed;
+        this.style = style;
+    }
+
     public void updateAll(Integer team, Integer teamAllowed, Integer style, Integer genderPreference) {
         this.team = team;
         this.teamAllowed = teamAllowed;

--- a/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/MatchRequirement.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 
 @Entity
 @Getter
-@Table(name = "match_requirement")
+@Table(name = "match_requirement",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_match_requirement_user", columnNames = "user_id")
+        }
+)
 public class MatchRequirement {
 
     @Id

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -6,30 +6,21 @@ import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.User;
-import at.mateball.domain.user.core.service.UserV3Service;
+import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 
 public class MatchRequirementV3Service {
     private final MatchRequirementRepository matchRequirementRepository;
-    private final UserV3Service userV3Service;
-    private final EntityManager entityManager;
+    private final UserRepository userRepository;
 
-    @Transactional
-    public void setAvgSeasonAndMatchRequirement(Long userId, String team, String teamAllowed, String style, int avgSeason) {
-        userV3Service.setAvgSeason(userId, avgSeason);
-        setMatchRequirement(userId, team, teamAllowed, style);
-    }
-
-    private void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
-        User user = entityManager.getReference(User.class, userId);
+    public void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
+        User user = userRepository.getReferenceById(userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
         if (matchRequirement != null) {
@@ -42,6 +33,6 @@ public class MatchRequirementV3Service {
                 teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
                 Style.fromLabel(style).getValue()
         );
-        entityManager.persist(matchRequirement);
+        matchRequirementRepository.save(matchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -24,15 +24,13 @@ public class MatchRequirementV3Service {
     }
 
     @Transactional
-    public void setMatchRequirement(Long userId, String team, String teamAllowed, int avgSeason, String style) {
+    public void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
         User user = entityManager.getReference(User.class, userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
         if (matchRequirement != null) {
             throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUIREMENT);
         }
-
-        user.updateAvgSeason(avgSeason);
 
         matchRequirement = new MatchRequirement(
                 user,

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -1,8 +1,16 @@
 package at.mateball.domain.matchrequirement.core.service;
 
+import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.team.core.TeamName;
+import at.mateball.domain.user.core.User;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MatchRequirementV3Service {
@@ -15,5 +23,23 @@ public class MatchRequirementV3Service {
         this.entityManager = entityManager;
     }
 
+    @Transactional
+    public void setMatchRequirement(Long userId, String team, String teamAllowed, int avgSeason, String style) {
+        User user = entityManager.getReference(User.class, userId);
+        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 
+        if (matchRequirement != null) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUIREMENT);
+        }
+
+        user.updateAvgSeason(avgSeason);
+
+        matchRequirement = new MatchRequirement(
+                user,
+                TeamName.fromLabel(team).getValue(),
+                teamAllowed == null ? TeamAllowed.NO_PREFERENCE.getValue() : TeamAllowed.fromLabel(teamAllowed).getValue(),
+                Style.fromLabel(style).getValue()
+        );
+        entityManager.persist(matchRequirement);
+    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -1,0 +1,19 @@
+package at.mateball.domain.matchrequirement.core.service;
+
+import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MatchRequirementV3Service {
+    private final MatchRequirementRepository matchRequirementRepository;
+
+    private final EntityManager entityManager;
+
+    public MatchRequirementV3Service(MatchRequirementRepository matchRequirementRepository, EntityManager entityManager) {
+        this.matchRequirementRepository = matchRequirementRepository;
+        this.entityManager = entityManager;
+    }
+
+
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -6,24 +6,28 @@ import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.User;
+import at.mateball.domain.user.core.service.UserV3Service;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+
 public class MatchRequirementV3Service {
     private final MatchRequirementRepository matchRequirementRepository;
-
+    private final UserV3Service userV3Service;
     private final EntityManager entityManager;
 
-    public MatchRequirementV3Service(MatchRequirementRepository matchRequirementRepository, EntityManager entityManager) {
-        this.matchRequirementRepository = matchRequirementRepository;
-        this.entityManager = entityManager;
+    @Transactional
+    public void setAvgSeasonAndMatchRequirement(Long userId, String team, String teamAllowed, String style, int avgSeason) {
+        userV3Service.setAvgSeason(userId, avgSeason);
+        setMatchRequirement(userId, team, teamAllowed, style);
     }
 
-    @Transactional
     public void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
         User user = entityManager.getReference(User.class, userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -28,7 +28,7 @@ public class MatchRequirementV3Service {
         setMatchRequirement(userId, team, teamAllowed, style);
     }
 
-    public void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
+    private void setMatchRequirement(Long userId, String team, String teamAllowed, String style) {
         User user = entityManager.getReference(User.class, userId);
         MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
 

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/OnboardingService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/OnboardingService.java
@@ -1,0 +1,19 @@
+package at.mateball.domain.matchrequirement.core.service;
+
+import at.mateball.domain.user.core.service.UserV3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+    private final UserV3Service userV3Service;
+    private final MatchRequirementV3Service matchRequirementV3Service;
+
+    @Transactional
+    public void setOnboardingInformation(Long userId, String team, String teamAllowed, String style, int avgSeason) {
+        userV3Service.setAvgSeason(userId, avgSeason);
+        matchRequirementV3Service.setMatchRequirement(userId, team, teamAllowed, style);
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -2,11 +2,14 @@ package at.mateball.domain.user.core;
 
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Gender;
+import at.mateball.exception.BusinessException;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static at.mateball.exception.code.BusinessErrorCode.INVALID_AVG_SEASON;
 
 @Entity
 @Getter
@@ -14,6 +17,8 @@ import java.util.List;
 public class User {
     public static final String DEFAULT_PROFILE_IMAGE_URL =
             "https://mateball-file.s3.ap-northeast-2.amazonaws.com/profile.jpg";
+    private static final int MIN_AVG_SEASON = 0;
+    private static final int MAX_AVG_SEASON = 999;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,10 +62,10 @@ public class User {
     }
 
     /*
-    * imgUrl s3 안정화 되면 기본 이미지 URL 반환 로직 수정
-    * this.profileImageKey = DEFAULT_PROFILE_IMAGE_KEY; 추가
-    * 서비스에서 URL 상수를 직접 쓰는게 아니라 porfileImgKey 보고 URL 생성
-    * */
+     * imgUrl s3 안정화 되면 기본 이미지 URL 반환 로직 수정
+     * this.profileImageKey = DEFAULT_PROFILE_IMAGE_KEY; 추가
+     * 서비스에서 URL 상수를 직접 쓰는게 아니라 porfileImgKey 보고 URL 생성
+     * */
     public User(Long kakaoUserId, String email, String imgUrl) {
         this.kakaoUserId = kakaoUserId;
         this.email = email;
@@ -97,6 +102,9 @@ public class User {
     }
 
     public void updateAvgSeason(int avgSeason) {
+        if (avgSeason > MAX_AVG_SEASON || avgSeason < MIN_AVG_SEASON) {
+            throw new BusinessException(INVALID_AVG_SEASON);
+        }
         this.avgSeason = avgSeason;
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -1,13 +1,35 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
+import at.mateball.exception.BusinessException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static at.mateball.exception.code.BusinessErrorCode.INVALID_AVG_SEASON;
+import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 
 @Service
 public class UserV3Service {
     private final UserRepository userRepository;
+    private final int MIN_AVG_SEASON = 0;
+    private final int MAX_AVG_SEASON = 999;
 
     public UserV3Service(UserRepository userRepository) {
         this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public void setAvgSeason(final Long userId, final int avgSeason) {
+        if (avgSeason > MAX_AVG_SEASON || avgSeason < MIN_AVG_SEASON) {
+            throw new BusinessException(INVALID_AVG_SEASON);
+        }
+
+        findUser(userId).updateAvgSeason(avgSeason);
+    }
+
+    public User findUser(final Long userId) {
+        return userRepository.getUser(userId).orElseThrow(()
+                -> new BusinessException(USER_NOT_FOUND));
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -28,7 +28,7 @@ public class UserV3Service {
         findUser(userId).updateAvgSeason(avgSeason);
     }
 
-    public User findUser(final Long userId) {
+    private User findUser(final Long userId) {
         return userRepository.getUser(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
     }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -1,0 +1,13 @@
+package at.mateball.domain.user.core.service;
+
+import at.mateball.domain.user.core.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserV3Service {
+    private final UserRepository userRepository;
+
+    public UserV3Service(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+}

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -5,7 +5,6 @@ import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import static at.mateball.exception.code.BusinessErrorCode.INVALID_AVG_SEASON;
 import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
@@ -17,7 +16,6 @@ public class UserV3Service {
     private static final int MIN_AVG_SEASON = 0;
     private static final int MAX_AVG_SEASON = 999;
 
-    @Transactional
     public void setAvgSeason(final Long userId, final int avgSeason) {
         if (avgSeason > MAX_AVG_SEASON || avgSeason < MIN_AVG_SEASON) {
             throw new BusinessException(INVALID_AVG_SEASON);

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -3,6 +3,7 @@ package at.mateball.domain.user.core.service;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,14 +11,11 @@ import static at.mateball.exception.code.BusinessErrorCode.INVALID_AVG_SEASON;
 import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 
 @Service
+@RequiredArgsConstructor
 public class UserV3Service {
     private final UserRepository userRepository;
     private static final int MIN_AVG_SEASON = 0;
     private static final int MAX_AVG_SEASON = 999;
-
-    public UserV3Service(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
 
     @Transactional
     public void setAvgSeason(final Long userId, final int avgSeason) {

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -6,21 +6,14 @@ import at.mateball.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static at.mateball.exception.code.BusinessErrorCode.INVALID_AVG_SEASON;
 import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class UserV3Service {
     private final UserRepository userRepository;
-    private static final int MIN_AVG_SEASON = 0;
-    private static final int MAX_AVG_SEASON = 999;
 
     public void setAvgSeason(final Long userId, final int avgSeason) {
-        if (avgSeason > MAX_AVG_SEASON || avgSeason < MIN_AVG_SEASON) {
-            throw new BusinessException(INVALID_AVG_SEASON);
-        }
-
         findUser(userId).updateAvgSeason(avgSeason);
     }
 

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -12,8 +12,8 @@ import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 @Service
 public class UserV3Service {
     private final UserRepository userRepository;
-    private final int MIN_AVG_SEASON = 0;
-    private final int MAX_AVG_SEASON = 999;
+    private static final int MIN_AVG_SEASON = 0;
+    private static final int MAX_AVG_SEASON = 999;
 
     public UserV3Service(UserRepository userRepository) {
         this.userRepository = userRepository;

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -29,6 +29,7 @@ public enum BusinessErrorCode implements ErrorCode {
     EMPTY_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "업로드할 프로필 이미지가 없습니다."),
     INVALID_PROFILE_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "프로필 이미지는 jpg, png, webp 형식만 업로드할 수 있습니다."),
     INVALID_PROFILE_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "프로필 이미지는 5MB 이하만 업로드할 수 있습니다."),
+    INVALID_AVG_SEASON(HttpStatus.BAD_REQUEST, "시즌 평균 직관 수는 0-999까지 입력 가능합니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #211

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 매칭 조건 설정 api를 v3 에 맞게 마이그레이션 했습니다.
- 매칭 조건 설정에서 선호 성별을 설정하는 로직을 지우고, 시즌 평균 직관 수를 추가하는 로직을 추가했습니다.
변경된 로직에 따라, 새롭게 가입하는 회원은 매칭조건-선호성별 데이터가 null 로 저장됩니다.
- 평균 직관 수는 0-999 사이로만 입력가능하게 제한합니다.

<br/>


### ❤️ To 다진 / To 헤음

---

- Request DTO 네이밍이 참 고민됩니다.. 추천받아요...
- 이전 코드에서 평균 직관 수 부분만 추가되었다고 보심 됩니다, 담부터 주석으로 표시를 좀 해놓을까해요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자가 매칭 조건(응원 팀, 팀 허용 여부, 시즌 평균 직관 수, 관람 스타일)을 설정·저장할 수 있는 신규 v3 API 엔드포인트 및 온보딩 처리 추가
* **Bug Fixes**
  * 시즌 평균 직관 수 유효성 검사 추가(0–999)
  * 동일 사용자에 대한 중복 매칭 조건 생성을 방지하는 제약 및 검증 로직 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->