### PR TITLE
[test] 온보딩 및 매칭조건 삭제

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -50,4 +50,14 @@ public class MatchRequirementV3Controller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
+
+    @DeleteMapping
+    public ResponseEntity<MateballResponse<?>> deleteMatchRequirement(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        matchRequirementV3Service.deleteByUserId(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));
+    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/repository/MatchRequirementRepository.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/repository/MatchRequirementRepository.java
@@ -5,6 +5,9 @@ import at.mateball.domain.matchrequirement.core.repository.querydsl.MatchRequire
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MatchRequirementRepository extends JpaRepository<MatchRequirement, Long>, MatchRequirementRepositoryCustom {
+    Optional<MatchRequirement> findByUserId(Long userId);
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -11,6 +11,7 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -51,5 +52,13 @@ public class MatchRequirementV3Service {
         }
 
         return matchRequirement;
+    }
+
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        MatchRequirement matchRequirement = matchRequirementRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
+
+        matchRequirementRepository.delete(matchRequirement);
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
@@ -1,0 +1,30 @@
+package at.mateball.domain.user.api.controller;
+
+import at.mateball.common.MateballResponse;
+import at.mateball.common.security.CustomUserDetails;
+import at.mateball.domain.user.api.dto.response.InfoCheckRes;
+import at.mateball.domain.user.core.service.UserV3Service;
+import at.mateball.exception.code.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v3/users")
+public class UserV3Controller {
+    private final UserV3Service userV3Service;
+
+    @PatchMapping("/onboarding")
+    public ResponseEntity<MateballResponse<?>> deleteOnboarding(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        userV3Service.clearOnboardingInfo(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));    }
+}

--- a/src/main/java/at/mateball/domain/user/core/User.java
+++ b/src/main/java/at/mateball/domain/user/core/User.java
@@ -107,4 +107,11 @@ public class User {
         }
         this.avgSeason = avgSeason;
     }
+
+    public void clearOnboardingInfo() {
+        this.nickname = null;
+        this.introduction = null;
+        this.birthYear = null;
+        this.gender = null;
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -3,8 +3,10 @@ package at.mateball.domain.user.core.service;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 
@@ -24,5 +26,13 @@ public class UserV3Service {
 
     public int getAvgSeason(final Long userId) {
         return findUser(userId).getAvgSeason();
+    }
+
+    @Transactional
+    public void clearOnboardingInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        user.clearOnboardingInfo();
     }
 }


### PR DESCRIPTION
[feat] 온보딩 및 매칭조건 삭제 API 구현

### 📌 이슈 번호

---

closed #225

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

클라이언트에서 온보딩 재진입이 가능하도록 로그인 사용자의 온보딩 정보와 매칭 조건을 삭제하는 API를 구현했습니다.

- User의 온보딩 정보(nickname, introduction, birth_year, gender) 초기화 API 구현
- 로그인 사용자의 MatchRequirement 삭제 API 구현
- 사용자 인증 정보(CustomUserDetails)를 기반으로 userId를 조회하여 처리하도록 구성

<br/>

### ❤️ To 다진 / To 헤음

---

클라이언트에서 온보딩을 다시 진행할 수 있도록 간단하게 초기화 API 추가해쓰요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 사용자의 매치 요구사항 삭제 기능 추가
- 온보딩 정보 초기화 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->