### PR TITLE
[feat/] 그룹장 닉네임 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/dto/GroupMatchMemberListRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupMatchMemberListRes.java
@@ -3,6 +3,7 @@ package at.mateball.domain.group.api.dto;
 import java.util.List;
 
 public record GroupMatchMemberListRes(
+        String leader,
         List<GroupMatchMemberRes> results
 ) {
 }

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -145,6 +145,9 @@ public class GroupV3Service {
         List<GroupMatchMemberQueryDto> members =
                 groupV3RepositoryCustom.findMatchMembersByMatchId(matchId);
 
+        String leaderNickname = groupV3RepositoryCustom.findLeaderNicknameByMatchId(matchId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
         MatchingTarget loginUserTarget = loginRequirement.toTarget(userId);
 
         List<Long> memberIds = members.stream()
@@ -165,7 +168,7 @@ public class GroupV3Service {
                 ))
                 .toList();
 
-        return new GroupMatchMemberListRes(results);
+        return new GroupMatchMemberListRes(leaderNickname, results);
     }
 
     private void validateNotOwnMatch(Long userId, Long matchId) {

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -145,9 +145,6 @@ public class GroupV3Service {
         List<GroupMatchMemberQueryDto> members =
                 groupV3RepositoryCustom.findMatchMembersByMatchId(matchId);
 
-        String leaderNickname = groupV3RepositoryCustom.findLeaderNicknameByMatchId(matchId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
-
         MatchingTarget loginUserTarget = loginRequirement.toTarget(userId);
 
         List<Long> memberIds = members.stream()
@@ -159,6 +156,12 @@ public class GroupV3Service {
                         MemberMatchCountDto::memberId,
                         MemberMatchCountDto::matchCount
                 ));
+
+        String leaderNickname = members.stream()
+                .filter(GroupMatchMemberQueryDto::isLeader)
+                .findFirst()
+                .map(GroupMatchMemberQueryDto::nickname)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
 
         List<GroupMatchMemberRes> results = members.stream()
                 .map(member -> toGroupMatchMemberRes(

--- a/src/main/java/at/mateball/domain/group/infrastructure/dto/GroupMatchMemberQueryDto.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/dto/GroupMatchMemberQueryDto.java
@@ -12,7 +12,8 @@ public record GroupMatchMemberQueryDto(
         Integer teamAllowed,
         Integer style,
         Integer avgSeason,
-        String profileImageKey
+        String profileImageKey,
+        Boolean isLeader
 ) {
     public MatchingTarget toMatchingTarget() {
         return new MatchingTarget(

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -23,8 +23,6 @@ public interface GroupV3RepositoryCustom {
 
     Optional<Long> findLeaderIdByMatchId(Long matchId);
 
-    Optional<String> findLeaderNicknameByMatchId(Long matchId);
-
     List<GroupMatchMemberQueryDto> findMatchMembersByMatchId(Long matchId);
 
     List<MemberMatchCountDto> countGroupMembersByUserIds(List<Long> memberIds);

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryCustom.java
@@ -23,6 +23,8 @@ public interface GroupV3RepositoryCustom {
 
     Optional<Long> findLeaderIdByMatchId(Long matchId);
 
+    Optional<String> findLeaderNicknameByMatchId(Long matchId);
+
     List<GroupMatchMemberQueryDto> findMatchMembersByMatchId(Long matchId);
 
     List<MemberMatchCountDto> countGroupMembersByUserIds(List<Long> memberIds);

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -206,6 +206,24 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
     }
 
     @Override
+    public Optional<String> findLeaderNicknameByMatchId(Long matchId) {
+        QGroupMember leaderMember = new QGroupMember("leaderMember");
+        QUser leaderUser = new QUser("leaderUser");
+
+        return Optional.ofNullable(
+                queryFactory
+                        .select(leaderUser.nickname)
+                        .from(leaderMember)
+                        .join(leaderMember.user, leaderUser)
+                        .where(
+                                leaderMember.group.id.eq(matchId),
+                                leaderMember.isLeader.isTrue()
+                        )
+                        .fetchOne()
+        );
+    }
+
+    @Override
     public List<GroupMatchMemberQueryDto> findMatchMembersByMatchId(Long matchId) {
         QGroupMember groupMember = new QGroupMember("groupMember");
         QUser memberUser = new QUser("memberUser");

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -206,24 +206,6 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
     }
 
     @Override
-    public Optional<String> findLeaderNicknameByMatchId(Long matchId) {
-        QGroupMember leaderMember = new QGroupMember("leaderMember");
-        QUser leaderUser = new QUser("leaderUser");
-
-        return Optional.ofNullable(
-                queryFactory
-                        .select(leaderUser.nickname)
-                        .from(leaderMember)
-                        .join(leaderMember.user, leaderUser)
-                        .where(
-                                leaderMember.group.id.eq(matchId),
-                                leaderMember.isLeader.isTrue()
-                        )
-                        .fetchOne()
-        );
-    }
-
-    @Override
     public List<GroupMatchMemberQueryDto> findMatchMembersByMatchId(Long matchId) {
         QGroupMember groupMember = new QGroupMember("groupMember");
         QUser memberUser = new QUser("memberUser");
@@ -241,7 +223,8 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         memberRequirement.teamAllowed,
                         memberRequirement.style,
                         memberUser.avgSeason,
-                        memberUser.profileImageKey
+                        memberUser.profileImageKey,
+                        groupMember.isLeader
                 ))
                 .from(groupMember)
                 .join(groupMember.user, memberUser)


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #255


<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

매칭된 그룹원 리스트 조회 API(`/v3/users/match/members/{matchId}`)에 리더 닉네임을 함께 반환하도록 수정했습니다.

기존에는 그룹원 리스트만 내려주고 있었으나, 클라이언트에서 리더 정보를 함께 활용할 수 있도록 응답 DTO에 `leader` 필드를 추가했습니다.

리더 정보는 `groupMember.isLeader = true` 조건으로 별도 조회하여 닉네임을 가져오고, 기존 그룹원 리스트와 함께 응답하도록 서비스 로직을 확장했습니다.

또한, 리더 검증 로직(`validateNotOwnMatch`)에서 사용되는 리더 ID 조회와 응답용 닉네임 조회를 각각 분리하여, 역할에 맞는 메서드(`findLeaderIdByMatchId`, `findLeaderNicknameByMatchId`)로 구성했습니다.


<br/>


### ❤️ To 다진 / To 헤음

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 멤버 목록 조회 응답에 그룹 리더 정보가 추가되었습니다. 이제 API 응답을 통해 그룹 리더를 명확히 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->