### PR TITLE
[fix] 예외 처리 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -132,6 +132,8 @@ public class GroupV3Service {
     }
 
     public GroupMatchMemberListRes getMatchGroupMembers(Long userId, Long matchId) {
+        validateNotOwnMatch(userId, matchId);
+
         LoginUserMatchRequirementDto loginRequirement = groupV3RepositoryCustom.findLoginUserMatchRequirement(userId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
 
@@ -159,6 +161,15 @@ public class GroupV3Service {
                 .toList();
 
         return new GroupMatchMemberListRes(results);
+    }
+
+    private void validateNotOwnMatch(Long userId, Long matchId) {
+        Long leaderId = groupV3RepositoryCustom.findLeaderIdByMatchId(matchId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        if (leaderId.equals(userId)) {
+            throw new BusinessException(BusinessErrorCode.OWN_MATCH_MEMBER_VIEW_NOT_ALLOWED);
+        }
     }
 
     private GroupMatchMemberRes toGroupMatchMemberRes(


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #231 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

getMatchGroupMembers() 조회 시 로그인 사용자가 생성한 매칭인지 검증하는 로직을 추가했습니다.

matchId의 leaderId를 조회하여 로그인 사용자와 동일한 경우OWN_MATCH_MEMBER_VIEW_NOT_ALLOWED 예외가 발생하도록 처리했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---

머지하다가 사라졌나봅니다... 다시 부활시켰어요ㅜㅜ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 매치 리더가 자신의 매치 멤버 정보를 조회하지 못하도록 접근 제어 기능을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->