### PR TITLE
[feat] 마이페이지 정보 조회 api 생성

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
@@ -2,9 +2,10 @@ package at.mateball.domain.user.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
-import at.mateball.domain.user.api.dto.response.InfoCheckRes;
+import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.service.UserV3Service;
 import at.mateball.exception.code.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,5 +27,17 @@ public class UserV3Controller {
         Long userId = customUserDetails.getUserId();
         userV3Service.clearOnboardingInfo(userId);
 
-        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));    }
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.NO_CONTENT, null));
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "마이페이지 정보 조회 api")
+    public ResponseEntity<MateballResponse<?>> getMyPageInformation(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        MyPageInformationRes userInfo = userV3Service.getMyPageInformation(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, userInfo));
+    }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
@@ -1,0 +1,12 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record MyPageInformationBaseRes(
+        String nickname,
+        Integer team,
+        Integer style,
+        String imgUrl,
+        Long matchCnt,
+        Integer avgSeason
+) {
+
+}

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
@@ -4,7 +4,6 @@ public record MyPageInformationBaseRes(
         String nickname,
         Integer team,
         Integer style,
-        String imgUrl,
         Long matchCnt,
         Integer avgSeason
 ) {

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationBaseRes.java
@@ -1,11 +1,11 @@
 package at.mateball.domain.user.api.dto.response;
 
+import at.mateball.domain.user.core.User;
+
 public record MyPageInformationBaseRes(
-        String nickname,
+        User user,
         Integer team,
         Integer style,
-        Long matchCnt,
-        Integer avgSeason
+        Long matchCnt
 ) {
-
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
@@ -18,17 +18,17 @@ public record MyPageInformationRes(
         @Schema(description = "시즌 평균 직관")
         Integer avgSeason
 ) {
-    public static MyPageInformationRes of(
+    public static MyPageInformationRes from(
             MyPageInformationBaseRes base,
             String imageUrl
     ) {
         return new MyPageInformationRes(
-                base.nickname(),
+                base.user().getNickname(),
                 TeamName.from(base.team()).getLabel(),
                 Style.from(base.style()).getLabel(),
                 imageUrl,
                 base.matchCnt(),
-                base.avgSeason()
+                base.user().getAvgSeason()
         );
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
@@ -1,0 +1,32 @@
+package at.mateball.domain.user.api.dto.response;
+
+import at.mateball.domain.matchrequirement.core.constant.Style;
+import at.mateball.domain.team.core.TeamName;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MyPageInformationRes(
+        @Schema(description = "사용자의 닉네임")
+        String nickname,
+        @Schema(description = "응원 팀")
+        String team,
+        @Schema(description = "사용자의 직관 스타일")
+        String style,
+        @Schema(description = "사용자의 프로필 이미지")
+        String imgUrl,
+        @Schema(description = "함께한 매칭")
+        Long matchCnt,
+        @Schema(description = "시즌 평균 직관")
+        Integer avgSeason
+) {
+    public static MyPageInformationRes fromBase(MyPageInformationBaseRes myPageInformationBaseRes) {
+        return new MyPageInformationRes(
+                myPageInformationBaseRes.nickname(),
+                TeamName.from(myPageInformationBaseRes.team()).getLabel(),
+                Style.from(myPageInformationBaseRes.style()).getLabel(),
+                myPageInformationBaseRes.imgUrl(),
+                myPageInformationBaseRes.matchCnt(),
+                myPageInformationBaseRes.avgSeason()
+        );
+    }
+
+}

--- a/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/MyPageInformationRes.java
@@ -18,15 +18,17 @@ public record MyPageInformationRes(
         @Schema(description = "시즌 평균 직관")
         Integer avgSeason
 ) {
-    public static MyPageInformationRes fromBase(MyPageInformationBaseRes myPageInformationBaseRes) {
+    public static MyPageInformationRes of(
+            MyPageInformationBaseRes base,
+            String imageUrl
+    ) {
         return new MyPageInformationRes(
-                myPageInformationBaseRes.nickname(),
-                TeamName.from(myPageInformationBaseRes.team()).getLabel(),
-                Style.from(myPageInformationBaseRes.style()).getLabel(),
-                myPageInformationBaseRes.imgUrl(),
-                myPageInformationBaseRes.matchCnt(),
-                myPageInformationBaseRes.avgSeason()
+                base.nickname(),
+                TeamName.from(base.team()).getLabel(),
+                Style.from(base.style()).getLabel(),
+                imageUrl,
+                base.matchCnt(),
+                base.avgSeason()
         );
     }
-
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -3,6 +3,7 @@ package at.mateball.domain.user.core.repository;
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
+import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
 
@@ -19,4 +20,6 @@ public interface UserRepositoryCustom {
     CheckUserRes fetchUserInfoCheck(Long userId);
 
     InfoCheckRes infoCheck(Long userId);
+
+    MyPageInformationRes findMyPageInformation(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryCustom.java
@@ -2,8 +2,8 @@ package at.mateball.domain.user.core.repository;
 
 import at.mateball.domain.user.api.dto.response.CheckUserRes;
 import at.mateball.domain.user.api.dto.response.InfoCheckRes;
+import at.mateball.domain.user.api.dto.response.MyPageInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.UserInformationRes;
-import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.User;
 import org.springframework.stereotype.Repository;
 
@@ -21,5 +21,5 @@ public interface UserRepositoryCustom {
 
     InfoCheckRes infoCheck(Long userId);
 
-    MyPageInformationRes findMyPageInformation(Long userId);
+    MyPageInformationBaseRes findMyPageInformation(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -142,11 +142,10 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         return queryFactory
                 .select(Projections.constructor(
                         MyPageInformationBaseRes.class,
-                        user.nickname,
+                        user,
                         matchRequirement.team,
                         matchRequirement.style,
-                        groupMember.id.count(),
-                        user.avgSeason
+                        groupMember.id.count()
                 ))
                 .from(user)
                 .leftJoin(matchRequirement)
@@ -159,7 +158,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .where(user.id.eq(userId))
                 .groupBy(
                         user.id,
-                        user.nickname,
                         matchRequirement.team,
                         matchRequirement.style,
                         user.avgSeason

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -134,18 +134,17 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     @Override
-    public MyPageInformationRes findMyPageInformation(Long userId) {
+    public MyPageInformationBaseRes findMyPageInformation(Long userId) {
         QUser user = QUser.user;
         QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
         QGroupMember groupMember = QGroupMember.groupMember;
 
-        var baseUserInformation = queryFactory
+        return queryFactory
                 .select(Projections.constructor(
                         MyPageInformationBaseRes.class,
                         user.nickname,
                         matchRequirement.team,
                         matchRequirement.style,
-                        user.imgUrl,
                         groupMember.id.count(),
                         user.avgSeason
                 ))
@@ -163,11 +162,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         user.nickname,
                         matchRequirement.team,
                         matchRequirement.style,
-                        user.imgUrl,
                         user.avgSeason
                 )
                 .fetchOne();
-
-        return MyPageInformationRes.fromBase(baseUserInformation);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,10 +1,9 @@
 package at.mateball.domain.user.core.repository;
 
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
-import at.mateball.domain.user.api.dto.response.CheckUserRes;
-import at.mateball.domain.user.api.dto.response.InfoCheckRes;
-import at.mateball.domain.user.api.dto.response.UserInformationBaseRes;
-import at.mateball.domain.user.api.dto.response.UserInformationRes;
+import at.mateball.domain.user.api.dto.response.*;
 import at.mateball.domain.user.core.QUser;
 import at.mateball.domain.user.core.User;
 import at.mateball.exception.BusinessException;
@@ -132,5 +131,43 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         boolean accepted = hasAccepted != null && hasAccepted;
 
         return new InfoCheckRes(nicknameExists, allConditionsPresent, accepted);
+    }
+
+    @Override
+    public MyPageInformationRes findMyPageInformation(Long userId) {
+        QUser user = QUser.user;
+        QMatchRequirement matchRequirement = QMatchRequirement.matchRequirement;
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        var baseUserInformation = queryFactory
+                .select(Projections.constructor(
+                        MyPageInformationBaseRes.class,
+                        user.nickname,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        user.imgUrl,
+                        groupMember.id.count(),
+                        user.avgSeason
+                ))
+                .from(user)
+                .leftJoin(matchRequirement)
+                .on(matchRequirement.user.id.eq(user.id))
+                .leftJoin(groupMember)
+                .on(
+                        groupMember.user.id.eq(user.id)
+                                .and(groupMember.status.eq(GroupMemberStatus.MATCHED.getValue()))
+                )
+                .where(user.id.eq(userId))
+                .groupBy(
+                        user.id,
+                        user.nickname,
+                        matchRequirement.team,
+                        matchRequirement.style,
+                        user.imgUrl,
+                        user.avgSeason
+                )
+                .fetchOne();
+
+        return MyPageInformationRes.fromBase(baseUserInformation);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -1,6 +1,8 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.domain.matchrequirement.core.constant.Style;
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.api.dto.response.MyPageInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.User;
@@ -48,13 +50,12 @@ public class UserV3Service {
     }
 
     public MyPageInformationRes getMyPageInformation(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+        MyPageInformationBaseRes baseRes = userRepository.findMyPageInformation(userId);
 
-        MyPageInformationBaseRes base = userRepository.findMyPageInformation(userId);
+        if (baseRes == null) {throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);}
 
-        String imageUrl = userProfileImageService.getProfileImageUrl(user);
+        String imageUrl = userProfileImageService.getProfileImageUrl(baseRes.user());
 
-        return MyPageInformationRes.of(base, imageUrl);
+        return MyPageInformationRes.from(baseRes,imageUrl);
     }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.user.core.service;
 
+import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
@@ -14,6 +16,7 @@ import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 @RequiredArgsConstructor
 public class UserV3Service {
     private final UserRepository userRepository;
+    private final MatchRequirementRepository matchRequirementRepository;
 
     public void setAvgSeason(final Long userId, final int avgSeason) {
         findUser(userId).updateAvgSeason(avgSeason);
@@ -27,7 +30,7 @@ public class UserV3Service {
     public int getAvgSeason(final Long userId) {
         return findUser(userId).getAvgSeason();
     }
-
+      
     @Transactional
     public void clearOnboardingInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -42,4 +45,7 @@ public class UserV3Service {
         }
     }
 
+    public MyPageInformationRes getMyPageInformation(Long userId) {
+        return userRepository.findMyPageInformation(userId);
+    }
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.user.core.service;
 
 import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepository;
+import at.mateball.domain.user.api.dto.response.MyPageInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
@@ -16,6 +17,7 @@ import static at.mateball.exception.code.BusinessErrorCode.USER_NOT_FOUND;
 @RequiredArgsConstructor
 public class UserV3Service {
     private final UserRepository userRepository;
+    private final UserProfileImageService userProfileImageService;
     private final MatchRequirementRepository matchRequirementRepository;
 
     public void setAvgSeason(final Long userId, final int avgSeason) {
@@ -30,7 +32,7 @@ public class UserV3Service {
     public int getAvgSeason(final Long userId) {
         return findUser(userId).getAvgSeason();
     }
-      
+
     @Transactional
     public void clearOnboardingInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -46,6 +48,13 @@ public class UserV3Service {
     }
 
     public MyPageInformationRes getMyPageInformation(Long userId) {
-        return userRepository.findMyPageInformation(userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.USER_NOT_FOUND));
+
+        MyPageInformationBaseRes base = userRepository.findMyPageInformation(userId);
+
+        String imageUrl = userProfileImageService.getProfileImageUrl(user);
+
+        return MyPageInformationRes.of(base, imageUrl);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #228

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 마이페이지 정보 조회 api 를 생성합니다.
- User Controller > User Service > User Repository (상위 service 로 통합 x)
- BaseRes /Res 로 클라이언트 전달 dto 와 쿼리문 전용 dto 분리
  - Res: BaseRes 의 값을 enum label 로 변환
- findMyPageInformation: user 테이블에서 닉네임,프로필 이미지,시즌평균 직관 수 가져옴 & matchRequirement 테이블에서 응원팀,응원스타일 가져옴 & groupMember 테이블에서 Matched(매칭완료) 상태인 row 수 count


<br/>


### ❤️ To 다진 / To 헤음

---

- 평균 직관 수 걍 매칭조건에 넣을걸 ~~~ ㅎㅎ ㅋㅋ ㅠㅠ



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 인증된 사용자의 마이페이지 정보 조회 추가(닉네임, 팀/스타일 표기, 프로필 이미지, 매치 횟수, 평균 시즌)
  * 사용자가 요청한 그룹 목록 조회 추가(요청 상태, 관련 매치 정보 및 이미지 포함)
* **동작/검증 개선**
  * 요청 그룹 조회 시 대기 중 상태에 대한 명확한 에러 처리 추가
  * 본인이 생성한 경기의 멤버 조회 제한 도입
* **표시 개선**
  * 그룹 요청 상태에 대한 사용자용 라벨 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->