### PR TITLE
[fea] 매칭 현황에서 매칭된 그룹원 조회

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
+++ b/src/main/java/at/mateball/domain/group/api/controller/GroupV3Controller.java
@@ -59,6 +59,19 @@ public class GroupV3Controller {
         return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
     }
 
+    @GetMapping("/match-status/members/{matchId}")
+    @Operation(summary = "매칭현황 매칭된 그룹원 리스트 api")
+    public ResponseEntity<MateballResponse<GroupMatchMemberListRes>> getMatchStatusGroupMembers(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long matchId
+    ) {
+        Long userId = customUserDetails.getUserId();
+
+        GroupMatchMemberListRes result = groupV3Service.getMatchStatusGroupMembers(userId, matchId);
+
+        return ResponseEntity.ok(MateballResponse.success(SuccessCode.OK, result));
+    }
+
     @GetMapping("request")
     @Operation(summary = "요청한 매칭 리스트 조회 api")
     public ResponseEntity<MateballResponse<RequestGroupListRes>> getRequestGroupList(

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV3Service.java
@@ -135,7 +135,14 @@ public class GroupV3Service {
 
     public GroupMatchMemberListRes getMatchGroupMembers(Long userId, Long matchId) {
         validateNotOwnMatch(userId, matchId);
+        return buildGroupMatchMemberList(userId, matchId);
+    }
 
+    public GroupMatchMemberListRes getMatchStatusGroupMembers(Long userId, Long matchId) {
+        return buildGroupMatchMemberList(userId, matchId);
+    }
+
+    private GroupMatchMemberListRes buildGroupMatchMemberList(Long userId, Long matchId) {
         LoginUserMatchRequirementDto loginRequirement = groupV3RepositoryCustom.findLoginUserMatchRequirement(userId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND));
 


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #258 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

기존 매칭 그룹원 조회 API와 매칭 현황 그룹원 조회 API에서 중복되던 응답 생성 로직을 공통 메서드로 분리했습니다.
기존 API는 내가 만든 매칭 예외 처리를 유지하고, 매칭 현황 API는 해당 예외 없이 동일한 응답을 내려줄 수 있도록 조회 정책만 분리했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 매치에 참여한 멤버들의 상태 정보를 조회할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->