### PR TITLE
[feat] 매칭 요청 api V3 마이그레이션

### DIFF
--- a/src/main/java/at/mateball/domain/alarm/common/AlarmType.java
+++ b/src/main/java/at/mateball/domain/alarm/common/AlarmType.java
@@ -1,5 +1,5 @@
 package at.mateball.domain.alarm.common;
 
 public enum AlarmType {
-    NEW_REQUEST, APPROVED, MATCHED
+    NEW_REQUEST, PENDING, APPROVED, MATCHED
 }

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -86,4 +86,17 @@ public class GroupV3Controller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, createMatchRes));
     }
+
+    @PostMapping("/match-request/{matchId}")
+    @Operation(summary = "매칭 요청 api")
+    public ResponseEntity<MateballResponse<?>> createRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        groupV3Service.createRequest(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupValidationRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupValidationRes.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.group.api.dto;
 
+import at.mateball.domain.group.core.Group;
+
 import java.time.LocalDate;
 
 public record GroupValidationRes(
@@ -7,4 +9,11 @@ public record GroupValidationRes(
         LocalDate gameDate,
         int status
 ) {
+    public static GroupValidationRes from(Group group) {
+        return new GroupValidationRes(
+                group.getLeader().getId(),
+                group.getGameInformation().getGameDate(),
+                group.getStatus()
+        );
+    }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupValidationRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupValidationRes.java
@@ -1,0 +1,10 @@
+package at.mateball.domain.group.api.dto;
+
+import java.time.LocalDate;
+
+public record GroupValidationRes(
+        Long leaderId,
+        LocalDate gameDate,
+        int status
+) {
+}

--- a/src/main/java/at/mateball/domain/group/api/dto/RequestValidationRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/RequestValidationRes.java
@@ -1,0 +1,8 @@
+
+package at.mateball.domain.group.api.dto;
+
+public record RequestValidationRes(
+        boolean isDuplicatedRequest,
+        boolean hasPendingRequest
+) {
+}

--- a/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
@@ -23,6 +23,12 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     void deleteAllByLeaderId(@Param("userId") Long userId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select g from Group g where g.id = :groupId")
+    @Query("""
+                select g
+                from Group g
+                join fetch g.leader
+                join fetch g.gameInformation
+                where g.id = :groupId
+            """)
     Optional<Group> findGroupWithLock(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/GroupRepository.java
@@ -2,11 +2,15 @@ package at.mateball.domain.group.core.repository;
 
 import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.repository.querydsl.GroupRepositoryCustom;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long>, GroupRepositoryCustom {
@@ -17,4 +21,8 @@ public interface GroupRepository extends JpaRepository<Group, Long>, GroupReposi
     @Modifying
     @Query("delete from Group g where g.leader.id = :userId")
     void deleteAllByLeaderId(@Param("userId") Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Group g where g.id = :groupId")
+    Optional<Group> findGroupWithLock(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryCustom.java
@@ -3,6 +3,7 @@ package at.mateball.domain.group.core.repository.querydsl;
 import at.mateball.domain.group.api.dto.ChattingAccessRes;
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
+import at.mateball.domain.group.api.dto.GroupValidationRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupGetBaseRes;
 
@@ -30,4 +31,6 @@ public interface GroupRepositoryCustom {
     int bulkUpdateGroupMemberStatusToMatchFailed(List<Long> groupIds);
 
     ChattingAccessRes findChattingAccessInfo(Long userId, Long groupId);
+
+    GroupValidationRes findValidateGroupData(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -5,6 +5,7 @@ import at.mateball.domain.gameinformation.core.QGameInformation;
 import at.mateball.domain.group.api.dto.ChattingAccessRes;
 import at.mateball.domain.group.api.dto.DirectCreateRes;
 import at.mateball.domain.group.api.dto.GroupCreateRes;
+import at.mateball.domain.group.api.dto.GroupValidationRes;
 import at.mateball.domain.group.api.dto.base.DirectCreateBaseRes;
 import at.mateball.domain.group.api.dto.base.DirectGetBaseRes;
 import at.mateball.domain.group.api.dto.base.GroupCreateBaseRes;
@@ -286,6 +287,21 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .leftJoin(groupMember)
                 .on(groupMember.group.id.eq(group.id)
                         .and(groupMember.user.id.eq(userId)))
+                .where(group.id.eq(groupId))
+                .fetchOne();
+    }
+
+    public GroupValidationRes findValidateGroupData(Long groupId) {
+        QGroup group = QGroup.group;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        GroupValidationRes.class,
+                        group.leader.id,
+                        group.gameInformation.gameDate,
+                        group.status
+                ))
+                .from(group)
                 .where(group.id.eq(groupId))
                 .fetchOne();
     }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -4,6 +4,7 @@ import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
+import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
 import at.mateball.domain.group.core.Group;
@@ -24,7 +25,9 @@ import at.mateball.domain.team.core.TeamNameMatch;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.storage.FileStorage;
+import jakarta.persistence.PersistenceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -337,10 +340,14 @@ public class GroupV3Service {
 
         validateRequest(userId, group);
 
-        groupMemberRepository.createGroupMember(userId, groupId);
-        groupMemberRepository.updateMemberStatus(group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
+        try {
+            groupMemberRepository.createGroupMember(userId, groupId);
+            groupMemberRepository.updateMemberStatus(group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
 
-        alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
+            alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
+        } catch (DataIntegrityViolationException | PersistenceException e) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+        }
     }
 
     private void validateRequest(Long userId, Group group) {

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -351,6 +351,10 @@ public class GroupV3Service {
             throw new BusinessException(BusinessErrorCode.CANNOT_REQUEST_OWN_MATCH);
         }
 
+        if (group.getStatus() == GroupStatus.COMPLETED.getValue()) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
+        }
+
         RequestValidationRes data =
                 groupV3RepositoryCustom.getValidation(userId, group.getId());
 
@@ -360,10 +364,6 @@ public class GroupV3Service {
 
         if (data.hasPendingRequest()) {
             throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
-        }
-
-        if (group.getStatus() == GroupStatus.COMPLETED.getValue()) {
-            throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
         }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,9 +1,12 @@
 package at.mateball.domain.group.core.service;
 
+import at.mateball.domain.alarm.common.AlarmType;
+import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
+import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.MatchType;
@@ -15,6 +18,7 @@ import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.core.constant.StyleMatch;
 import at.mateball.domain.team.core.TeamNameMatch;
 import at.mateball.exception.BusinessException;
@@ -42,6 +46,8 @@ public class GroupV3Service {
 
     private final GroupRepository groupRepository;
     private final GameInformationRepository gameInformationRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final AlarmService alarmService;
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final GroupMatchAggregator groupMatchAggregator;
     private final MatchImageAssembler matchImageAssembler;
@@ -321,5 +327,43 @@ public class GroupV3Service {
 
     private boolean isGroupMatch(MatchType matchType) {
         return matchType == MatchType.GROUP;
+    }
+
+    @Transactional
+    public void createRequest(Long userId, Long groupId) {
+
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        validateRequest(userId, group);
+
+        groupMemberRepository.createGroupMember(userId, groupId);
+        groupMemberRepository.updateMemberStatus(group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
+
+        alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
+    }
+
+    private void validateRequest(Long userId, Group group) {
+
+        validate(group.getGameInformation().getGameDate());
+
+        if (group.getLeader().getId().equals(userId)) {
+            throw new BusinessException(BusinessErrorCode.CANNOT_REQUEST_OWN_MATCH);
+        }
+
+        RequestValidationRes data =
+                groupV3RepositoryCustom.getValidation(userId, group.getId());
+
+        if (data.isDuplicatedRequest()) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+        }
+
+        if (data.hasPendingRequest()) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
+        }
+
+        if (group.getStatus() == GroupStatus.COMPLETED.getValue()) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -345,7 +345,7 @@ public class GroupV3Service {
             groupMemberRepository.updateMemberStatus(group.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
             alarmService.createAlarm(group.leaderId(), AlarmType.NEW_REQUEST, groupId);
         } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(BusinessErrorCode.NOT_ALLOWED_AGE);
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
         }
     }
 

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -25,7 +25,6 @@ import at.mateball.domain.team.core.TeamNameMatch;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.storage.FileStorage;
-import jakarta.persistence.PersistenceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -334,36 +333,35 @@ public class GroupV3Service {
 
     @Transactional
     public void createRequest(Long userId, Long groupId) {
+        GroupValidationRes group = groupRepository.findValidateGroupData(groupId);
+        if (group == null) {
+            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
+        }
 
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
-
-        validateRequest(userId, group);
+        validateRequest(userId, group, groupId);
 
         try {
-            groupMemberRepository.createGroupMember(userId, groupId);
-            groupMemberRepository.updateMemberStatus(group.getLeader().getId(), group.getId(), GroupMemberStatus.NEW_REQUEST.getValue());
-
-            alarmService.createAlarm(group.getLeader().getId(), AlarmType.NEW_REQUEST, group.getId());
-        } catch (DataIntegrityViolationException | PersistenceException e) {
-            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+            groupMemberRepository.createGroupMemberV3(userId, groupId);
+            groupMemberRepository.updateMemberStatus(group.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
+            alarmService.createAlarm(group.leaderId(), AlarmType.NEW_REQUEST, groupId);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(BusinessErrorCode.NOT_ALLOWED_AGE);
         }
     }
 
-    private void validateRequest(Long userId, Group group) {
+    private void validateRequest(Long userId, GroupValidationRes group, Long groupId) {
 
-        validate(group.getGameInformation().getGameDate());
+        validate(group.gameDate());
 
-        if (group.getLeader().getId().equals(userId)) {
+        if (group.leaderId().equals(userId)) {
             throw new BusinessException(BusinessErrorCode.CANNOT_REQUEST_OWN_MATCH);
         }
 
-        if (group.getStatus() == GroupStatus.COMPLETED.getValue()) {
+        if (group.status() == GroupStatus.COMPLETED.getValue()) {
             throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
         }
 
-        RequestValidationRes data =
-                groupV3RepositoryCustom.getValidation(userId, group.getId());
+        RequestValidationRes data = groupV3RepositoryCustom.getValidation(userId, groupId);
 
         if (data.isDuplicatedRequest()) {
             throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,13 +1,10 @@
 package at.mateball.domain.group.core.service;
 
-import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
-import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
-import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.MatchType;
@@ -18,6 +15,7 @@ import at.mateball.domain.group.core.calculator.common.GroupMatchAggregator;
 import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
+import at.mateball.domain.groupRequest.GroupRequestService;
 import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.core.constant.StyleMatch;
@@ -26,7 +24,6 @@ import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
 import at.mateball.storage.FileStorage;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +47,7 @@ public class GroupV3Service {
     private final GameInformationRepository gameInformationRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final AlarmService alarmService;
+    private final GroupRequestService groupRequestService;
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final GroupMatchAggregator groupMatchAggregator;
     private final MatchImageAssembler matchImageAssembler;
@@ -333,42 +331,6 @@ public class GroupV3Service {
 
     @Transactional
     public void createRequest(Long userId, Long groupId) {
-        GroupValidationRes group = groupRepository.findValidateGroupData(groupId);
-        if (group == null) {
-            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
-        }
-
-        validateRequest(userId, group, groupId);
-
-        try {
-            groupMemberRepository.createGroupMemberV3(userId, groupId);
-            groupMemberRepository.updateMemberStatus(group.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
-            alarmService.createAlarm(group.leaderId(), AlarmType.NEW_REQUEST, groupId);
-        } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
-        }
-    }
-
-    private void validateRequest(Long userId, GroupValidationRes group, Long groupId) {
-
-        validate(group.gameDate());
-
-        if (group.leaderId().equals(userId)) {
-            throw new BusinessException(BusinessErrorCode.CANNOT_REQUEST_OWN_MATCH);
-        }
-
-        if (group.status() == GroupStatus.COMPLETED.getValue()) {
-            throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
-        }
-
-        RequestValidationRes data = groupV3RepositoryCustom.getValidation(userId, groupId);
-
-        if (data.isDuplicatedRequest()) {
-            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
-        }
-
-        if (data.hasPendingRequest()) {
-            throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
-        }
+        groupRequestService.createRequest(userId, groupId);
     }
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -1,15 +1,8 @@
 package at.mateball.domain.group.infrastructure.repository;
 
-import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.api.dto.MatchValidationRes;
-import at.mateball.domain.group.infrastructure.dto.CreateGroupImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.CreateGroupQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GameInfoQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchCandidateFlatDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchImageQueryDto;
-import at.mateball.domain.group.infrastructure.dto.GroupMatchMemberQueryDto;
-import at.mateball.domain.group.infrastructure.dto.LoginUserMatchRequirementDto;
-import at.mateball.domain.group.infrastructure.dto.MemberMatchCountDto;
+import at.mateball.domain.group.infrastructure.dto.*;
+import at.mateball.domain.group.api.dto.RequestValidationRes;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,4 +32,6 @@ public interface GroupV3RepositoryCustom {
     List<GroupMatchImageQueryDto> findRequestGroupImagesByMatchIds(List<Long> matchIds);
 
     MatchValidationRes getMatchValidationInfo(Long userId, Long gameId);
+
+    RequestValidationRes getValidation(Long userId, Long groupId);
 }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.group.infrastructure.repository;
 
 import at.mateball.domain.group.api.dto.MatchValidationRes;
+import at.mateball.domain.group.api.dto.RequestValidationRes;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -21,6 +22,8 @@ import java.util.Optional;
 
 import static at.mateball.domain.gameinformation.core.QGameInformation.gameInformation;
 import static at.mateball.domain.group.core.QGroup.group;
+import static at.mateball.domain.groupmember.GroupMemberStatus.AWAITING_APPROVAL;
+import static at.mateball.domain.groupmember.core.QGroupMember.groupMember;
 
 @Repository
 @RequiredArgsConstructor
@@ -338,6 +341,36 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                                 .and(group.leader.id.eq(userId))
                 )
                 .where(gameInformation.id.eq(gameId))
+                .fetchOne();
+    }
+
+    public RequestValidationRes getValidation(Long userId, Long groupId) {
+
+        return queryFactory
+                .select(Projections.constructor(
+                        RequestValidationRes.class,
+
+                        JPAExpressions
+                                .selectOne()
+                                .from(groupMember)
+                                .where(
+                                        groupMember.user.id.eq(userId),
+                                        groupMember.group.id.eq(groupId)
+                                )
+                                .exists(),
+
+                        JPAExpressions
+                                .selectOne()
+                                .from(groupMember)
+                                .where(
+                                        groupMember.group.id.eq(groupId),
+                                        groupMember.user.id.ne(userId),
+                                        groupMember.status.eq(AWAITING_APPROVAL.getValue())
+                                )
+                                .exists()
+                ))
+                .from(group)
+                .where(group.id.eq(groupId))
                 .fetchOne();
     }
 }

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -10,9 +10,10 @@ import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCusto
 import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.exception.BusinessException;
+import at.mateball.exception.ConstraintExceptionTranslator;
 import at.mateball.exception.code.BusinessErrorCode;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,8 @@ public class GroupRequestService {
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final AlarmService alarmService;
     private final GroupRequestValidator groupRequestValidator;
+    private final ConstraintExceptionTranslator constraintExceptionTranslator;
+    private final EntityManager entityManager;
 
     @Transactional
     public void createRequest(Long userId, Long groupId) {
@@ -39,8 +42,9 @@ public class GroupRequestService {
             groupMemberRepository.createGroupMemberV3(userId, groupId);
             groupMemberRepository.updateMemberStatus(validatedGroup.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
             alarmService.createAlarm(validatedGroup.leaderId(), AlarmType.NEW_REQUEST, groupId);
-        } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+            entityManager.flush();
+        } catch (Exception e) {
+            throw constraintExceptionTranslator.translate(e);
         }
     }
 }

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -1,0 +1,46 @@
+package at.mateball.domain.groupRequest;
+
+import at.mateball.domain.alarm.common.AlarmType;
+import at.mateball.domain.alarm.core.service.AlarmService;
+import at.mateball.domain.group.api.dto.GroupValidationRes;
+import at.mateball.domain.group.api.dto.RequestValidationRes;
+import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupRequestService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupV3RepositoryCustom groupV3RepositoryCustom;
+    private final AlarmService alarmService;
+    private final GroupRequestValidator groupRequestValidator;
+
+    @Transactional
+    public void createRequest(Long userId, Long groupId) {
+        GroupValidationRes group = groupRepository.findValidateGroupData(groupId);
+        if (group == null) {
+            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
+        }
+
+        RequestValidationRes validationData = groupV3RepositoryCustom.getValidation(userId, groupId);
+        groupRequestValidator.validateCreateRequest(userId, group, validationData);
+
+        try {
+            groupMemberRepository.createGroupMemberV3(userId, groupId);
+            groupMemberRepository.updateMemberStatus(group.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
+            alarmService.createAlarm(group.leaderId(), AlarmType.NEW_REQUEST, groupId);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -4,6 +4,7 @@ import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.group.api.dto.GroupValidationRes;
 import at.mateball.domain.group.api.dto.RequestValidationRes;
+import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.repository.GroupRepository;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupmember.GroupMemberStatus;
@@ -27,18 +28,17 @@ public class GroupRequestService {
 
     @Transactional
     public void createRequest(Long userId, Long groupId) {
-        GroupValidationRes group = groupRepository.findValidateGroupData(groupId);
-        if (group == null) {
-            throw new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND);
-        }
+        Group group = groupRepository.findGroupWithLock(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
 
+        GroupValidationRes validatedGroup = GroupValidationRes.from(group);
         RequestValidationRes validationData = groupV3RepositoryCustom.getValidation(userId, groupId);
-        groupRequestValidator.validateCreateRequest(userId, group, validationData);
+        groupRequestValidator.validateCreateRequest(userId, validatedGroup, validationData);
 
         try {
             groupMemberRepository.createGroupMemberV3(userId, groupId);
-            groupMemberRepository.updateMemberStatus(group.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
-            alarmService.createAlarm(group.leaderId(), AlarmType.NEW_REQUEST, groupId);
+            groupMemberRepository.updateMemberStatus(validatedGroup.leaderId(), groupId, GroupMemberStatus.NEW_REQUEST.getValue());
+            alarmService.createAlarm(validatedGroup.leaderId(), AlarmType.NEW_REQUEST, groupId);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
         }

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestValidator.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestValidator.java
@@ -1,0 +1,35 @@
+package at.mateball.domain.groupRequest;
+
+
+import at.mateball.domain.group.api.dto.GroupValidationRes;
+import at.mateball.domain.group.api.dto.RequestValidationRes;
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import org.springframework.stereotype.Component;
+
+import static at.mateball.domain.group.core.validator.DateValidator.validate;
+
+@Component
+public class GroupRequestValidator {
+
+    public void validateCreateRequest(Long userId, GroupValidationRes group, RequestValidationRes data) {
+        validate(group.gameDate());
+
+        if (group.leaderId().equals(userId)) {
+            throw new BusinessException(BusinessErrorCode.CANNOT_REQUEST_OWN_MATCH);
+        }
+
+        if (group.status() == GroupStatus.COMPLETED.getValue()) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_FINISHED_MATCH);
+        }
+
+        if (data.isDuplicatedRequest()) {
+            throw new BusinessException(BusinessErrorCode.DUPLICATED_MATCH_REQUEST);
+        }
+
+        if (data.hasPendingRequest()) {
+            throw new BusinessException(BusinessErrorCode.ALREADY_HAS_PENDING_REQUEST);
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/GroupMember.java
@@ -67,4 +67,8 @@ public class GroupMember {
     public static GroupMember leader(User user, Group group, int status) {
         return new GroupMember(user, group, true, status, true);
     }
+
+    public static GroupMember member(User user, Group group, int status) {
+        return new GroupMember(user, group, false, status, false);
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,14 +1,9 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
-import at.mateball.domain.groupmember.api.dto.DetailMatchingListRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
-import at.mateball.domain.groupmember.api.dto.base.*;
-import at.mateball.domain.groupmember.api.dto.base.DetailMatchingBaseRes;
-import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
-import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseRes;
-import at.mateball.domain.groupmember.api.dto.base.GroupInformationRes;
+import at.mateball.domain.groupmember.api.dto.base.*;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -80,4 +75,7 @@ public interface GroupMemberRepositoryCustom {
 
     Optional<Long> findApprovedRequesterUserId(Long groupId);
 
-    Optional<Long> findMatchedRequesterUserId(Long groupId);}
+    Optional<Long> findMatchedRequesterUserId(Long groupId);
+
+    void createGroupMemberV3(Long userId, Long matchId);
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -841,4 +841,15 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
         return Optional.ofNullable(requesterId);
     }
+
+
+    @Override
+    public void createGroupMemberV3(Long userId, Long matchId) {
+        User user = entityManager.getReference(User.class, userId);
+        Group group = entityManager.getReference(Group.class, matchId);
+
+        GroupMember groupMember = GroupMember.member(user,group,GroupMemberStatus.AWAITING_APPROVAL.getValue());
+
+        entityManager.persist(groupMember);
+    }
 }

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -33,6 +33,8 @@ public enum BusinessErrorCode implements ErrorCode {
     INVALID_AVG_SEASON(HttpStatus.BAD_REQUEST, "시즌 평균 직관 수는 0-999까지 입력 가능합니다."),
     WAITING_MATE_ACCEPTANCE(HttpStatus.BAD_REQUEST,"메이트의 수락을 기다리는 중입니다."),
     INVALID_CHATTING_REQUEST_MEMBER(HttpStatus.BAD_REQUEST, "생성자와 승인된 요청자만 채팅방에 입장할 수 있습니다."),
+    ALREADY_FINISHED_MATCH(HttpStatus.BAD_REQUEST, "이미 종료된 매칭입니다."),
+    CANNOT_REQUEST_OWN_MATCH(HttpStatus.BAD_REQUEST, "내가 만든 매칭에는 요청을 보낼 수 없습니다."),
 
     // 401 UNAUTHORIZED
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
@@ -65,6 +67,7 @@ public enum BusinessErrorCode implements ErrorCode {
     DUPLICATED_INFO(HttpStatus.BAD_REQUEST, "이미 사용자 정보가 존재합니다. 사용자 정보 설정은 최초 한 번만 가능합니다."),
     DUPLICATED_MATCH_REQUIREMENT(HttpStatus.CONFLICT, "이미 매칭 조건이 존재합니다."),
     CHATTING_ALREADY_USED(HttpStatus.CONFLICT, "이미 배정된 오픈채팅입니다. 매칭에 오픈채팅을 할당할 수 없습니다."),
+    DUPLICATED_MATCH_REQUEST(HttpStatus.CONFLICT, "요청 이력이 있는 매칭입니다."),
 
     // 429 TOO MANY REQUESTS
     EXCEED_GROUP_MATCHING_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "그룹 매칭은 최대 2개까지만 가능합니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #239 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 로직 흐름: 매칭 요청 api 호출 -> groupMember 테이블에 요청자 row 생성 > 매칭생성자의 memberStatus를 "새요청"으로 업데이트 > 매칭생성자에 "새요청" 알림 생성
- 검증:  내가 생성한 매칭인지 > 동일한 매칭에 요청을 보낸 전적이 있는지 > 매칭에 현재 승인대기중인 요청자가 있는지 > 이미 완료된 매칭인지
- 검증에 사용되는 data 는 queryDSL 을 활용하여 한 번에 조회(isDuplicatedRequest,hasPendingRequest)


<br/>


### ❤️ To 다진 / To 헤음

---

- 뚱땅뚱땅... 비록 내 코드들은 날아갔지만 로직이 단순해져서 좋아요 ㅎㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 매칭에 참여 요청을 보낼 수 있는 POST 엔드포인트 및 요청 생성 흐름 추가
  * 요청 검증 결과에 중복 요청 여부 및 대기 요청 여부 반환
  * 그룹/매칭 유효성 검사용 데이터 조회 기능 추가

* **예외 처리 / 개선**
  * 요청 불가 사유 추가: 이미 종료된 매칭, 자신의 매칭 요청 금지, 중복 요청 감지 및 관련 오류 응답

* **데이터 무결성**
  * 동일 사용자-매칭 중복 저장 방지(중복 제약 및 중복요청 처리)

* **알림**
  * 요청 생성 시 대기 상태 반영 및 알림 전송 흐름 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->