### PR TITLE
[feat] 매칭 생성 api v3 migration

### DIFF
--- a/src/main/java/at/mateball/domain/chatting/core/repository/ChattingRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/chatting/core/repository/ChattingRepositoryImpl.java
@@ -3,6 +3,7 @@ package at.mateball.domain.chatting.core.repository;
 import at.mateball.domain.chatting.core.Chatting;
 import at.mateball.domain.chatting.core.QChatting;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 
 import java.util.Optional;
 
@@ -22,6 +23,7 @@ public class ChattingRepositoryImpl implements ChattingRepositoryCustom {
                 .selectFrom(chatting)
                 .where(chatting.isUsed.eq(false))
                 .orderBy(chatting.id.asc())
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
                 .fetchFirst();
 
         return Optional.ofNullable(result);

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -78,7 +78,7 @@ public class GroupV3Controller {
     @Operation(summary = "매칭 생성 api")
     public ResponseEntity<MateballResponse<?>> createMatch(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
-            @Valid @RequestBody CreateMatchReq createMatchReq
+            @Valid @RequestBody CreateMatchV3Req createMatchReq
     ) {
         Long userId = customUserDetails.getUserId();
 

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -6,9 +6,11 @@ import at.mateball.domain.group.api.dto.CreateGroupListRes;
 import at.mateball.domain.group.api.dto.GroupMatchMemberListRes;
 import at.mateball.domain.group.api.dto.GroupMatchRes;
 import at.mateball.domain.group.api.dto.RequestGroupListRes;
+import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.core.service.GroupV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -70,5 +72,18 @@ public class GroupV3Controller {
         RequestGroupListRes ressult = groupV3Service.getRequestGroupList(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, ressult));
+    }
+
+    @PostMapping("/match")
+    @Operation(summary = "매칭 생성 api")
+    public ResponseEntity<MateballResponse<?>> createMatch(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody CreateMatchReq createMatchReq
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        CreateMatchRes createMatchRes = groupV3Service.createMatch(userId, createMatchReq.gameId(), createMatchReq.matchType());
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, createMatchRes));
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/CreateMatchV3Req.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/CreateMatchV3Req.java
@@ -1,0 +1,15 @@
+package at.mateball.domain.group.api.dto;
+
+import at.mateball.domain.group.core.MatchType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateMatchV3Req(
+        @NotNull
+        @Schema(description = "경기 ID")
+        Long gameId,
+        @NotNull
+        @Schema(description = "매칭 유형")
+        MatchType matchType
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/MatchValidationDto.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/MatchValidationDto.java
@@ -1,0 +1,8 @@
+package at.mateball.domain.group.api.dto;
+
+import java.time.LocalDate;
+
+public record MatchValidationDto(
+        LocalDate gameDate,
+        Boolean existsMatchOnSameGameInformation
+) {}

--- a/src/main/java/at/mateball/domain/group/api/dto/MatchValidationRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/MatchValidationRes.java
@@ -2,7 +2,7 @@ package at.mateball.domain.group.api.dto;
 
 import java.time.LocalDate;
 
-public record MatchValidationDto(
+public record MatchValidationRes(
         LocalDate gameDate,
         Boolean existsMatchOnSameGameInformation
 ) {}

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -10,7 +10,11 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "match_group")
+@Table(name = "match_group",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "game_information_id"})
+        }
+)
 public class Group {
 
     @Id

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "match_group",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"user_id", "game_information_id"}),
-                @UniqueConstraint(columnNames = {"chatting_id"})
+                @UniqueConstraint(name = "uk_group_chatting", columnNames = {"chatting_id"})
         }
 )
 public class Group {

--- a/src/main/java/at/mateball/domain/group/core/Group.java
+++ b/src/main/java/at/mateball/domain/group/core/Group.java
@@ -12,7 +12,8 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "match_group",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "game_information_id"})
+                @UniqueConstraint(columnNames = {"user_id", "game_information_id"}),
+                @UniqueConstraint(columnNames = {"chatting_id"})
         }
 )
 public class Group {
@@ -51,5 +52,13 @@ public class Group {
         this.createdAt = createdAt;
         this.status = status;
         this.isGroup = isGroup;
+    }
+
+    public static Group create(User leader, GameInformation gameInformation, boolean isGroup) {
+        return new Group(leader, gameInformation, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
+    }
+
+    public void assignChatting(Chatting chatting) {
+        this.chatting = chatting;
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -1,0 +1,41 @@
+package at.mateball.domain.group.core;
+
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.GroupMember;
+import at.mateball.domain.user.core.User;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+public class GroupExecutorV3 {
+
+    private final EntityManager entityManager;
+
+    public GroupExecutorV3(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Transactional
+    public Long createGroup(Long userId, Long gameId, boolean isGroup) {
+        User user = entityManager.find(User.class, userId);
+        if (user == null) {
+            throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);
+        }
+
+        GameInformation game = entityManager.find(GameInformation.class, gameId);
+
+        Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
+        entityManager.persist(group);
+
+        GroupMember leader = new GroupMember(user, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);
+        entityManager.persist(leader);
+
+        return group.getId();
+    }
+}

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.group.core;
 
+import at.mateball.domain.chatting.core.Chatting;
+import at.mateball.domain.chatting.core.service.ChattingV2Service;
 import at.mateball.domain.gameinformation.core.GameInformation;
 import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.GroupMember;
@@ -7,7 +9,6 @@ import at.mateball.domain.user.core.User;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,9 +18,11 @@ import java.time.LocalDateTime;
 public class GroupExecutorV3 {
 
     private final EntityManager entityManager;
+    private final ChattingV2Service chattingV2Service;
 
-    public GroupExecutorV3(EntityManager entityManager) {
+    public GroupExecutorV3(EntityManager entityManager, ChattingV2Service chattingV2Service) {
         this.entityManager = entityManager;
+        this.chattingV2Service = chattingV2Service;
     }
 
     @Transactional
@@ -31,17 +34,20 @@ public class GroupExecutorV3 {
 
         GameInformation game = entityManager.find(GameInformation.class, gameId);
 
-        try {
-            Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
-            entityManager.persist(group);
-            entityManager.flush();
-
-            GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
-            entityManager.persist(leader);
-
-            return group.getId();
-        } catch (PersistenceException e) {
-            throw new BusinessException(BusinessErrorCode.EXCEED_MATCHING_LIMIT);
+        Chatting chatting = chattingV2Service.assignChatting();
+        if (chatting == null) {
+            throw new BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND);
         }
+
+        Group group = Group.create(user, game, isGroup);
+        group.assignChatting(chatting);
+
+        entityManager.persist(group);
+        entityManager.flush();
+
+        GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
+        entityManager.persist(leader);
+
+        return group.getId();
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -7,6 +7,7 @@ import at.mateball.domain.user.core.User;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,12 +31,17 @@ public class GroupExecutorV3 {
 
         GameInformation game = entityManager.find(GameInformation.class, gameId);
 
-        Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
-        entityManager.persist(group);
+        try {
+            Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
+            entityManager.persist(group);
+            entityManager.flush();
 
-        GroupMember leader = GroupMember.leader(user,group,GroupMemberStatus.PENDING_REQUEST.getValue());
-        entityManager.persist(leader);
+            GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
+            entityManager.persist(leader);
 
-        return group.getId();
+            return group.getId();
+        } catch (PersistenceException e) {
+            throw new BusinessException(BusinessErrorCode.EXCEED_MATCHING_LIMIT);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -33,7 +33,7 @@ public class GroupExecutorV3 {
         Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
         entityManager.persist(group);
 
-        GroupMember leader = new GroupMember(user, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);
+        GroupMember leader = GroupMember.leader(user,group,GroupMemberStatus.PENDING_REQUEST.getValue());
         entityManager.persist(leader);
 
         return group.getId();

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -9,10 +9,11 @@ import at.mateball.domain.user.core.User;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import static at.mateball.exception.code.BusinessErrorCode.EXCEED_MATCHING_LIMIT;
 
 @Component
 public class GroupExecutorV3 {
@@ -27,27 +28,33 @@ public class GroupExecutorV3 {
 
     @Transactional
     public Long createGroup(Long userId, Long gameId, boolean isGroup) {
-        User user = entityManager.find(User.class, userId);
-        if (user == null) {
-            throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);
+
+        try {
+            User user = entityManager.find(User.class, userId);
+
+            if (user == null) {
+                throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);
+            }
+
+            GameInformation game = entityManager.find(GameInformation.class, gameId);
+
+            Chatting chatting = chattingV2Service.assignChatting();
+            if (chatting == null) {
+                throw new BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND);
+            }
+
+            Group group = Group.create(user, game, isGroup);
+            group.assignChatting(chatting);
+            entityManager.persist(group);
+            entityManager.flush();
+
+            GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
+            entityManager.persist(leader);
+
+            return group.getId();
+
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(EXCEED_MATCHING_LIMIT);
         }
-
-        GameInformation game = entityManager.find(GameInformation.class, gameId);
-
-        Chatting chatting = chattingV2Service.assignChatting();
-        if (chatting == null) {
-            throw new BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND);
-        }
-
-        Group group = Group.create(user, game, isGroup);
-        group.assignChatting(chatting);
-
-        entityManager.persist(group);
-        entityManager.flush();
-
-        GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
-        entityManager.persist(leader);
-
-        return group.getId();
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -7,23 +7,23 @@ import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.GroupMember;
 import at.mateball.domain.user.core.User;
 import at.mateball.exception.BusinessException;
+import at.mateball.exception.ConstraintExceptionTranslator;
 import at.mateball.exception.code.BusinessErrorCode;
 import jakarta.persistence.EntityManager;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import static at.mateball.exception.code.BusinessErrorCode.EXCEED_MATCHING_LIMIT;
 
 @Component
 public class GroupExecutorV3 {
 
     private final EntityManager entityManager;
     private final ChattingV2Service chattingV2Service;
+    private final ConstraintExceptionTranslator constraintExceptionTranslator;
 
-    public GroupExecutorV3(EntityManager entityManager, ChattingV2Service chattingV2Service) {
+    public GroupExecutorV3(EntityManager entityManager, ChattingV2Service chattingV2Service, ConstraintExceptionTranslator constraintExceptionTranslator) {
         this.entityManager = entityManager;
         this.chattingV2Service = chattingV2Service;
+        this.constraintExceptionTranslator = constraintExceptionTranslator;
     }
 
     @Transactional
@@ -53,8 +53,8 @@ public class GroupExecutorV3 {
 
             return group.getId();
 
-        } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(EXCEED_MATCHING_LIMIT);
+        } catch (Exception e) {
+            throw constraintExceptionTranslator.translate(e);
         }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -2,13 +2,17 @@ package at.mateball.domain.group.core.service;
 
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.group.api.dto.*;
+import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
+import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
+import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.assembler.MatchImageAssembler;
 import at.mateball.domain.group.core.calculator.MatchingScoreCalculator;
 import at.mateball.domain.group.core.calculator.MatchingTarget;
 import at.mateball.domain.group.core.calculator.common.GroupMatchAggregator;
 import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -28,6 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static at.mateball.domain.group.core.MatchType.DIRECT;
+import static at.mateball.domain.group.core.MatchType.GROUP;
+import static at.mateball.domain.group.core.validator.DateValidator.validate;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,11 +44,13 @@ public class GroupV3Service {
     private static final String NEW_REQUEST_LABEL = "새요청";
 
     private final GroupRepository groupRepository;
+    private final GameInformationRepository gameInformationRepository;
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final GroupMatchAggregator groupMatchAggregator;
     private final MatchImageAssembler matchImageAssembler;
     private final MatchingScoreCalculator matchingScoreCalculator;
     private final FileStorage fileStorage;
+    private final GroupExecutorV3 groupExecutor;
 
     public GroupMatchRes getGroupMatches(Long userId, Long gameId) {
         GameInfoQueryDto gameInfo = groupV3RepositoryCustom.findGameInfoByGameId(gameId)
@@ -288,5 +298,34 @@ public class GroupV3Service {
         }
 
         return new ChattingRes(data.chattingUrl());
+    }
+
+    @Transactional
+    public CreateMatchRes createMatch(Long userId, Long gameId, String matchType) {
+
+        boolean isGroup = validateMatchType(matchType);
+
+        MatchValidationDto data = groupV3RepositoryCustom.getMatchValidationInfo(userId, gameId);
+
+        if (data == null) {
+            throw new BusinessException(BusinessErrorCode.GAME_NOT_FOUND);
+        }
+
+        validate(data.gameDate());
+
+        if (data.existsMatchOnSameGameInformation()) {
+            throw new BusinessException(BusinessErrorCode.EXCEED_MATCHING_LIMIT);
+        }
+
+        return new CreateMatchRes(
+                groupExecutor.createGroup(userId, gameId, isGroup)
+        );
+    }
+
+    private boolean validateMatchType(String matchType) {
+        if (!String.valueOf(GROUP).equalsIgnoreCase(matchType) && !String.valueOf(DIRECT).equalsIgnoreCase(matchType)) {
+            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MATCH_TYPE);
+        }
+        return matchType.equalsIgnoreCase(String.valueOf(GROUP));
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -305,7 +305,7 @@ public class GroupV3Service {
 
         boolean isGroup = validateMatchType(matchType);
 
-        MatchValidationDto data = groupV3RepositoryCustom.getMatchValidationInfo(userId, gameId);
+        MatchValidationRes data = groupV3RepositoryCustom.getMatchValidationInfo(userId, gameId);
 
         if (data == null) {
             throw new BusinessException(BusinessErrorCode.GAME_NOT_FOUND);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,18 +1,17 @@
 package at.mateball.domain.group.core.service;
 
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
-import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
 import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.group.core.MatchType;
 import at.mateball.domain.group.core.assembler.MatchImageAssembler;
 import at.mateball.domain.group.core.calculator.MatchingScoreCalculator;
 import at.mateball.domain.group.core.calculator.MatchingTarget;
 import at.mateball.domain.group.core.calculator.common.GroupMatchAggregator;
 import at.mateball.domain.group.core.repository.GroupRepository;
-import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -32,8 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static at.mateball.domain.group.core.MatchType.DIRECT;
-import static at.mateball.domain.group.core.MatchType.GROUP;
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
 
 @Service
@@ -301,9 +298,9 @@ public class GroupV3Service {
     }
 
     @Transactional
-    public CreateMatchRes createMatch(Long userId, Long gameId, String matchType) {
+    public CreateMatchRes createMatch(Long userId, Long gameId, MatchType matchType) {
 
-        boolean isGroup = validateMatchType(matchType);
+        boolean isGroup = isGroupMatch(matchType);
 
         MatchValidationRes data = groupV3RepositoryCustom.getMatchValidationInfo(userId, gameId);
 
@@ -322,10 +319,7 @@ public class GroupV3Service {
         );
     }
 
-    private boolean validateMatchType(String matchType) {
-        if (!String.valueOf(GROUP).equalsIgnoreCase(matchType) && !String.valueOf(DIRECT).equalsIgnoreCase(matchType)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MATCH_TYPE);
-        }
-        return matchType.equalsIgnoreCase(String.valueOf(GROUP));
+    private boolean isGroupMatch(MatchType matchType) {
+        return matchType == MatchType.GROUP;
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
+++ b/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
@@ -13,7 +13,7 @@ public class DateValidator {
 
     public static void validate(LocalDate date) {
         LocalDate today = LocalDate.now();
-
+//        경기가 없는 월요일을 선택한 경우
 //        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
 //            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_MONDAY);
 //        }
@@ -22,6 +22,7 @@ public class DateValidator {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
         }
 
+//        경기 이틀전 매칭을 생성하려는 경우
 //        LocalDate minAvailableDate = today.plusDays(2);
 //        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
 //            minAvailableDate = today.plusDays(2);

--- a/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
+++ b/src/main/java/at/mateball/domain/group/core/validator/DateValidator.java
@@ -22,15 +22,14 @@ public class DateValidator {
             throw new BusinessException(BusinessErrorCode.BAD_REQUEST_PAST);
         }
 
-        LocalDate minAvailableDate = today.plusDays(2);
-        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
-            minAvailableDate = today.plusDays(2);
-//                        minAvailableDate = today.plusDays(3);
-        }
+//        LocalDate minAvailableDate = today.plusDays(2);
+//        if (minAvailableDate.getDayOfWeek() == DayOfWeek.MONDAY) {
+//            minAvailableDate = today.plusDays(2);
+//            minAvailableDate = today.plusDays(3);
+//        }
 
-        if (date.isBefore(minAvailableDate)) {
-            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_DATE);
-
-        }
+//        if (date.isBefore(minAvailableDate)) {
+//            throw new BusinessException(BusinessErrorCode.BAD_REQUEST_DATE);
+//        }
     }
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -1,7 +1,7 @@
 package at.mateball.domain.group.infrastructure.repository;
 
 import at.mateball.domain.group.infrastructure.dto.*;
-import at.mateball.domain.group.api.dto.MatchValidationDto;
+import at.mateball.domain.group.api.dto.MatchValidationRes;
 import at.mateball.domain.group.infrastructure.dto.CreateGroupImageQueryDto;
 import at.mateball.domain.group.infrastructure.dto.CreateGroupQueryDto;
 import at.mateball.domain.group.infrastructure.dto.GameInfoQueryDto;
@@ -38,5 +38,5 @@ public interface GroupV3RepositoryCustom {
 
     List<GroupMatchImageQueryDto> findRequestGroupImagesByMatchIds(List<Long> matchIds);
 
-    MatchValidationDto getMatchValidationInfo(Long userId, Long gameId);
+    MatchValidationRes getMatchValidationInfo(Long userId, Long gameId);
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -1,6 +1,15 @@
 package at.mateball.domain.group.infrastructure.repository;
 
 import at.mateball.domain.group.infrastructure.dto.*;
+import at.mateball.domain.group.api.dto.MatchValidationDto;
+import at.mateball.domain.group.infrastructure.dto.CreateGroupImageQueryDto;
+import at.mateball.domain.group.infrastructure.dto.CreateGroupQueryDto;
+import at.mateball.domain.group.infrastructure.dto.GameInfoQueryDto;
+import at.mateball.domain.group.infrastructure.dto.GroupMatchCandidateFlatDto;
+import at.mateball.domain.group.infrastructure.dto.GroupMatchImageQueryDto;
+import at.mateball.domain.group.infrastructure.dto.GroupMatchMemberQueryDto;
+import at.mateball.domain.group.infrastructure.dto.LoginUserMatchRequirementDto;
+import at.mateball.domain.group.infrastructure.dto.MemberMatchCountDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,4 +37,6 @@ public interface GroupV3RepositoryCustom {
     List<RequestGroupQueryDto> findRequestGroupsByUserId(Long userId);
 
     List<GroupMatchImageQueryDto> findRequestGroupImagesByMatchIds(List<Long> matchIds);
+
+    MatchValidationDto getMatchValidationInfo(Long userId, Long gameId);
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -1,5 +1,6 @@
 package at.mateball.domain.group.infrastructure.repository;
 
+import at.mateball.domain.group.api.dto.MatchValidationDto;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -310,5 +311,23 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         groupMember.id.asc()
                 )
                 .fetch();
+    }
+
+    @Override
+    public MatchValidationDto getMatchValidationInfo(Long userId, Long gameId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        MatchValidationDto.class,
+                        gameInformation.gameDate,
+                        group.id.isNotNull()
+                ))
+                .from(gameInformation)
+                .leftJoin(group)
+                .on(
+                        group.gameInformation.id.eq(gameInformation.id)
+                                .and(group.leader.id.eq(userId))
+                )
+                .where(gameInformation.id.eq(gameId))
+                .fetchOne();
     }
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -1,6 +1,6 @@
 package at.mateball.domain.group.infrastructure.repository;
 
-import at.mateball.domain.group.api.dto.MatchValidationDto;
+import at.mateball.domain.group.api.dto.MatchValidationRes;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -314,10 +314,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
     }
 
     @Override
-    public MatchValidationDto getMatchValidationInfo(Long userId, Long gameId) {
+    public MatchValidationRes getMatchValidationInfo(Long userId, Long gameId) {
         return queryFactory
                 .select(Projections.constructor(
-                        MatchValidationDto.class,
+                        MatchValidationRes.class,
                         gameInformation.gameDate,
                         group.id.isNotNull()
                 ))

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -11,7 +11,11 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "group_member")
+@Table(name = "group_member",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_group_member_user_group", columnNames = {"user_id", "group_id"})
+        }
+)
 @EntityListeners(AuditingEntityListener.class)
 public class GroupMember {
 

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -59,4 +59,8 @@ public class GroupMember {
         this.createdAt = LocalDateTime.now();
         this.isLeader = isLeader;
     }
+
+    public static GroupMember leader(User user, Group group, int status) {
+        return new GroupMember(user, group, true, status, true);
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -50,4 +50,13 @@ public class GroupMember {
         this.status = status;
         this.createdAt = LocalDateTime.now();
     }
+
+    public GroupMember(User user, Group group, Boolean isParticipant, int status, boolean isLeader) {
+        this.user = user;
+        this.group = group;
+        this.isParticipant = isParticipant;
+        this.status = status;
+        this.createdAt = LocalDateTime.now();
+        this.isLeader = isLeader;
+    }
 }

--- a/src/main/java/at/mateball/exception/ConstraintExceptionTranslator.java
+++ b/src/main/java/at/mateball/exception/ConstraintExceptionTranslator.java
@@ -16,8 +16,13 @@ public class ConstraintExceptionTranslator {
 
     public BusinessException translate(Exception e) {
         String constraint = extractConstraintName(e);
+
         BusinessErrorCode errorCode = CONSTRAINT_MAP.get(constraint);
-        return new BusinessException(errorCode);
+        if (errorCode != null) {
+            return new BusinessException(errorCode);
+        }
+
+        return new BusinessException(BusinessErrorCode.ERROR_UNKNOWN_ERROR);
     }
 
     private String extractConstraintName(Throwable e) {

--- a/src/main/java/at/mateball/exception/ConstraintExceptionTranslator.java
+++ b/src/main/java/at/mateball/exception/ConstraintExceptionTranslator.java
@@ -1,0 +1,35 @@
+package at.mateball.exception;
+
+import at.mateball.exception.code.BusinessErrorCode;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ConstraintExceptionTranslator {
+
+    private static final Map<String, BusinessErrorCode> CONSTRAINT_MAP = Map.of(
+            "uk_group_chatting", BusinessErrorCode.CHATTING_ALREADY_USED,
+            "uk_group_member_user_group", BusinessErrorCode.EXCEED_MATCHING_LIMIT
+    );
+
+    public BusinessException translate(Exception e) {
+        String constraint = extractConstraintName(e);
+        BusinessErrorCode errorCode = CONSTRAINT_MAP.get(constraint);
+        return new BusinessException(errorCode);
+    }
+
+    private String extractConstraintName(Throwable e) {
+        Throwable cause = e;
+
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException exception) {
+                return exception.getConstraintName();
+            }
+            cause = cause.getCause();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -67,7 +67,8 @@ public enum BusinessErrorCode implements ErrorCode {
 
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),
-    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "1대1 매칭은 최대 3개까지만 가능합니다.");
+    EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "1대1 매칭은 최대 3개까지만 가능합니다."),
+    EXCEED_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "한 경기에는 하나의 매칭만 생성할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -64,6 +64,7 @@ public enum BusinessErrorCode implements ErrorCode {
     DUPLICATED_REQUEST(HttpStatus.CONFLICT, "이미 요청을 전송한 매칭입니다."),
     DUPLICATED_INFO(HttpStatus.BAD_REQUEST, "이미 사용자 정보가 존재합니다. 사용자 정보 설정은 최초 한 번만 가능합니다."),
     DUPLICATED_MATCH_REQUIREMENT(HttpStatus.CONFLICT, "이미 매칭 조건이 존재합니다."),
+    CHATTING_ALREADY_USED(HttpStatus.CONFLICT, "이미 배정된 오픈채팅입니다. 매칭에 오픈채팅을 할당할 수 없습니다."),
 
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -69,7 +69,10 @@ public enum BusinessErrorCode implements ErrorCode {
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),
     EXCEED_DIRECT_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "1대1 매칭은 최대 3개까지만 가능합니다."),
-    EXCEED_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "한 경기에는 하나의 매칭만 생성할 수 있습니다.");
+    EXCEED_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "한 경기에는 하나의 매칭만 생성할 수 있습니다."),
+
+    // 501 Not Supported Error
+    ERROR_UNKNOWN_ERROR(HttpStatus.NOT_IMPLEMENTED, "서버 내부 오류: 에러 코드를 추출할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #237

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- groupMember 생성자에 isLeader 추가하면서 GroupExecutor를 V3로 마이그레이션
 -  `GroupMember leader = new GroupMember(user, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);` <- isLeader 값 추가됨
`
- DateValidator 에서 기존에 있던 경기 날짜 관련 검증 로직을 주석처리했으며, 과거의 경기인지 검증하는 로직만 남겨놨습니다.
- groupV3RepositoryCustom.getMatchValidationInfo : 쿼리 DSL로 경기정보(날짜) + 사용자가 같은 경기에 매칭을 생성했는지 에 대한 정보를 받아와 검증합니다. 만약 같은 경기에 매칭을 생성했을 경우 EXCEED_MATCHING_LIMIT 예외 터집니다.


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 매칭 생성용 새 API 엔드포인트 추가 (POST /v3/users/match)
  * 매칭 생성 응답 반환 및 관련 DTO 추가

* **개선 사항**
  * 매칭 생성 흐름 구현 및 영속화 처리 추가
  * 게임별 중복 매칭 방지 검증 추가
  * 날짜 검증 규칙 완화(최소 허용일 제한 제거)
  * 그룹 멤버에 리더 지정 기능 명시적 추가
  * 그룹 엔티티에 게임별 중복 방지 DB 제약 추가
  * 매칭 제한 관련 오류 코드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->