### PR TITLE
[fix] 매칭 조건 수정에 시즌 평균 직관 수 추가

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -73,7 +73,8 @@ public class MatchRequirementV3Controller {
         matchRequirementAndAvgSeasonService.updateMatchRequirementAndAvgSeason(userId, matchRequirementUpdateReq);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
-      
+    }
+
     @DeleteMapping
     public ResponseEntity<MateballResponse<?>> deleteMatchRequirement(
             @AuthenticationPrincipal CustomUserDetails customUserDetails

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -73,5 +73,14 @@ public class MatchRequirementV3Controller {
         matchRequirementAndAvgSeasonService.updateMatchRequirementAndAvgSeason(userId, matchRequirementUpdateReq);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
+      
+    @DeleteMapping
+    public ResponseEntity<MateballResponse<?>> deleteMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        matchRequirementV3Service.deleteByUserId(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -3,7 +3,7 @@ package at.mateball.domain.matchrequirement.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
-import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementUpdateReq;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementAndAvgSeasonService;
 import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndAvgSeasonRes;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;

--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -3,6 +3,7 @@ package at.mateball.domain.matchrequirement.api.controller;
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementV3Req;
+import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementAndAvgSeasonService;
 import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndAvgSeasonRes;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementV3Service;
@@ -59,5 +60,18 @@ public class MatchRequirementV3Controller {
         matchRequirementV3Service.deleteByUserId(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));
+    }
+
+    @PatchMapping
+    @Operation(summary = "매칭 조건 수정 api")
+    public ResponseEntity<MateballResponse<?>> updateMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody MatchRequirementUpdateReq matchRequirementUpdateReq
+    ) {
+        Long userId = userDetails.getUserId();
+
+        matchRequirementAndAvgSeasonService.updateMatchRequirementAndAvgSeason(userId, matchRequirementUpdateReq);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementUpdateReq.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/dto/request/MatchRequirementUpdateReq.java
@@ -1,4 +1,4 @@
-package at.mateball.domain.matchrequirement.core.repository.querydsl;
+package at.mateball.domain.matchrequirement.api.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementUpdateReq.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementUpdateReq.java
@@ -1,0 +1,16 @@
+package at.mateball.domain.matchrequirement.core.repository.querydsl;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MatchRequirementUpdateReq(
+        @Schema(description = "응원하는 팀 이름")
+        String team,
+        @Schema(description = "응원 팀 허용 여부")
+        String teamAllowed,
+        @Schema(description = "시즌 평균 직관 수")
+        int avgSeason,
+        @Schema(description = "관람스타일")
+        String style
+) {
+}
+

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementUpdateReq.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/querydsl/MatchRequirementUpdateReq.java
@@ -8,7 +8,7 @@ public record MatchRequirementUpdateReq(
         @Schema(description = "응원 팀 허용 여부")
         String teamAllowed,
         @Schema(description = "시즌 평균 직관 수")
-        int avgSeason,
+        Integer avgSeason,
         @Schema(description = "관람스타일")
         String style
 ) {

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
@@ -4,7 +4,7 @@ import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndA
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
-import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementUpdateReq;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.service.UserV3Service;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementAndAvgSeasonService.java
@@ -4,6 +4,7 @@ import at.mateball.domain.matchrequirement.api.dto.response.MatchRequirementAndA
 import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
+import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.service.UserV3Service;
 import lombok.RequiredArgsConstructor;
@@ -33,5 +34,11 @@ public class MatchRequirementAndAvgSeasonService {
                 avgSeason
         );
 
+    }
+
+    @Transactional
+    public void updateMatchRequirementAndAvgSeason(Long userId, MatchRequirementUpdateReq req) {
+        userV3Service.updateAvgSeason(userId, req.avgSeason());
+        matchRequirementV3Service.updateMatchRequirement(userId, req);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -64,22 +64,30 @@ public class MatchRequirementV3Service {
     }
 
     public void updateMatchRequirement(Long userId, MatchRequirementUpdateReq req) {
-        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
+        MatchRequirement matchRequirement =
+                matchRequirementRepository.findUserMatchRequirement(userId);
+
+        TeamName currentTeam = TeamName.from(matchRequirement.getTeam());
+        TeamAllowed currentAllowed = TeamAllowed.from(matchRequirement.getTeamAllowed());
+
+        TeamName newTeam = req.team() != null
+                ? TeamName.fromLabel(req.team())
+                : currentTeam;
+
+        TeamAllowed newAllowed = req.teamAllowed() != null
+                ? TeamAllowed.fromLabel(req.teamAllowed())
+                : currentAllowed;
+
+        if (newTeam == TeamName.NONE && newAllowed != TeamAllowed.NO_PREFERENCE) {
+            throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
+        }
 
         if (req.team() != null) {
-            TeamName selectedTeam = TeamName.fromLabel(req.team());
-            matchRequirement.updateTeam(selectedTeam.getValue());
+            matchRequirement.updateTeam(newTeam.getValue());
+        }
 
-            if (req.teamAllowed() != null) {
-                TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
-                if (selectedTeam == TeamName.NONE && selectedAllowed != TeamAllowed.NO_PREFERENCE) {
-                    throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
-                }
-                matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
-            }
-        } else if (req.teamAllowed() != null) {
-            TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
-            matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
+        if (req.teamAllowed() != null) {
+            matchRequirement.updateTeamAllowed(newAllowed.getValue());
         }
 
         if (req.style() != null) {

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -93,5 +93,12 @@ public class MatchRequirementV3Service {
         if (req.style() != null) {
             matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
         }
+      
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        MatchRequirement matchRequirement = matchRequirementRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
+
+        matchRequirementRepository.delete(matchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -93,6 +93,7 @@ public class MatchRequirementV3Service {
         if (req.style() != null) {
             matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
         }
+    }
       
     @Transactional
     public void deleteByUserId(Long userId) {

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -4,7 +4,7 @@ import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
-import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
+import at.mateball.domain.matchrequirement.api.dto.request.MatchRequirementUpdateReq;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -4,6 +4,7 @@ import at.mateball.domain.matchrequirement.core.MatchRequirement;
 import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.constant.TeamAllowed;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequirementUpdateReq;
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
@@ -60,5 +61,29 @@ public class MatchRequirementV3Service {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
 
         matchRequirementRepository.delete(matchRequirement);
+    }
+
+    public void updateMatchRequirement(Long userId, MatchRequirementUpdateReq req) {
+        MatchRequirement matchRequirement = matchRequirementRepository.findUserMatchRequirement(userId);
+
+        if (req.team() != null) {
+            TeamName selectedTeam = TeamName.fromLabel(req.team());
+            matchRequirement.updateTeam(selectedTeam.getValue());
+
+            if (req.teamAllowed() != null) {
+                TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+                if (selectedTeam == TeamName.NONE && selectedAllowed != TeamAllowed.NO_PREFERENCE) {
+                    throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
+                }
+                matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
+            }
+        } else if (req.teamAllowed() != null) {
+            TeamAllowed selectedAllowed = TeamAllowed.fromLabel(req.teamAllowed());
+            matchRequirement.updateTeamAllowed(selectedAllowed.getValue());
+        }
+
+        if (req.style() != null) {
+            matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -40,5 +40,12 @@ public class UserV3Service {
         if (avgSeason != null) {
             findUser(userId).updateAvgSeason(avgSeason);
         }
+      
+    @Transactional
+    public void clearOnboardingInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        user.clearOnboardingInfo();
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -35,4 +35,10 @@ public class UserV3Service {
 
         user.clearOnboardingInfo();
     }
+
+    public void updateAvgSeason(Long userId, Integer avgSeason) {
+        if (avgSeason != null) {
+            findUser(userId).updateAvgSeason(avgSeason);
+        }
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -40,6 +40,7 @@ public class UserV3Service {
         if (avgSeason != null) {
             findUser(userId).updateAvgSeason(avgSeason);
         }
+    }
       
     @Transactional
     public void clearOnboardingInfo(Long userId) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #222

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- MatchRequirementService,UserService 의 상위 Service인 MatchRequirementAndAvgSeasonService에 각각의 서비스를 호출하여, 매칭 조건과 시즌 평균 수 를 수정합니다.
- null 유무를 통해 각가의 컬럼값을 업데이트 합니다. 이때 기존/최신 응원팀/응원허용여부 를 조합하여 "응원팀이 없는데, 같은 팀을 응원하는 회원과 매칭되기를 원하는 경우"가 되는 것을 방지합니다.
```
        TeamName currentTeam = TeamName.from(matchRequirement.getTeam());
        TeamAllowed currentAllowed = TeamAllowed.from(matchRequirement.getTeamAllowed());

        TeamName newTeam = req.team() != null
                ? TeamName.fromLabel(req.team())
                : currentTeam;

        TeamAllowed newAllowed = req.teamAllowed() != null
                ? TeamAllowed.fromLabel(req.teamAllowed())
                : currentAllowed;

        if (newTeam == TeamName.NONE && newAllowed != TeamAllowed.NO_PREFERENCE) {
            throw new BusinessException(BusinessErrorCode.INVALID_TEAM_ALLOWED);
        }
```

<br/>


### ❤️ To 다진 / To 헤음

---

아 회식 가기 정말 싫어요
가기전에 우다다다다다....


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 매칭 요구사항 업데이트 기능 추가 - 팀 선호도, 허용된 팀, 평균 시즌, 플레이 스타일을 수정할 수 있습니다.
  * 매칭 요구사항 삭제 기능 추가 - 사용자가 자신의 매칭 요구사항을 제거할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->