### PR TITLE
[feat/#227] 요청 리스트 조회

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -5,6 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.group.api.dto.CreateGroupListRes;
 import at.mateball.domain.group.api.dto.GroupMatchMemberListRes;
 import at.mateball.domain.group.api.dto.GroupMatchRes;
+import at.mateball.domain.group.api.dto.RequestGroupListRes;
 import at.mateball.domain.group.core.service.GroupV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,8 +46,8 @@ public class GroupV3Controller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
-  
-  @GetMapping("/match/members/{matchId}")
+
+    @GetMapping("/match/members/{matchId}")
     @Operation(summary = "매칭된 그룹원 리스트 조회 api")
     public ResponseEntity<MateballResponse<GroupMatchMemberListRes>> getMatchGroupMembers(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -57,5 +58,17 @@ public class GroupV3Controller {
         GroupMatchMemberListRes result = groupV3Service.getMatchGroupMembers(userId, matchId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
+    @GetMapping("request")
+    @Operation(summary = "요청한 매칭 리스트 조회 api")
+    public ResponseEntity<MateballResponse<RequestGroupListRes>> getRequestGroupList(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        RequestGroupListRes ressult = groupV3Service.getRequestGroupList(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, ressult));
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/RequestGroupListRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/RequestGroupListRes.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.group.api.dto;
+
+import java.util.List;
+
+public record RequestGroupListRes(
+        List<RequestGroupRes> results
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/RequestGroupRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/RequestGroupRes.java
@@ -1,0 +1,18 @@
+package at.mateball.domain.group.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record RequestGroupRes(
+        Long matchId,
+        String nickname,
+        Integer count,
+        Boolean isGroup,
+        String awayTeam,
+        String homeTeam,
+        LocalDate date,
+        String stateLabel,
+        String update,
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,10 +1,6 @@
 package at.mateball.domain.group.core.service;
 
-import at.mateball.domain.group.api.dto.CreateGroupListRes;
-import at.mateball.domain.group.api.dto.CreateGroupRes;
-import at.mateball.domain.group.api.dto.GroupMatchMemberListRes;
-import at.mateball.domain.group.api.dto.GroupMatchMemberRes;
-import at.mateball.domain.group.api.dto.GroupMatchRes;
+import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.assembler.MatchImageAssembler;
@@ -26,6 +22,8 @@ import at.mateball.storage.FileStorage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.group.infrastructure.dto.RequestGroupQueryDto;
 
 import java.time.LocalDate;
 import java.util.Collections;
@@ -186,6 +184,45 @@ public class GroupV3Service {
         );
     }
 
+    public RequestGroupListRes getRequestGroupList(Long userId) {
+        List<RequestGroupQueryDto> groups = groupV3RepositoryCustom.findRequestGroupsByUserId(userId);
+
+        if (groups.isEmpty()) {
+            return new RequestGroupListRes(List.of());
+        }
+
+        validateRequestGroupStatuses(groups);
+
+        List<Long> matchIds = groups.stream()
+                .map(RequestGroupQueryDto::matchId)
+                .toList();
+
+        Map<Long, List<String>> imageMap = matchImageAssembler.assemble(
+                groupV3RepositoryCustom.findRequestGroupImagesByMatchIds(matchIds)
+        );
+
+        List<RequestGroupRes> results = groups.stream()
+                .map(group -> {
+                    GroupMemberStatus status = group.statusEnum();
+
+                    return new RequestGroupRes(
+                            group.matchId(),
+                            group.nickname(),
+                            group.count(),
+                            group.isGroup(),
+                            group.awayTeam(),
+                            group.homeTeam(),
+                            group.date(),
+                            status.toResponseLabel(),
+                            resolveRequestUpdateLabel(status),
+                            imageMap.getOrDefault(group.matchId(), Collections.emptyList())
+                    );
+                })
+                .toList();
+
+        return new RequestGroupListRes(results);
+    }
+
     private String resolveUpdateLabel(Boolean hasNewRequest) {
         return Boolean.TRUE.equals(hasNewRequest) ? NEW_REQUEST_LABEL : null;
     }
@@ -209,5 +246,18 @@ public class GroupV3Service {
 
     private String resolveProfileImageUrl(String profileImageKey) {
         return fileStorage.getImageUrl(profileImageKey);
+    }
+
+    private void validateRequestGroupStatuses(List<RequestGroupQueryDto> groups) {
+        boolean hasPendingRequest = groups.stream()
+                .anyMatch(group -> group.statusEnum() == GroupMemberStatus.PENDING_REQUEST);
+
+        if (hasPendingRequest) {
+            throw new BusinessException(BusinessErrorCode.WAITING_MATE_ACCEPTANCE);
+        }
+    }
+
+    private String resolveRequestUpdateLabel(GroupMemberStatus status) {
+        return status == GroupMemberStatus.MATCH_FAILED ? GroupMemberStatus.MATCH_FAILED.getLabel() : null;
     }
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/dto/RequestGroupQueryDto.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/dto/RequestGroupQueryDto.java
@@ -1,0 +1,20 @@
+package at.mateball.domain.group.infrastructure.dto;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+
+import java.time.LocalDate;
+
+public record RequestGroupQueryDto(
+        Long matchId,
+        String nickname,
+        Integer count,
+        Boolean isGroup,
+        String awayTeam,
+        String homeTeam,
+        LocalDate date,
+        Integer status
+) {
+    public GroupMemberStatus statusEnum() {
+        return GroupMemberStatus.from(status);
+    }
+}

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -1,13 +1,6 @@
 package at.mateball.domain.group.infrastructure.repository;
 
-import at.mateball.domain.group.infrastructure.dto.CreateGroupImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.CreateGroupQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GameInfoQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchCandidateFlatDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchMemberQueryDto;
-import at.mateball.domain.group.infrastructure.dto.LoginUserMatchRequirementDto;
-import at.mateball.domain.group.infrastructure.dto.MemberMatchCountDto;
+import at.mateball.domain.group.infrastructure.dto.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,4 +24,8 @@ public interface GroupV3RepositoryCustom {
     List<GroupMatchMemberQueryDto> findMatchMembersByMatchId(Long matchId);
 
     List<MemberMatchCountDto> countGroupMembersByUserIds(List<Long> memberIds);
+
+    List<RequestGroupQueryDto> findRequestGroupsByUserId(Long userId);
+
+    List<GroupMatchImageQueryDto> findRequestGroupImagesByMatchIds(List<Long> matchIds);
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -1,21 +1,16 @@
 package at.mateball.domain.group.infrastructure.repository;
 
 import at.mateball.domain.group.core.GroupStatus;
-import at.mateball.domain.group.infrastructure.dto.CreateGroupImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.CreateGroupQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GameInfoQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchCandidateFlatDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchMemberQueryDto;
-import at.mateball.domain.group.infrastructure.dto.LoginUserMatchRequirementDto;
-import at.mateball.domain.group.infrastructure.dto.MemberMatchCountDto;
+import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.core.QUser;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -246,6 +241,70 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .from(groupMember)
                 .where(groupMember.user.id.in(memberIds))
                 .groupBy(groupMember.user.id)
+                .fetch();
+    }
+
+    @Override
+    public List<RequestGroupQueryDto> findRequestGroupsByUserId(Long userId) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QGroupMember leaderGroupMember = new QGroupMember("leaderGroupMember");
+        QGroupMember countGroupMember = new QGroupMember("countGroupMember");
+        QUser leaderUser = new QUser("leaderUser");
+
+        return queryFactory
+                .select(Projections.constructor(
+                        RequestGroupQueryDto.class,
+                        group.id,
+                        leaderUser.nickname,
+                        ExpressionUtils.as(
+                                JPAExpressions
+                                        .select(countGroupMember.count().intValue())
+                                        .from(countGroupMember)
+                                        .where(countGroupMember.group.id.eq(group.id)),
+                                "count"
+                        ),
+                        group.isGroup,
+                        gameInformation.awayTeamName,
+                        gameInformation.homeTeamName,
+                        gameInformation.gameDate,
+                        groupMember.status
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .join(group.gameInformation, gameInformation)
+                .join(leaderGroupMember).on(
+                        leaderGroupMember.group.id.eq(group.id)
+                                .and(leaderGroupMember.isLeader.isTrue())
+                )
+                .join(leaderGroupMember.user, leaderUser)
+                .where(
+                        groupMember.user.id.eq(userId),
+                        groupMember.isLeader.isFalse()
+                )
+                .orderBy(gameInformation.gameDate.asc(), group.id.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<GroupMatchImageQueryDto> findRequestGroupImagesByMatchIds(List<Long> matchIds) {
+        QGroupMember groupMember = QGroupMember.groupMember;
+
+        if (matchIds == null || matchIds.isEmpty()) {
+            return List.of();
+        }
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GroupMatchImageQueryDto.class,
+                        group.id,
+                        groupMember.user.profileImageKey
+                ))
+                .from(groupMember)
+                .join(groupMember.group, group)
+                .where(
+                        group.id.in(matchIds),
+                        groupMember.isParticipant.isTrue()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -305,6 +305,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         group.id.in(matchIds),
                         groupMember.isParticipant.isTrue()
                 )
+                .orderBy(
+                        group.id.asc(),
+                        groupMember.id.asc()
+                )
                 .fetch();
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -32,8 +32,8 @@ public enum GroupMemberStatus {
 
     public String toResponseLabel() {
         return switch (this) {
-            case AWAITING_APPROVAL -> "그룹원 모집 중";
-            case APPROVED -> "매칭완료";
+            case AWAITING_APPROVAL -> "수락 대기 중";
+            case APPROVED -> "수락완료";
             default -> null;
         };
     }

--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -29,4 +29,12 @@ public enum GroupMemberStatus {
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
+
+    public String toResponseLabel() {
+        return switch (this) {
+            case AWAITING_APPROVAL -> "그룹원 모집 중";
+            case APPROVED -> "매칭완료";
+            default -> null;
+        };
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -37,6 +37,9 @@ public class GroupMember {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "is_leader")
+    private Boolean isLeader;
+
     protected GroupMember() {
     }
 

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -31,6 +31,7 @@ public enum BusinessErrorCode implements ErrorCode {
     INVALID_PROFILE_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "프로필 이미지는 5MB 이하만 업로드할 수 있습니다."),
     OWN_MATCH_MEMBER_VIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "내가 만든 매칭은 매칭현황에서 확인 가능해요."),
     INVALID_AVG_SEASON(HttpStatus.BAD_REQUEST, "시즌 평균 직관 수는 0-999까지 입력 가능합니다."),
+    WAITING_MATE_ACCEPTANCE(HttpStatus.BAD_REQUEST,"메이트의 수락을 기다리는 중입니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #227

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

**요청한 매칭 리스트 조회 API**를 구현했습니다.

* `GroupV3Controller`

  * 로그인 사용자가 **요청한 매칭 리스트를 조회하는 API** 추가

* `GroupV3Service`

  * 요청한 매칭 목록 조회 로직 구현
  * 기존 `CreateGroupList` 흐름을 참고하여 동일한 구조로 서비스 로직 구성
  * 경기 정보, 매칭 상태, 이미지 등을 함께 반환하도록 처리

* `GroupV3Repository`

  * 로그인 사용자가 **참여한 그룹 중 leader가 아닌 매칭**을 조회하도록 쿼리 작성
  * 그룹 리더 정보를 join하여 **리더 닉네임 반환**
  * 참여 인원 수(count)는 **리더 포함 인원 기준으로 계산**

* 이미지 처리

  * `is_participant = 1` 인 멤버를 기준으로 이미지 조회
  * `profile_image_key` 가 null인 경우에도 조회되도록 수정하여
    `FileStorage#getImageUrl()`의 **기본 이미지 반환 로직을 활용하도록 개선**

<br/>

### ❤️ To 다진 / To 헤음

---

일단 자고 일어날게요..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 신청 목록 조회 추가: 사용자가 신청한 그룹 목록에서 매치 정보, 주최자 닉네임, 팀/일시, 이미지 목록을 한눈에 확인 가능
  * 상태 및 업데이트 라벨 표시: 모집 상태와 매칭 실패에 따른 업데이트 라벨을 함께 노출

* **버그 수정 및 개선**
  * 대기 중인 신청에 대한 검사 및 오류 처리 강화 (대기 상태 관련 메시지 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->