### PR TITLE
[fix] 매칭 그룹 리스트 조회 이미지 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -69,20 +69,20 @@ public class GroupV3Service {
         );
 
         List<GroupMatchBaseRes> result = groupMatchAggregator.aggregate(
-                flatRows,
-                loginUserTarget,
-                userId,
-                imageMap
-        );
-
-        result.sort(
-                Comparator.comparing(
-                                GroupMatchBaseRes::matchRate,
-                                Comparator.nullsLast(Comparator.reverseOrder())
-                        )
-                        .thenComparing(GroupMatchBaseRes::count, Comparator.reverseOrder())
-                        .thenComparing(GroupMatchBaseRes::matchId)
-        );
+                        flatRows,
+                        loginUserTarget,
+                        userId,
+                        imageMap
+                ).stream()
+                .sorted(
+                        Comparator.comparing(
+                                        GroupMatchBaseRes::matchRate,
+                                        Comparator.nullsLast(Comparator.reverseOrder())
+                                )
+                                .thenComparing(GroupMatchBaseRes::count, Comparator.reverseOrder())
+                                .thenComparing(GroupMatchBaseRes::matchId)
+                )
+                .toList();
 
         return new GroupMatchRes(
                 gameInfo.awayTeam(),

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -113,6 +113,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .join(groupMember.group, group)
                 .where(
                         group.gameInformation.id.eq(gameId),
+                        groupMember.isParticipant.isTrue(),
                         group.status.eq(GroupStatus.PENDING.getValue()),
                         groupMember.status.ne(GroupMemberStatus.MATCH_FAILED.getValue())
                 )
@@ -177,7 +178,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 ))
                 .from(groupMember)
                 .join(groupMember.user, memberUser)
-                .where(groupMember.group.id.in(matchIds))
+                .where(
+                        group.id.in(matchIds),
+                        groupMember.isParticipant.isTrue()
+                )
                 .orderBy(groupMember.group.id.asc(), groupMember.id.asc())
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -78,7 +78,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         group.isGroup,
 
                         memberUser.id,
-                        memberUser.profileImageKey,
+
                         memberRequirement.team,
                         memberRequirement.teamAllowed,
                         memberRequirement.style

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -85,8 +85,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 ))
                 .from(group)
                 .join(group.leader, leaderUser)
-                .join(member).on(member.group.id.eq(group.id))
-                .join(member.user, memberUser)
+                .join(member).on(
+                        member.group.id.eq(group.id)
+                                .and(member.isParticipant.isTrue())
+                )                .join(member.user, memberUser)
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
                         group.gameInformation.id.eq(gameId),
@@ -146,8 +148,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 ))
                 .from(group)
                 .join(group.leader, leaderUser)
-                .join(groupMember).on(groupMember.group.id.eq(group.id))
-                .where(group.leader.id.eq(userId))
+                .join(groupMember).on(
+                        groupMember.group.id.eq(group.id)
+                                .and(groupMember.isParticipant.isTrue())
+                )                .where(group.leader.id.eq(userId))
                 .groupBy(
                         group.id,
                         leaderUser.nickname,
@@ -179,7 +183,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .from(groupMember)
                 .join(groupMember.user, memberUser)
                 .where(
-                        group.id.in(matchIds),
+                        groupMember.group.id.in(matchIds),
                         groupMember.isParticipant.isTrue()
                 )
                 .orderBy(groupMember.group.id.asc(), groupMember.id.asc())
@@ -264,7 +268,9 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                                 JPAExpressions
                                         .select(countGroupMember.count().intValue())
                                         .from(countGroupMember)
-                                        .where(countGroupMember.group.id.eq(group.id)),
+                                        .where(countGroupMember.group.id.eq(group.id),
+                                                countGroupMember.isParticipant.isTrue()
+                                        ),
                                 "count"
                         ),
                         group.isGroup,

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -76,8 +76,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .select(user.nickname,
                         matchRequirement.team,
                         matchRequirement.teamAllowed,
-                        matchRequirement.style,
-                        matchRequirement.genderPreference
+                        matchRequirement.style
                 )
                 .from(user)
                 .leftJoin(matchRequirement).on(matchRequirement.user.id.eq(user.id))
@@ -93,8 +92,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         boolean allConditionsPresent =
                 result.get(matchRequirement.team) != null &&
                         result.get(matchRequirement.teamAllowed) != null &&
-                        result.get(matchRequirement.style) != null &&
-                        result.get(matchRequirement.genderPreference) != null;
+                        result.get(matchRequirement.style) != null;
 
         return new CheckUserRes(nicknameExists, allConditionsPresent);
     }
@@ -109,7 +107,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         matchRequirement.team,
                         matchRequirement.teamAllowed,
                         matchRequirement.style,
-                        matchRequirement.genderPreference,
                         user.hasAccepted)
                 .from(user)
                 .leftJoin(matchRequirement).on(matchRequirement.user.id.eq(user.id))
@@ -125,8 +122,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         boolean allConditionsPresent =
                 result.get(matchRequirement.team) != null &&
                         result.get(matchRequirement.teamAllowed) != null &&
-                        result.get(matchRequirement.style) != null &&
-                        result.get(matchRequirement.genderPreference) != null;
+                        result.get(matchRequirement.style) != null;
 
         Boolean hasAccepted = result.get(user.hasAccepted);
         boolean accepted = hasAccepted != null && hasAccepted;

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -76,7 +76,8 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .select(user.nickname,
                         matchRequirement.team,
                         matchRequirement.teamAllowed,
-                        matchRequirement.style
+                        matchRequirement.style,
+                        matchRequirement.genderPreference
                 )
                 .from(user)
                 .leftJoin(matchRequirement).on(matchRequirement.user.id.eq(user.id))


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #245 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

매칭 리스트 조회 시 인원 수(count)가 실제 참여 인원과 다르게 계산되던 문제를 해결했습니다.

group_member 전체를 기준으로 count를 집계하던 기존 로직에서 isParticipant = true 조건을 추가하여 실제 참여자만 포함되도록 수정했습니다.

- countGroupMember 서브쿼리에 isParticipant.isTrue() 조건 추가
- 이미지 조회 로직 또한 동일하게 참여자 기준으로 통일

<br/>


### ❤️ To 다진 / To 헤음

---

이 사건이 없었다면 이미지와 카운트를 잘못세었을거요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그룹 매칭 조회가 실제 그룹 참여자만 포함하도록 개선되었습니다.
  * 그룹 매칭 결과의 정렬 처리 방식이 변경되어 기존 정렬 기준(매칭률·카운트·ID 순)을 보존하며 안정적으로 반환됩니다.
  * 사용자 정보 검증 로직에서 성별 선호 항목은 더 이상 필수 조건으로 간주되지 않도록 수정되어 정보 판정 조건이 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->