### PR TITLE
[feat] 사용자 수 반환 api

### DIFF
--- a/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
@@ -55,4 +55,14 @@ public class UserV3Controller {
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, data));
     }
+
+    @GetMapping("/count")
+    @Operation(summary = "가입자 수 조회 api")
+    public ResponseEntity<MateballResponse<?>> getUsersCount(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        UserCountRes response = userService.getUsersCount(userId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, response));
+    }
 }

--- a/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
+++ b/src/main/java/at/mateball/domain/user/api/controller/UserV3Controller.java
@@ -5,6 +5,7 @@ import at.mateball.common.security.CustomUserDetails;
 import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
 import at.mateball.domain.chatting.api.dto.response.ChattingRes;
 import at.mateball.domain.group.core.service.GroupV3Service;
+import at.mateball.domain.user.api.dto.response.UserCountRes;
 import at.mateball.domain.user.core.service.UserV3Service;
 import at.mateball.exception.code.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -61,7 +62,9 @@ public class UserV3Controller {
     public ResponseEntity<MateballResponse<?>> getUsersCount(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
-        UserCountRes response = userService.getUsersCount(userId);
+        Long userId = customUserDetails.getUserId();
+
+        UserCountRes response = userV3Service.getUsersCount(userId);
 
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, response));
     }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserCountRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserCountRes.java
@@ -1,0 +1,6 @@
+package at.mateball.domain.user.api.dto.response;
+
+public record UserCountRes(
+        Long userCnt
+) {
+}

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     Optional<User> findByKakaoUserId(Long kakaoUserId);
     @Query("select u.nickname from User u where u.id = :id")
     String findNicknameById(@Param("id") Long id);
+
+    Long countByIdNot(Long userId);
 }

--- a/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserV3Service.java
@@ -5,6 +5,7 @@ import at.mateball.domain.matchrequirement.core.repository.MatchRequirementRepos
 import at.mateball.domain.team.core.TeamName;
 import at.mateball.domain.user.api.dto.response.MyPageInformationBaseRes;
 import at.mateball.domain.user.api.dto.response.MyPageInformationRes;
+import at.mateball.domain.user.api.dto.response.UserCountRes;
 import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
@@ -57,5 +58,10 @@ public class UserV3Service {
         String imageUrl = userProfileImageService.getProfileImageUrl(baseRes.user());
 
         return MyPageInformationRes.from(baseRes,imageUrl);
+    }
+
+    public UserCountRes getUsersCount(Long userId) {
+        Long userCnt = userRepository.countByIdNot(userId);
+        return new UserCountRes(userCnt);
     }
 }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #251 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

member 테이블을 기준으로 전체 사용자 수를 count하는 로직을 구현했습니다.
로그인한 사용자를 제외하기 위해 countByIdNot(userId) 메서드를 사용하여 불필요한 조회 없이 count 쿼리만 수행하도록 처리했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---

간단한 집계 기능이라 JPA derived query로 구현했슙니당!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 인증된 사용자를 제외한 전체 사용자 수를 조회하는 새로운 API 엔드포인트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->