### PR TITLE
[fix] 매칭 조건 조회에 avgSeason 추가

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -3,7 +3,7 @@ package at.mateball.domain.matchrequirement.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
-import at.mateball.domain.matchrequirement.core.service.OnboardingService;
+import at.mateball.domain.matchrequirement.core.service.MatchRequirementAndAvgSeasonService;
 import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
 import at.mateball.exception.code.SuccessCode;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
-    private final OnboardingService onboardingService;
+    private final MatchRequirementAndAvgSeasonService matchRequirementAndAvgSeasonService;
     private final MatchRequirementV3Service matchRequirementV3Service;
 
     @PostMapping
@@ -28,7 +28,7 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        onboardingService.setOnboardingInformation(
+        matchRequirementAndAvgSeasonService.setMatchRequirementAndAvgSeason(
                 userId,
                 onboardingReq.team(),
                 onboardingReq.teamAllowed(),
@@ -46,7 +46,7 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        MatchRequirementV3Res result = onboardingService.getMatchRequirementAndAvgSeason(userId);
+        MatchRequirementV3Res result = matchRequirementAndAvgSeasonService.getMatchRequirementAndAvgSeason(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -4,7 +4,7 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementAndAvgSeasonService;
-import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndAvgSeasonRes;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,7 +46,7 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        MatchRequirementV3Res result = matchRequirementAndAvgSeasonService.getMatchRequirementAndAvgSeason(userId);
+        MatchRequirementAndAvgSeasonRes result = matchRequirementAndAvgSeasonService.getMatchRequirementAndAvgSeason(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -46,7 +46,7 @@ public class MatchRequirementV3Controller {
     ) {
         Long userId = userDetails.getUserId();
 
-        MatchRequirementV3Res result = matchRequirementV3Service.getMatchRequirement(userId);
+        MatchRequirementV3Res result = onboardingService.getMatchRequirementAndAvgSeason(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -4,21 +4,21 @@ import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
 import at.mateball.domain.matchrequirement.core.service.OnboardingService;
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
+import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v3/users/match-condition")
 public class MatchRequirementV3Controller {
     private final OnboardingService onboardingService;
+    private final MatchRequirementV3Service matchRequirementV3Service;
 
     @PostMapping
     @Operation(summary = "매칭 조건 설정 api")
@@ -37,5 +37,17 @@ public class MatchRequirementV3Controller {
         );
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
+
+    @GetMapping
+    @Operation(summary = "매칭 조건 조회 api")
+    public ResponseEntity<MateballResponse<?>> getMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        MatchRequirementV3Res result = matchRequirementV3Service.getMatchRequirement(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementAndAvgSeasonRes.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementAndAvgSeasonRes.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.matchrequirement.api.dto.response;
 
-public record MatchRequirementV3Res(
+public record MatchRequirementAndAvgSeasonRes(
         String team,
         String teamAllowed,
         String style,

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementV3Res.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/response/MatchRequirementV3Res.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.matchrequirement.api.dto.response;
+
+public record MatchRequirementV3Res(
+        String team,
+        String teamAllowed,
+        String style,
+        int avgSeason
+) {
+}

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.matchrequirement.core.service;
 
-import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndAvgSeasonRes;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
@@ -22,11 +22,11 @@ public class MatchRequirementAndAvgSeasonService {
         matchRequirementV3Service.setMatchRequirement(userId, team, teamAllowed, style);
     }
 
-    public MatchRequirementV3Res getMatchRequirementAndAvgSeason(Long userId) {
+    public MatchRequirementAndAvgSeasonRes getMatchRequirementAndAvgSeason(Long userId) {
         int avgSeason = userV3Service.getAvgSeason(userId);
         MatchRequirement matchRequirement = matchRequirementV3Service.getMatchRequirement(userId);
 
-        return new MatchRequirementV3Res(
+        return new MatchRequirementAndAvgSeasonRes(
                 TeamName.from(matchRequirement.getTeam()).getLabel(),
                 TeamAllowed.from(matchRequirement.getTeamAllowed()).getLabel(),
                 Style.from(matchRequirement.getStyle()).getLabel(),

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
@@ -12,12 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class OnboardingService {
+public class MatchRequirementAndAvgSeasonService {
     private final UserV3Service userV3Service;
     private final MatchRequirementV3Service matchRequirementV3Service;
 
     @Transactional
-    public void setOnboardingInformation(Long userId, String team, String teamAllowed, String style, int avgSeason) {
+    public void setMatchRequirementAndAvgSeason(Long userId, String team, String teamAllowed, String style, int avgSeason) {
         userV3Service.setAvgSeason(userId, avgSeason);
         matchRequirementV3Service.setMatchRequirement(userId, team, teamAllowed, style);
     }
@@ -32,7 +32,6 @@ public class OnboardingService {
                 Style.from(matchRequirement.getStyle()).getLabel(),
                 avgSeason
         );
-
 
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.matchrequirement.core.service;
 
-import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
@@ -12,7 +11,6 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -42,15 +40,10 @@ public class MatchRequirementV3Service {
         matchRequirementRepository.save(matchRequirement);
     }
 
-    public MatchRequirementV3Res getMatchRequirement(Long userId) {
-        MatchRequirement requirement = Optional.ofNullable(matchRequirementRepository.findUserMatchRequirement(userId))
+    public MatchRequirement getMatchRequirement(Long userId) {
+        MatchRequirement matchRequirement = Optional.ofNullable(matchRequirementRepository.findUserMatchRequirement(userId))
                 .orElseThrow(() -> new BusinessException(MATCH_REQUIREMENT_NOT_FOUND));
 
-        return new MatchRequirementV3Res(
-                TeamName.from(requirement.getTeam()).getLabel(),
-                TeamAllowed.from(requirement.getTeamAllowed()).getLabel(),
-                Style.from(requirement.getStyle()).getLabel(),
-                requirement.getUser().getAvgSeason()
-        );
+        return matchRequirement;
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.matchrequirement.core.service;
 
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
@@ -11,6 +12,11 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static at.mateball.exception.code.BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -34,5 +40,17 @@ public class MatchRequirementV3Service {
                 Style.fromLabel(style).getValue()
         );
         matchRequirementRepository.save(matchRequirement);
+    }
+
+    public MatchRequirementV3Res getMatchRequirement(Long userId) {
+        MatchRequirement requirement = Optional.ofNullable(matchRequirementRepository.findUserMatchRequirement(userId))
+                .orElseThrow(() -> new BusinessException(MATCH_REQUIREMENT_NOT_FOUND));
+
+        return new MatchRequirementV3Res(
+                TeamName.from(requirement.getTeam()).getLabel(),
+                TeamAllowed.from(requirement.getTeamAllowed()).getLabel(),
+                Style.from(requirement.getStyle()).getLabel(),
+                requirement.getUser().getAvgSeason()
+        );
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -44,6 +44,12 @@ public class MatchRequirementV3Service {
         MatchRequirement matchRequirement = Optional.ofNullable(matchRequirementRepository.findUserMatchRequirement(userId))
                 .orElseThrow(() -> new BusinessException(MATCH_REQUIREMENT_NOT_FOUND));
 
+        if (matchRequirement.getTeam() == null
+                || matchRequirement.getTeamAllowed() == null
+                || matchRequirement.getStyle() == null) {
+            throw new BusinessException(MATCH_REQUIREMENT_NOT_FOUND);
+        }
+
         return matchRequirement;
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/OnboardingService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/OnboardingService.java
@@ -1,5 +1,10 @@
 package at.mateball.domain.matchrequirement.core.service;
 
+import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementV3Res;
+import at.mateball.domain.matchrequirement.core.MatchRequirement;
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
+import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.service.UserV3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,5 +20,19 @@ public class OnboardingService {
     public void setOnboardingInformation(Long userId, String team, String teamAllowed, String style, int avgSeason) {
         userV3Service.setAvgSeason(userId, avgSeason);
         matchRequirementV3Service.setMatchRequirement(userId, team, teamAllowed, style);
+    }
+
+    public MatchRequirementV3Res getMatchRequirementAndAvgSeason(Long userId) {
+        int avgSeason = userV3Service.getAvgSeason(userId);
+        MatchRequirement matchRequirement = matchRequirementV3Service.getMatchRequirement(userId);
+
+        return new MatchRequirementV3Res(
+                TeamName.from(matchRequirement.getTeam()).getLabel(),
+                TeamAllowed.from(matchRequirement.getTeamAllowed()).getLabel(),
+                Style.from(matchRequirement.getStyle()).getLabel(),
+                avgSeason
+        );
+
+
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -21,4 +21,8 @@ public class UserV3Service {
         return userRepository.getUser(userId).orElseThrow(()
                 -> new BusinessException(USER_NOT_FOUND));
     }
+
+    public int getAvgSeason(final Long userId) {
+        return findUser(userId).getAvgSeason();
+    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #217

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 OnboardingService -> MatchRequirementAndAvgSeason 으로 변경했습니다, 매우 긴 네이밍이지만 제일 직관적이라고 생각합니다...
- MatchRequirementAndAvgSeason Service 에서 User,MatchRequirement Service 의 함수를 호출해 필요한 정보들을 불러옵니다. (User->avgSeason / MatchRequirement -> team,teamAllowed,style)


<br/>


### ❤️ To 다진 / To 헤음

---

- 괴물네이밍의 등장...,
- user에서 avgSeason 조회 + matchRequirement에서 조건 조회해서 합쳐오는거라 2번의 쿼리가 발생하는데, 그냥 **쿼리DSL을 활용해서 한 번에 값을 가져오는게** 나을까요? (다시보니 너무 1차원적으로 작성한 코드인 것 같기도......................)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 현재 매치 요구사항과 평균 시즌을 반환하는 새 조회 API(/v3/users/match-condition) 추가
  * 매치 요구사항 등록/수정 흐름이 매치 요구사항과 평균 시즌을 함께 저장하도록 개선

* **Refactor**
  * 매치 요구사항과 평균 시즌 처리를 전반적으로 통합한 서비스 구조로 재구성
  * 평균 시즌 조회 기능이 서비스 레이어에서 노출되어 전반적 안정성 및 응답 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->