### PR TITLE
[fix] 충돌 해결하면서 생긴 중복 메소드 삭제

### DIFF
--- a/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/api/controller/MatchRequirementV3Controller.java
@@ -74,14 +74,4 @@ public class MatchRequirementV3Controller {
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
     }
-
-    @DeleteMapping
-    public ResponseEntity<MateballResponse<?>> deleteMatchRequirement(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
-    ) {
-        Long userId = customUserDetails.getUserId();
-        matchRequirementV3Service.deleteByUserId(userId);
-
-        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));
-    }
 }

--- a/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
+++ b/src/main/java/at/mateball/domain/matchrequirement/core/service/MatchRequirementV3Service.java
@@ -94,12 +94,5 @@ public class MatchRequirementV3Service {
             matchRequirement.updateStyle(Style.fromLabel(req.style()).getValue());
         }
     }
-      
-    @Transactional
-    public void deleteByUserId(Long userId) {
-        MatchRequirement matchRequirement = matchRequirementRepository.findByUserId(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
 
-        matchRequirementRepository.delete(matchRequirement);
-    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -41,12 +41,5 @@ public class UserV3Service {
             findUser(userId).updateAvgSeason(avgSeason);
         }
     }
-      
-    @Transactional
-    public void clearOnboardingInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
 
-        user.clearOnboardingInfo();
-    }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #229 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---



<br/>


### ❤️ To 다진 / To 헤음

---

- 아까 깃 머지 해결하다가 꼬인 부분 함수가 중복으로 존재해서 삭제했습니다...........


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 매치 조건 삭제 기능이 제거되었습니다.
  * 사용자 온보딩 정보 초기화 기능이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->