### PR TITLE
[feat] 매칭 요청 수락 api V3 마이그레이션

### DIFF
--- a/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
+++ b/src/main/java/at/mateball/domain/alarm/core/service/AlarmService.java
@@ -71,4 +71,14 @@ public class AlarmService {
 
         alarms.forEach(Alarm::markAsRead);
     }
+
+    @Transactional
+    public void notifyMatched(Long userId, Long groupId) {
+        createOrUpdateAlarm(userId, AlarmType.MATCHED, groupId);
+    }
+
+    @Transactional
+    public void notifyApproved(Long userId, Long groupId) {
+        createOrUpdateAlarm(userId, AlarmType.APPROVED, groupId);
+    }
 }

--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -2,15 +2,12 @@ package at.mateball.domain.group.api.controller;
 
 import at.mateball.common.MateballResponse;
 import at.mateball.common.security.CustomUserDetails;
-import at.mateball.domain.group.api.dto.CreateGroupListRes;
-import at.mateball.domain.group.api.dto.GroupMatchMemberListRes;
-import at.mateball.domain.group.api.dto.GroupMatchRes;
-import at.mateball.domain.group.api.dto.RequestGroupListRes;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.core.service.GroupV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -98,5 +95,18 @@ public class GroupV3Controller {
         groupV3Service.createRequest(userId, matchId);
 
         return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.CREATED));
+    }
+
+    @PatchMapping("/match-accept/{matchId}")
+    @Operation(summary = "요청 수락 api")
+    public ResponseEntity<MateballResponse<?>> permitRequest(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @NotNull @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        groupV3Service.permitRequest(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.successWithNoData(SuccessCode.NO_CONTENT));
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,12 +1,10 @@
 package at.mateball.domain.group.core.service;
 
-import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
-import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.MatchType;
@@ -15,12 +13,10 @@ import at.mateball.domain.group.core.calculator.MatchingScoreCalculator;
 import at.mateball.domain.group.core.calculator.MatchingTarget;
 import at.mateball.domain.group.core.calculator.common.GroupMatchAggregator;
 import at.mateball.domain.group.core.repository.GroupRepository;
-import at.mateball.domain.group.core.validator.GroupValidator;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupRequest.GroupRequestService;
 import at.mateball.domain.groupmember.GroupMemberStatus;
-import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.core.constant.StyleMatch;
 import at.mateball.domain.team.core.TeamNameMatch;
@@ -32,7 +28,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
@@ -43,12 +42,8 @@ import static at.mateball.domain.group.core.validator.DateValidator.validate;
 public class GroupV3Service {
 
     private static final String NEW_REQUEST_LABEL = "새요청";
-    private static final int TOTAL_GROUP_MEMBER = 4;
 
     private final GroupRepository groupRepository;
-    private final GameInformationRepository gameInformationRepository;
-    private final GroupMemberRepository groupMemberRepository;
-    private final AlarmService alarmService;
     private final GroupRequestService groupRequestService;
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final GroupMatchAggregator groupMatchAggregator;
@@ -338,81 +333,7 @@ public class GroupV3Service {
 
     @Transactional
     public void permitRequest(Long userId, Long groupId) {
-        Group group = getValidatedGroup(userId, groupId);
-        boolean isGroup = group.isGroup();
-
-        GroupMatchSummaryRes summary = groupMemberRepository.getMatchSummary(groupId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUEST_NOT_FOUND));
-        Long requesterId = Optional.ofNullable(summary.requesterId())
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
-
-        if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
-        else processDirectMatch(userId, requesterId, groupId);
+        groupRequestService.permitRequest(userId, groupId);
     }
 
-    private Group getValidatedGroup(Long userId, Long groupId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
-
-        GroupValidator.validate(group);
-
-        if (!group.getLeader().getId().equals(userId)) {
-            throw new BusinessException(BusinessErrorCode.NOT_MATCH_LEADER);
-        }
-
-        return group;
-    }
-
-    private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
-        updateMemberStatusMatched(userId, groupId);
-        updateMemberStatusMatched(requesterId, groupId);
-
-        updateGroupStatusCompleted(groupId);
-
-        notifyMatched(userId, groupId);
-        notifyMatched(requesterId, groupId);
-    }
-
-    private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
-        updateMemberStatusMatched(requesterId, groupId);
-
-        boolean isFull = isGroupFull(summary);
-
-        if (isFull) {
-            updateMemberStatusMatched(userId, groupId);
-            updateGroupStatusCompleted(groupId);
-
-            notifyMatched(userId, groupId);
-            notifyMatched(requesterId, groupId);
-        } else {
-            updateLeaderStatusPending(userId, groupId);
-            alarmService.readAllAlarms(userId);
-            notifyApproved(requesterId, groupId);
-        }
-    }
-
-    private boolean isGroupFull(GroupMatchSummaryRes summary) {
-        long totalMatched = summary.matchedParticipants() + 1;
-        return totalMatched == TOTAL_GROUP_MEMBER;
-    }
-
-    private void updateMemberStatusMatched(Long userId, Long groupId) {
-        groupMemberRepository.updateStatusAndParticipant(userId, groupId, GroupMemberStatus.MATCHED.getValue());
-    }
-
-    private void updateLeaderStatusPending(Long userId, Long groupId) {
-        groupMemberRepository.updateMemberStatus(userId, groupId, GroupMemberStatus.PENDING_REQUEST.getValue());
-    }
-
-    private void updateGroupStatusCompleted(Long groupId) {
-        groupRepository.updateGroupStatus(groupId, GroupStatus.COMPLETED.getValue());
-    }
-
-    private void notifyMatched(Long userId, Long groupId) {
-        alarmService.createOrUpdateAlarm(userId, AlarmType.MATCHED, groupId);
-    }
-
-    private void notifyApproved(Long userId, Long groupId) {
-        alarmService.createOrUpdateAlarm(userId, AlarmType.APPROVED, groupId);
-    }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -1,10 +1,12 @@
 package at.mateball.domain.group.core.service;
 
+import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.gameinformation.core.repository.GameInformationRepository;
 import at.mateball.domain.group.api.dto.*;
 import at.mateball.domain.group.api.dto.base.GroupMatchBaseRes;
+import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.GroupExecutorV3;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.MatchType;
@@ -13,10 +15,12 @@ import at.mateball.domain.group.core.calculator.MatchingScoreCalculator;
 import at.mateball.domain.group.core.calculator.MatchingTarget;
 import at.mateball.domain.group.core.calculator.common.GroupMatchAggregator;
 import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.group.core.validator.GroupValidator;
 import at.mateball.domain.group.infrastructure.dto.*;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupRequest.GroupRequestService;
 import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import at.mateball.domain.matchrequirement.core.constant.StyleMatch;
 import at.mateball.domain.team.core.TeamNameMatch;
@@ -28,10 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static at.mateball.domain.group.core.validator.DateValidator.validate;
@@ -42,6 +43,7 @@ import static at.mateball.domain.group.core.validator.DateValidator.validate;
 public class GroupV3Service {
 
     private static final String NEW_REQUEST_LABEL = "새요청";
+    private static final int TOTAL_GROUP_MEMBER = 4;
 
     private final GroupRepository groupRepository;
     private final GameInformationRepository gameInformationRepository;
@@ -332,5 +334,86 @@ public class GroupV3Service {
     @Transactional
     public void createRequest(Long userId, Long groupId) {
         groupRequestService.createRequest(userId, groupId);
+    }
+}
+
+
+@Transactional
+public void permitRequest(Long userId, Long groupId) {
+    Group group = getValidatedGroup(userId, groupId);
+    boolean isGroup = group.isGroup();
+
+    GroupMatchSummaryRes summary = groupMemberRepository.getMatchSummary(groupId)
+            .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUEST_NOT_FOUND));
+    Long requesterId = Optional.ofNullable(summary.requesterId())
+            .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
+
+    if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
+    else processDirectMatch(userId, requesterId, groupId);
+}
+
+private Group getValidatedGroup(Long userId, Long groupId) {
+    Group group = groupRepository.findById(groupId)
+            .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+    GroupValidator.validate(group);
+
+    if (!group.getLeader().getId().equals(userId)) {
+        throw new BusinessException(BusinessErrorCode.NOT_MATCH_LEADER);
+    }
+
+    return group;
+}
+
+private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
+    updateMemberStatusMatched(userId, groupId);
+    updateMemberStatusMatched(requesterId, groupId);
+
+    updateGroupStatusCompleted(groupId);
+
+    notifyMatched(userId, groupId);
+    notifyMatched(requesterId, groupId);
+}
+
+private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
+    updateMemberStatusMatched(requesterId, groupId);
+
+    boolean isFull = isGroupFull(summary);
+
+    if (isFull) {
+        updateMemberStatusMatched(userId, groupId);
+        updateGroupStatusCompleted(groupId);
+
+        notifyMatched(userId, groupId);
+        notifyMatched(requesterId, groupId);
+    } else {
+        updateLeaderStatusPending(userId, groupId);
+        alarmService.readAllAlarms(userId);
+        notifyApproved(requesterId, groupId);
+    }
+
+    private boolean isGroupFull (GroupMatchSummaryRes summary){
+        long totalMatched = summary.matchedParticipants() + 1;
+        return totalMatched == TOTAL_GROUP_MEMBER;
+    }
+
+    private void updateMemberStatusMatched (Long userId, Long groupId){
+        groupMemberRepository.updateStatusAndParticipant(userId, groupId, GroupMemberStatus.MATCHED.getValue());
+    }
+
+    private void updateLeaderStatusPending (Long userId, Long groupId){
+        groupMemberRepository.updateMemberStatus(userId, groupId, GroupMemberStatus.PENDING_REQUEST.getValue());
+    }
+
+    private void updateGroupStatusCompleted (Long groupId){
+        groupRepository.updateGroupStatus(groupId, GroupStatus.COMPLETED.getValue());
+    }
+
+    private void notifyMatched (Long userId, Long groupId){
+        alarmService.createOrUpdateAlarm(userId, AlarmType.MATCHED, groupId);
+    }
+
+    private void notifyApproved (Long userId, Long groupId){
+        alarmService.createOrUpdateAlarm(userId, AlarmType.APPROVED, groupId);
     }
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -335,85 +335,84 @@ public class GroupV3Service {
     public void createRequest(Long userId, Long groupId) {
         groupRequestService.createRequest(userId, groupId);
     }
-}
 
+    @Transactional
+    public void permitRequest(Long userId, Long groupId) {
+        Group group = getValidatedGroup(userId, groupId);
+        boolean isGroup = group.isGroup();
 
-@Transactional
-public void permitRequest(Long userId, Long groupId) {
-    Group group = getValidatedGroup(userId, groupId);
-    boolean isGroup = group.isGroup();
+        GroupMatchSummaryRes summary = groupMemberRepository.getMatchSummary(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUEST_NOT_FOUND));
+        Long requesterId = Optional.ofNullable(summary.requesterId())
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
 
-    GroupMatchSummaryRes summary = groupMemberRepository.getMatchSummary(groupId)
-            .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUEST_NOT_FOUND));
-    Long requesterId = Optional.ofNullable(summary.requesterId())
-            .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
-
-    if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
-    else processDirectMatch(userId, requesterId, groupId);
-}
-
-private Group getValidatedGroup(Long userId, Long groupId) {
-    Group group = groupRepository.findById(groupId)
-            .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
-
-    GroupValidator.validate(group);
-
-    if (!group.getLeader().getId().equals(userId)) {
-        throw new BusinessException(BusinessErrorCode.NOT_MATCH_LEADER);
+        if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
+        else processDirectMatch(userId, requesterId, groupId);
     }
 
-    return group;
-}
+    private Group getValidatedGroup(Long userId, Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
 
-private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
-    updateMemberStatusMatched(userId, groupId);
-    updateMemberStatusMatched(requesterId, groupId);
+        GroupValidator.validate(group);
 
-    updateGroupStatusCompleted(groupId);
+        if (!group.getLeader().getId().equals(userId)) {
+            throw new BusinessException(BusinessErrorCode.NOT_MATCH_LEADER);
+        }
 
-    notifyMatched(userId, groupId);
-    notifyMatched(requesterId, groupId);
-}
+        return group;
+    }
 
-private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
-    updateMemberStatusMatched(requesterId, groupId);
-
-    boolean isFull = isGroupFull(summary);
-
-    if (isFull) {
+    private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
         updateMemberStatusMatched(userId, groupId);
+        updateMemberStatusMatched(requesterId, groupId);
+
         updateGroupStatusCompleted(groupId);
 
         notifyMatched(userId, groupId);
         notifyMatched(requesterId, groupId);
-    } else {
-        updateLeaderStatusPending(userId, groupId);
-        alarmService.readAllAlarms(userId);
-        notifyApproved(requesterId, groupId);
     }
 
-    private boolean isGroupFull (GroupMatchSummaryRes summary){
+    private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
+        updateMemberStatusMatched(requesterId, groupId);
+
+        boolean isFull = isGroupFull(summary);
+
+        if (isFull) {
+            updateMemberStatusMatched(userId, groupId);
+            updateGroupStatusCompleted(groupId);
+
+            notifyMatched(userId, groupId);
+            notifyMatched(requesterId, groupId);
+        } else {
+            updateLeaderStatusPending(userId, groupId);
+            alarmService.readAllAlarms(userId);
+            notifyApproved(requesterId, groupId);
+        }
+    }
+
+    private boolean isGroupFull(GroupMatchSummaryRes summary) {
         long totalMatched = summary.matchedParticipants() + 1;
         return totalMatched == TOTAL_GROUP_MEMBER;
     }
 
-    private void updateMemberStatusMatched (Long userId, Long groupId){
+    private void updateMemberStatusMatched(Long userId, Long groupId) {
         groupMemberRepository.updateStatusAndParticipant(userId, groupId, GroupMemberStatus.MATCHED.getValue());
     }
 
-    private void updateLeaderStatusPending (Long userId, Long groupId){
+    private void updateLeaderStatusPending(Long userId, Long groupId) {
         groupMemberRepository.updateMemberStatus(userId, groupId, GroupMemberStatus.PENDING_REQUEST.getValue());
     }
 
-    private void updateGroupStatusCompleted (Long groupId){
+    private void updateGroupStatusCompleted(Long groupId) {
         groupRepository.updateGroupStatus(groupId, GroupStatus.COMPLETED.getValue());
     }
 
-    private void notifyMatched (Long userId, Long groupId){
+    private void notifyMatched(Long userId, Long groupId) {
         alarmService.createOrUpdateAlarm(userId, AlarmType.MATCHED, groupId);
     }
 
-    private void notifyApproved (Long userId, Long groupId){
+    private void notifyApproved(Long userId, Long groupId) {
         alarmService.createOrUpdateAlarm(userId, AlarmType.APPROVED, groupId);
     }
 }

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -35,7 +35,6 @@ public class GroupRequestService {
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final AlarmService alarmService;
     private final GroupMemberV3Service groupMemberV3Service;
-    private final GroupV3Service groupV3Service;
     private final GroupRequestValidator groupRequestValidator;
     private final ConstraintExceptionTranslator constraintExceptionTranslator;
     private final EntityManager entityManager;

--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -5,10 +5,15 @@ import at.mateball.domain.alarm.core.service.AlarmService;
 import at.mateball.domain.group.api.dto.GroupValidationRes;
 import at.mateball.domain.group.api.dto.RequestValidationRes;
 import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.group.core.service.GroupV3Service;
+import at.mateball.domain.group.core.validator.GroupValidator;
 import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom;
 import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import at.mateball.domain.groupmember.core.service.GroupMemberV3Service;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.ConstraintExceptionTranslator;
 import at.mateball.exception.code.BusinessErrorCode;
@@ -17,14 +22,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class GroupRequestService {
+
+    private static final int TOTAL_GROUP_MEMBER = 4;
 
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupV3RepositoryCustom groupV3RepositoryCustom;
     private final AlarmService alarmService;
+    private final GroupMemberV3Service groupMemberV3Service;
+    private final GroupV3Service groupV3Service;
     private final GroupRequestValidator groupRequestValidator;
     private final ConstraintExceptionTranslator constraintExceptionTranslator;
     private final EntityManager entityManager;
@@ -46,5 +57,69 @@ public class GroupRequestService {
         } catch (Exception e) {
             throw constraintExceptionTranslator.translate(e);
         }
+    }
+
+    @Transactional
+    public void permitRequest(Long userId, Long groupId) {
+        Group group = getValidatedGroup(userId, groupId);
+        boolean isGroup = group.isGroup();
+
+        GroupMatchSummaryRes summary = groupMemberRepository.getMatchSummary(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUEST_NOT_FOUND));
+        Long requesterId = Optional.ofNullable(summary.requesterId())
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
+
+        if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
+        else processDirectMatch(userId, requesterId, groupId);
+    }
+
+    private Group getValidatedGroup(Long userId, Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        GroupValidator.validate(group);
+
+        if (!group.getLeader().getId().equals(userId)) {
+            throw new BusinessException(BusinessErrorCode.NOT_MATCH_LEADER);
+        }
+
+        return group;
+    }
+
+    private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
+        groupMemberV3Service.updateMemberStatusMatched(userId, groupId);
+        groupMemberV3Service.updateMemberStatusMatched(requesterId, groupId);
+
+        updateGroupStatusCompleted(groupId);
+
+        alarmService.notifyMatched(userId, groupId);
+        alarmService.notifyMatched(requesterId, groupId);
+    }
+
+    private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
+        groupMemberV3Service.updateMemberStatusMatched(requesterId, groupId);
+
+        boolean isFull = isGroupFull(summary);
+
+        if (isFull) {
+            groupMemberV3Service.updateMemberStatusMatched(userId, groupId);
+            updateGroupStatusCompleted(groupId);
+
+            alarmService.notifyMatched(userId, groupId);
+            alarmService.notifyMatched(requesterId, groupId);
+        } else {
+            groupMemberV3Service.updateLeaderStatusPending(userId, groupId);
+            alarmService.readAllAlarms(userId);
+            alarmService.notifyApproved(requesterId, groupId);
+        }
+    }
+
+    public void updateGroupStatusCompleted(Long groupId) { // 순환참조 발생으로 request service 에 위치
+        groupRepository.updateGroupStatus(groupId, GroupStatus.COMPLETED.getValue());
+    }
+
+    private boolean isGroupFull(GroupMatchSummaryRes summary) {
+        long totalMatched = summary.matchedParticipants() + 1;
+        return totalMatched == TOTAL_GROUP_MEMBER;
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMatchSummaryRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/GroupMatchSummaryRes.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.groupmember.api.dto;
+
+public record GroupMatchSummaryRes(
+        Long requesterId,
+        Long matchedParticipants
+) {}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.groupmember.core.repository.querydsl;
 
 
+import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
 import at.mateball.domain.groupmember.api.dto.base.*;
@@ -78,4 +79,8 @@ public interface GroupMemberRepositoryCustom {
     Optional<Long> findMatchedRequesterUserId(Long groupId);
 
     void createGroupMemberV3(Long userId, Long matchId);
+
+    void updateStatusAndParticipant(Long userId, Long groupId, int status);
+
+    Optional<GroupMatchSummaryRes> getMatchSummary(Long groupId);
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -5,6 +5,7 @@ import at.mateball.domain.group.core.Group;
 import at.mateball.domain.group.core.GroupStatus;
 import at.mateball.domain.group.core.QGroup;
 import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberCountRes;
 import at.mateball.domain.groupmember.api.dto.GroupMemberRes;
 import at.mateball.domain.groupmember.api.dto.base.*;
@@ -20,7 +21,6 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,12 +29,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static at.mateball.domain.matchrequirement.core.QMatchRequirement.matchRequirement;
-
 public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final EntityManager entityManager;
 
+    QGroupMember gm = QGroupMember.groupMember;
     QGroupMember groupMember = QGroupMember.groupMember;
     QGroup group = QGroup.group;
     QGameInformation game = QGameInformation.gameInformation;
@@ -842,14 +841,46 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         return Optional.ofNullable(requesterId);
     }
 
-
     @Override
     public void createGroupMemberV3(Long userId, Long matchId) {
         User user = entityManager.getReference(User.class, userId);
         Group group = entityManager.getReference(Group.class, matchId);
 
-        GroupMember groupMember = GroupMember.member(user,group,GroupMemberStatus.AWAITING_APPROVAL.getValue());
+        GroupMember groupMember = GroupMember.member(user, group, GroupMemberStatus.AWAITING_APPROVAL.getValue());
 
         entityManager.persist(groupMember);
+    }
+
+    @Override
+    public void updateStatusAndParticipant(Long userId, Long groupId, int status) {
+        queryFactory.update(groupMember)
+                .set(groupMember.status, status)
+                .set(groupMember.isParticipant, true)
+                .where(groupMember.user.id.eq(userId), groupMember.group.id.eq(groupId))
+                .execute();
+    }
+
+    @Override
+    public Optional<GroupMatchSummaryRes> getMatchSummary(Long groupId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .select(Projections.constructor(
+                                GroupMatchSummaryRes.class,
+                                Expressions.numberTemplate(Long.class,
+                                        "MAX(CASE WHEN {0} = false AND {1} = {2} THEN {3} END)",
+                                        gm.isParticipant,
+                                        gm.status,
+                                        GroupMemberStatus.AWAITING_APPROVAL.getValue(),
+                                        gm.user.id
+                                ),
+                                Expressions.numberTemplate(Long.class,
+                                        "COALESCE(SUM(CASE WHEN {0} = true THEN 1 ELSE 0 END), 0)",
+                                        gm.isParticipant
+                                )
+                        ))
+                        .from(gm)
+                        .where(gm.group.id.eq(groupId))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -33,7 +33,6 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
     private final JPAQueryFactory queryFactory;
     private final EntityManager entityManager;
 
-    QGroupMember gm = QGroupMember.groupMember;
     QGroupMember groupMember = QGroupMember.groupMember;
     QGroup group = QGroup.group;
     QGameInformation game = QGameInformation.gameInformation;
@@ -868,18 +867,18 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                                 GroupMatchSummaryRes.class,
                                 Expressions.numberTemplate(Long.class,
                                         "MAX(CASE WHEN {0} = false AND {1} = {2} THEN {3} END)",
-                                        gm.isParticipant,
-                                        gm.status,
+                                        groupMember.isParticipant,
+                                        groupMember.status,
                                         GroupMemberStatus.AWAITING_APPROVAL.getValue(),
-                                        gm.user.id
+                                        groupMember.user.id
                                 ),
                                 Expressions.numberTemplate(Long.class,
                                         "COALESCE(SUM(CASE WHEN {0} = true THEN 1 ELSE 0 END), 0)",
-                                        gm.isParticipant
+                                        groupMember.isParticipant
                                 )
                         ))
-                        .from(gm)
-                        .where(gm.group.id.eq(groupId))
+                        .from(groupMember)
+                        .where(groupMember.group.id.eq(groupId))
                         .fetchOne()
         );
     }

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV3Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV3Service.java
@@ -1,0 +1,21 @@
+package at.mateball.domain.groupmember.core.service;
+
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupMemberV3Service {
+
+    private final GroupMemberRepository groupMemberRepository;
+
+    public void updateMemberStatusMatched(Long userId, Long groupId) {
+        groupMemberRepository.updateStatusAndParticipant(userId, groupId, GroupMemberStatus.MATCHED.getValue());
+    }
+
+    public void updateLeaderStatusPending(Long userId, Long groupId) {
+        groupMemberRepository.updateMemberStatus(userId, groupId, GroupMemberStatus.PENDING_REQUEST.getValue());
+    }
+}

--- a/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
+++ b/src/main/java/at/mateball/exception/code/BusinessErrorCode.java
@@ -48,6 +48,7 @@ public enum BusinessErrorCode implements ErrorCode {
     // 403 FORBIDDEN
     AGE_NOT_APPROPRIATE(HttpStatus.FORBIDDEN, "만 19세 이상부터 가입이 가능합니다."),
     NOT_GROUP_MEMBER(HttpStatus.FORBIDDEN, "요청을 처리할 권한이 없습니다. 그룹의 참가자가 아닙니다."),
+    NOT_MATCH_LEADER(HttpStatus.FORBIDDEN, "요청을 처리할 권한이 없습니다. 매칭 생성자가 아닙니다."),
 
     // 404 NOT FOUND
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "요청에 해당하는 토큰이 존재하지 않습니다."),
@@ -59,6 +60,7 @@ public enum BusinessErrorCode implements ErrorCode {
     CHATTING_NOT_FOUND(HttpStatus.NOT_FOUND, "오픈채팅이 존재하지 않습니다."),
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
     NO_GAME_SCHEDULED(HttpStatus.NOT_FOUND, "선택한 날짜에 경기가 존재하지 않습니다."),
+    REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "요청 정보를 찾을 수 없습니다."),
 
     // 409 CONFLICT
     DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #241

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- Repository Code- `getMatchSummary` : 매칭 참여 요청자, 현재 매칭에 참여중인 인원 수 count (COALESCE 키워드 사용해서 null 이면 0으로 반환하도록 조정)
- 로직흐름 설명 : 
  - `permitRequest` : 그룹 검증 > 일대일/그룹매칭에 따라 검증 함수 분리
    - `processDirectMatch` : 일대일 매칭은 수락하면, 생성자와 요청자 모두 매칭완료 처리(그룹멤버 상태/그룹상태 완료로 변경 + 매칭완료 알림 생성)
    - `processGroupMatch` : 
    그룹인원이 모두 채워진 경우(마지막 요청자인 경우) : processDirectMatch 와 동일
    그룹인원이 모두 채워지지 않은 경우(마지막 요청자가 아닌 경우) : 요청자의 그룹멤버 상태만 완료로 변경 + 매칭승인 알림 생성 , 생성자의 그룹 멤버 상태는 기존 새요청 -> 새 요청 대기중으로 변경
- 그룹/일대일 매칭 함수는 분리되었지만 공통 함수가 많이 나오므로, `updateMemberStatusMatched`,`updateGroupStatusCompleted`,`notifyMatched`,`notifyApproved` 의 로직은 따로 뺐습니다.
- `isGroupFull` 함수에서 totalMatched = summary.matchedParticipants() + 1;  처럼 +1이 붙은 이유는, repository 에서 값을 받아올때 요청자의 isParticipant 값이 아직 변환되지 않았기에, 수동으로 추가해줬습니다.


<br/>


### ❤️ To 다진 / To 헤음

---

- 앱잼 하는 것 같고 좋네요
- 이제 좀 머리가 어지럽소

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 매칭 요청 수락용 PATCH 엔드포인트 추가 및 수락 흐름 서비스화
  * 매칭 요약 응답 타입 추가 및 매칭 상태 일괄 업데이트/조회 기능 확장

* **버그 수정 / 개선**
  * 요청·권한 검증 강화 및 관련 오류 코드 추가
  * 그룹 매칭 완료 판단과 참가자 상태 전환 로직 개선

* **알림**
  * 매칭 상태별 알림 생성·발송 및 읽음 처리 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->