### PR TITLE
[fix] v1 GroupMember 생성자에 isLeader 값 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/core/GroupExecutor.java
+++ b/src/main/java/at/mateball/domain/group/core/GroupExecutor.java
@@ -36,7 +36,7 @@ public class GroupExecutor {
         Group group = new Group(user, game, LocalDateTime.now(), GroupStatus.PENDING.getValue(), isGroup);
         entityManager.persist(group);
 
-        GroupMember leader = new GroupMember(user, group, true, GroupMemberStatus.PENDING_REQUEST.getValue());
+        GroupMember leader = new GroupMember(user, group, true, GroupMemberStatus.PENDING_REQUEST.getValue(),true); //v1 버전 해결 (임시)
         entityManager.persist(leader);
 
         return group.getId();

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -363,7 +363,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         User user = entityManager.getReference(User.class, userId);
         Group group = entityManager.getReference(Group.class, matchId);
 
-        GroupMember groupMember = new GroupMember(user, group, false, GroupMemberStatus.AWAITING_APPROVAL.getValue());
+        GroupMember groupMember = new GroupMember(user, group, false, GroupMemberStatus.AWAITING_APPROVAL.getValue(), false);
 
         entityManager.persist(groupMember);
     }


### PR DESCRIPTION
isLeader=true추가

<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #253 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존 매칭생성,요청생성에 사용되는 GroupMember 생성자에 isLeader 값을 추가했습니다.
(isLeader 컬럼은 v3 마이그레이션하면서 생긴 컬럼)


<br/>


### ❤️ To 다진 / To 헤음

---

- api 정상 작동 확인했습니다, 바로 배포할게요~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **내부 개선**
  * 그룹 멤버 관리 모듈의 내부 구조를 최적화했습니다. 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->