### PR TITLE
[feat] 경기 날짜 기준 매칭 완료,실패 스케쥴러 생성

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutorV3.java
@@ -1,0 +1,62 @@
+package at.mateball.domain.group.core;
+
+import at.mateball.domain.chatting.core.Chatting;
+import at.mateball.domain.chatting.core.service.ChattingV2Service;
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.group.scheduler.MatchSchedule;
+import at.mateball.domain.group.scheduler.ScheduleType;
+import at.mateball.domain.group.scheduler.repository.SchedulerRepository;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.GroupMember;
+import at.mateball.domain.user.core.User;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+public class GroupExecutorV3 {
+
+    private final EntityManager entityManager;
+    private final ChattingV2Service chattingV2Service;
+    private final SchedulerRepository schedulerRepository;
+
+    public GroupExecutorV3(EntityManager entityManager, ChattingV2Service chattingV2Service, SchedulerRepository schedulerRepository) {
+        this.entityManager = entityManager;
+        this.chattingV2Service = chattingV2Service;
+        this.schedulerRepository = schedulerRepository;
+    }
+
+    @Transactional
+    public Long createGroup(Long userId, Long gameId, boolean isGroup) {
+        User user = entityManager.find(User.class, userId);
+        if (user == null) {
+            throw new BusinessException(BusinessErrorCode.USER_NOT_FOUND);
+        }
+
+        GameInformation game = entityManager.find(GameInformation.class, gameId);
+        LocalDateTime gameDateTime = LocalDateTime.of(game.getGameDate(), game.getGameTime());
+
+        Chatting chatting = chattingV2Service.assignChatting();
+        if (chatting == null) {
+            throw new BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND);
+        }
+
+        Group group = Group.create(user, game, isGroup);
+        group.assignChatting(chatting);
+
+        entityManager.persist(group);
+        entityManager.flush();
+
+        GroupMember leader = GroupMember.leader(user, group, GroupMemberStatus.PENDING_REQUEST.getValue());
+        entityManager.persist(leader);
+
+        schedulerRepository.save(new MatchSchedule(group, gameDateTime.minusMinutes(1), ScheduleType.FAIL));
+        schedulerRepository.save(new MatchSchedule(group, gameDateTime, ScheduleType.COMPLETE));
+
+        return group.getId();
+    }
+}

--- a/src/main/java/at/mateball/domain/group/core/GroupStatus.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupStatus.java
@@ -34,6 +34,14 @@ public enum GroupStatus {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
 
+    public static String labelOf(int value) {
+        return Arrays.stream(values())
+                .filter(status -> status.value == value)
+                .map(status -> status.label)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
     public String toResponseLabel() {
         return switch (this) {
             case PENDING -> "그룹원 모집중";

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchCompleteService.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchCompleteService.java
@@ -1,0 +1,31 @@
+package at.mateball.domain.group.scheduler;
+
+import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GroupMatchCompleteService {
+    private static final int MIN_PARTICIPANT_FOR_COMPLETE = 2;
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    @Transactional
+    public void validateCompleteStatus(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        int memberCount = groupMemberRepository.countGroupMember(groupId).count();
+
+        if ((group.isGroup() && memberCount >= MIN_PARTICIPANT_FOR_COMPLETE)) {
+            groupMemberRepository.updateAllStatusComplete(groupId);
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/GroupMatchFailService.java
@@ -1,6 +1,7 @@
 package at.mateball.domain.group.scheduler;
 
 import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +13,14 @@ import java.util.List;
 @Service
 @Slf4j
 public class GroupMatchFailService {
-    private final GroupRepository groupRepository;
+    private static final int MIN_PARTICIPANT_FOR_COMPLETE = 2;
 
-    public GroupMatchFailService(GroupRepository groupRepository) {
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    public GroupMatchFailService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository) {
         this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
     }
 
     @Transactional
@@ -43,5 +48,13 @@ public class GroupMatchFailService {
         }
 
         return today.plusDays(2);
+    }
+
+    public void validateFailStatus(Long groupId) {
+        int participantCount = groupMemberRepository.countGroupMember(groupId).count();
+
+        if (participantCount < MIN_PARTICIPANT_FOR_COMPLETE) {
+            groupMemberRepository.updateAllStatusFail(groupId);
+        }
     }
 }

--- a/src/main/java/at/mateball/domain/group/scheduler/MatchSchedule.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/MatchSchedule.java
@@ -1,0 +1,44 @@
+package at.mateball.domain.group.scheduler;
+
+import at.mateball.domain.group.core.Group;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "match_schedule")
+public class MatchSchedule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @Column(nullable = false)
+    private LocalDateTime executeTime;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ScheduleType type;
+
+    @Column(nullable = false)
+    private boolean executed = false;
+
+    protected MatchSchedule() {
+    }
+
+    public MatchSchedule(Group group, LocalDateTime executeTime, ScheduleType type) {
+        this.group = group;
+        this.executeTime = executeTime;
+        this.type = type;
+        this.executed = false;
+    }
+
+    public void markExecuted() {
+        this.executed = true;
+    }
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/MatchScheduler.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/MatchScheduler.java
@@ -1,0 +1,45 @@
+package at.mateball.domain.group.scheduler;
+
+import at.mateball.domain.group.scheduler.repository.SchedulerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MatchScheduler {
+
+    private final SchedulerRepository repository;
+    private final GroupMatchFailService matchFailService;
+    private final GroupMatchCompleteService matchCompleteService;
+
+    @Scheduled(cron = "0 */1 * * * *")
+    @Transactional
+    public void run() {
+        log.info("매칭 상태 업데이트 스케줄러 호출 완료");
+
+        LocalDateTime now = LocalDateTime.now();
+        List<MatchSchedule> targets = repository.findAllDueSchedules(now);
+
+        for (MatchSchedule s : targets) {
+            try {
+                if (s.getType().isFail()) {
+                    matchFailService.validateFailStatus(s.getGroup().getId());
+                } else {
+                    matchCompleteService.validateCompleteStatus(s.getGroup().getId());
+                }
+
+                s.markExecuted();
+
+            } catch (Exception e) {
+                log.error("스케줄 처리 실패 groupId={}", s.getGroup().getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/ScheduleType.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/ScheduleType.java
@@ -1,0 +1,15 @@
+package at.mateball.domain.group.scheduler;
+
+public enum ScheduleType {
+
+    FAIL,
+    COMPLETE;
+
+    public boolean isFail() {
+        return this == FAIL;
+    }
+
+    public boolean isComplete() {
+        return this == COMPLETE;
+    }
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerCustom.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerCustom.java
@@ -1,0 +1,12 @@
+package at.mateball.domain.group.scheduler.repository;
+
+import at.mateball.domain.group.scheduler.MatchSchedule;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SchedulerCustom {
+    void save(MatchSchedule schedule);
+
+    List<MatchSchedule> findAllDueSchedules(LocalDateTime now);
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerRepository.java
@@ -1,0 +1,9 @@
+package at.mateball.domain.group.scheduler.repository;
+
+import at.mateball.domain.group.core.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerRepository extends JpaRepository<Group, Long>, SchedulerCustom {
+}

--- a/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/scheduler/repository/SchedulerRepositoryImpl.java
@@ -1,0 +1,37 @@
+package at.mateball.domain.group.scheduler.repository;
+
+import at.mateball.domain.group.scheduler.MatchSchedule;
+import at.mateball.domain.group.scheduler.QMatchSchedule;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SchedulerRepositoryImpl implements SchedulerCustom {
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    public SchedulerRepositoryImpl(JPAQueryFactory queryFactory, EntityManager em) {
+        this.queryFactory = queryFactory;
+        this.em = em;
+    }
+
+    @Override
+    public void save(MatchSchedule schedule) {
+        em.persist(schedule);
+    }
+
+    @Override
+    public List<MatchSchedule> findAllDueSchedules(LocalDateTime now) {
+        QMatchSchedule matchSchedule = QMatchSchedule.matchSchedule;
+
+        return queryFactory
+                .selectFrom(matchSchedule)
+                .where(
+                        matchSchedule.executed.isFalse(),
+                        matchSchedule.executeTime.loe(now)
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -30,6 +30,14 @@ public enum GroupMemberStatus {
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
     }
 
+    public static String labelOf(int value) {
+        return Arrays.stream(values())
+                .filter(status -> status.value == value)
+                .map(status -> status.label)
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BAD_REQUEST_ENUM));
+    }
+
     public String toResponseLabel() {
         return switch (this) {
             case AWAITING_APPROVAL -> "수락 대기 중";

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryCustom.java
@@ -80,4 +80,9 @@ public interface GroupMemberRepositoryCustom {
 
     Optional<Long> findApprovedRequesterUserId(Long groupId);
 
-    Optional<Long> findMatchedRequesterUserId(Long groupId);}
+    Optional<Long> findMatchedRequesterUserId(Long groupId);
+
+    void updateAllStatusFail(Long groupId);
+
+    void updateAllStatusComplete(Long groupId);
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -841,4 +841,34 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
         return Optional.ofNullable(requesterId);
     }
+
+    @Override
+    public void updateAllStatusFail(Long groupId){
+        queryFactory
+                .update(groupMember)
+                .set(groupMember.status, GroupMemberStatus.MATCH_FAILED.getValue())
+                .where(groupMember.group.id.eq(groupId))
+                .execute();
+
+        queryFactory
+                .update(group)
+                .set(group.status, GroupStatus.FAILED.getValue())
+                .where(group.id.eq(groupId))
+                .execute();
+    }
+
+    @Override
+    public void updateAllStatusComplete(Long groupId){
+        queryFactory
+                .update(groupMember)
+                .set(groupMember.status, GroupMemberStatus.MATCHED.getValue())
+                .where(groupMember.group.id.eq(groupId))
+                .execute();
+
+        queryFactory
+                .update(group)
+                .set(group.status, GroupStatus.COMPLETED.getValue())
+                .where(group.id.eq(groupId))
+                .execute();
+    }
 }

--- a/src/test/java/at/mateball/scheduler/MatchSchedulerIntegrationTest.java
+++ b/src/test/java/at/mateball/scheduler/MatchSchedulerIntegrationTest.java
@@ -170,7 +170,7 @@ class MatchSchedulerIntegrationTest {
         Group group = Group.create(userA, game, true);
         em.persist(group);
 
-        GroupMember m1 = new GroupMember(userB, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);
+        GroupMember m1 = new GroupMember(userA, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);
         GroupMember m2 = new GroupMember(userB, group, true, GroupMemberStatus.MATCHED.getValue(), false);
         em.persist(m1);
         em.persist(m2);

--- a/src/test/java/at/mateball/scheduler/MatchSchedulerIntegrationTest.java
+++ b/src/test/java/at/mateball/scheduler/MatchSchedulerIntegrationTest.java
@@ -1,0 +1,243 @@
+package at.mateball.scheduler;
+
+import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.group.scheduler.MatchSchedule;
+import at.mateball.domain.group.scheduler.ScheduleType;
+import at.mateball.domain.group.scheduler.repository.SchedulerRepository;
+import at.mateball.domain.group.scheduler.MatchScheduler;
+import at.mateball.domain.groupmember.core.GroupMember;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.user.core.User;
+import at.mateball.domain.gameinformation.core.GameInformation;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class MatchSchedulerIntegrationTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private SchedulerRepository schedulerRepository;
+
+    @Autowired
+    private MatchScheduler scheduler;
+
+    // ===================== FAIL =====================
+    @Test
+    @DisplayName("스케줄 실행 시 FAIL 처리")
+    void 그룹원이_생성자_혼자일때_FAIL_테스트() {
+
+        System.out.println("\n================ 🔥그룹원이_생성자_혼자일때 FAIL 테스트 시작 ================\n");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        User userA = new User(1L, "male", "url");
+        em.persist(userA);
+
+        GameInformation game = new GameInformation(
+                "A", "B",
+                now.toLocalDate(),
+                now.toLocalTime().minusMinutes(10),
+                "stadium"
+        );
+        em.persist(game);
+
+        Group group = Group.create(userA, game, true);
+        em.persist(group);
+
+        GroupMember leader = GroupMember.leader(userA, group,GroupMemberStatus.NEW_REQUEST.getValue());
+        em.persist(leader);
+
+        LocalDateTime gameTime = LocalDateTime.of(game.getGameDate(), game.getGameTime());
+
+        MatchSchedule schedule = new MatchSchedule(group, gameTime, ScheduleType.FAIL);
+        schedulerRepository.save(schedule);
+
+        em.flush();
+        em.clear();
+
+        // ===== when =====
+        scheduler.run();
+
+        em.flush();
+        em.clear();
+
+        // ===== then =====
+        System.out.println("\n========= 📊 FAIL 결과 =========");
+
+        printGroup(group.getId());
+        printMembers(group.getId());
+        printSchedule(schedule.getId());
+
+        MatchSchedule result = em.find(MatchSchedule.class, schedule.getId());
+        assertThat(result.isExecuted()).isTrue();
+
+        System.out.println("\n================ 🔥 FAIL 테스트 종료 ================\n");
+    }
+
+    @Test
+    @DisplayName("스케줄 실행 시 FAIL 처리")
+    void 그룹원이_생성자_혼자면서_승인_대기자가_존재할때_FAIL_테스트() {
+
+        System.out.println("\n================ 🔥 그룹원이_생성자_혼자면서_승인_대기자가_존재할때 FAIL 테스트 시작 ================\n");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        User userA = new User(1L, "male", "url");
+        User userB = new User(2L, "female", "url");
+        em.persist(userA);
+        em.persist(userB);
+
+        GameInformation game = new GameInformation(
+                "A", "B",
+                now.toLocalDate(),
+                now.toLocalTime().minusMinutes(10),
+                "stadium"
+        );
+        em.persist(game);
+
+        Group group = Group.create(userA, game, true);
+        em.persist(group);
+
+        GroupMember leader = GroupMember.leader(userA, group,GroupMemberStatus.NEW_REQUEST.getValue());
+        GroupMember m2 = new GroupMember(userB, group, false, GroupMemberStatus.AWAITING_APPROVAL.getValue(), false);
+        em.persist(leader);
+        em.persist(m2);
+
+        LocalDateTime gameTime = LocalDateTime.of(game.getGameDate(), game.getGameTime());
+
+        MatchSchedule schedule = new MatchSchedule(group, gameTime, ScheduleType.FAIL);
+        schedulerRepository.save(schedule);
+
+        em.flush();
+        em.clear();
+
+        // ===== when =====
+        scheduler.run();
+
+        em.flush();
+        em.clear();
+
+        // ===== then =====
+        System.out.println("\n========= 📊 FAIL 결과 =========");
+
+        printGroup(group.getId());
+        printMembers(group.getId());
+        printSchedule(schedule.getId());
+
+        MatchSchedule result = em.find(MatchSchedule.class, schedule.getId());
+        assertThat(result.isExecuted()).isTrue();
+
+        System.out.println("\n================ 🔥 FAIL 테스트 종료 ================\n");
+    }
+
+    // ===================== COMPLETE =====================
+    @Test
+    @DisplayName("스케줄 실행 시 COMPLETE 처리")
+    void COMPLETE_테스트() {
+
+        System.out.println("\n================ 🚀 COMPLETE 테스트 시작 ================\n");
+
+        LocalDateTime now = LocalDateTime.now();
+
+        User userA = new User(1L, "male", "url");
+        User userB = new User(2L, "female", "url");
+
+        em.persist(userA);
+        em.persist(userB);
+
+        GameInformation game = new GameInformation(
+                "A", "B",
+                now.toLocalDate(),
+                now.toLocalTime().minusMinutes(10),
+                "stadium"
+        );
+        em.persist(game);
+
+        Group group = Group.create(userA, game, true);
+        em.persist(group);
+
+        GroupMember m1 = new GroupMember(userB, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(), true);
+        GroupMember m2 = new GroupMember(userB, group, true, GroupMemberStatus.MATCHED.getValue(), false);
+        em.persist(m1);
+        em.persist(m2);
+
+        LocalDateTime gameTime = LocalDateTime.of(game.getGameDate(), game.getGameTime());
+
+        MatchSchedule schedule = new MatchSchedule(group, gameTime, ScheduleType.COMPLETE);
+        schedulerRepository.save(schedule);
+
+        em.flush();
+        em.clear();
+
+        // ===== when =====
+        scheduler.run();
+
+        em.flush();
+        em.clear();
+
+        // ===== then =====
+        System.out.println("\n========= 📊 COMPLETE 결과 =========");
+
+        printGroup(group.getId());
+        printMembers(group.getId());
+        printSchedule(schedule.getId());
+
+        MatchSchedule result = em.find(MatchSchedule.class, schedule.getId());
+        assertThat(result.isExecuted()).isTrue();
+
+        System.out.println("\n================ 🚀 COMPLETE 테스트 종료 ================\n");
+    }
+
+    // ===================== 로그 유틸 =====================
+
+    private void printGroup(Long groupId) {
+        Group group = em.find(Group.class, groupId);
+
+        System.out.println("🏟️ 그룹 상태 = "
+                + GroupStatus.labelOf(group.getStatus())
+                + " (" + group.getStatus() + ")");
+    }
+
+    private void printMembers(Long groupId) {
+        List<GroupMember> members = em.createQuery(
+                        "select gm from GroupMember gm where gm.group.id = :groupId",
+                        GroupMember.class
+                )
+                .setParameter("groupId", groupId)
+                .getResultList();
+
+        for (GroupMember m : members) {
+            System.out.println(
+                    "👤 유저ID=" + m.getUser().getId()
+                            + " | 역할=" + roleOf(m)
+                            + " | 상태=" + GroupMemberStatus.labelOf(m.getStatus())
+                            + " (" + m.getStatus() + ")"
+            );
+        }
+    }
+
+    private void printSchedule(Long scheduleId) {
+        MatchSchedule s = em.find(MatchSchedule.class, scheduleId);
+
+        System.out.println("📌 스케줄 실행 여부 = "
+                + (s.isExecuted() ? "실행됨 ✅" : "미실행 ❌"));
+    }
+
+    private String roleOf(GroupMember m) {
+        return m.getIsLeader() ? "👑 생성자" : "🙋 참여자";
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #249

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 스케쥴러를 통해 경기날짜(시간)이 되면, 매칭현황에 따라 매칭상태가 변경되도록 구현했습니다. 이에 따라 MatchSchedule 테이블에 추가되었습니다.
- 흐름은 다음과 같습니다.
  - 그룹 생성시, 스케쥴러 등록
  - 경기시간이 되기 1분전 -> fail 스케쥴 처리
  경기시간 기준 -> complete 스케쥴 처리
    - `findAllDueSchedules`: 아직 실행되지 않은 스케쥴에 한해 로직이 실행됩니다.
    - `GroupMatchFailService` fail 이 되는 경우: 스케쥴러가 접근했을때, 매칭 참여자(isParticipant=ture)가 한 명인 경우
    -> 이때, 매칭생성자뿐만 아니라 그룹에 요청했던 요청자까지도 함께 매칭실패 로 상태가 변경됩니다.
    - `GroupMatchCompleteService` complete 이 되는 경우: 스케쥴러가 접근했을때, 매칭 참여자(isParticipant=true)가 두 명 이상인 경우
 - `MatchSchedulerIntegrationTest` 을 통해, 총 3개의 경우의 수를 테스트해볼 수 있습니다. <- 다만 기존 "매칭생성"브랜치에서 작업했던 내용이라, 실행은 매칭생성 병합 후에 가능합니다.. ㅠㅠ
<img width="1621" height="1203" alt="image" src="https://github.com/user-attachments/assets/42b2463b-dc04-47b9-aa3d-3a93f95774f7" />




<br/>


### ❤️ To 다진 / To 헤음

---

- ............뭔가 잘못된걸 끝나고 나서야..알게된 것 같아요.. 이거 그냥 삭제할까...그냥 없었던 일로 할까....
- 되돌아보니까 그냥 쿼리 조회 완전 마니 하는 코드 된 것 같은데... 흑흑..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 매칭 자동 스케줄링 시스템 추가: 게임 시간 기준으로 매칭 실패/완료 자동 처리
  * 그룹 생성 및 멤버 상태 관리 기능 강화
  * 상태 레이블 조회 기능 추가

* **테스트**
  * 스케줄러 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->