### PR TITLE
[fix] 프로필 정보 상태 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -253,10 +253,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         groupMember.count().intValue()
                 ))
                 .from(groupMember)
-                .where(
-                        groupMember.user.id.in(memberIds),
-                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
-                )
+                .where(groupMember.user.id.in(memberIds))
                 .groupBy(groupMember.user.id)
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -253,7 +253,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                         groupMember.count().intValue()
                 ))
                 .from(groupMember)
-                .where(groupMember.user.id.in(memberIds))
+                .where(
+                        groupMember.user.id.in(memberIds),
+                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
+                )
                 .groupBy(groupMember.user.id)
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -250,10 +250,13 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .select(Projections.constructor(
                         MemberMatchCountDto.class,
                         groupMember.user.id,
-                        groupMember.count().intValue()
+                        groupMember.id.countDistinct().intValue()
                 ))
                 .from(groupMember)
-                .where(groupMember.user.id.in(memberIds))
+                .where(
+                        groupMember.user.id.in(memberIds),
+                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
+                )
                 .groupBy(groupMember.user.id)
                 .fetch();
     }

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,6 +1,5 @@
 package at.mateball.domain.user.core.repository;
 
-import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.api.dto.response.*;
@@ -148,10 +147,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .leftJoin(matchRequirement)
                 .on(matchRequirement.user.id.eq(user.id))
                 .leftJoin(groupMember)
-                .on(
-                        groupMember.user.id.eq(user.id)
-                                .and(groupMember.status.eq(GroupMemberStatus.MATCHED.getValue()))
-                )
+                .on(groupMember.user.id.eq(user.id))
                 .where(user.id.eq(userId))
                 .groupBy(
                         user.id,

--- a/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
+++ b/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
@@ -1,0 +1,96 @@
+package at.mateball.group;
+
+import at.mateball.config.QuerydslConfig;
+import at.mateball.domain.gameinformation.core.GameInformation;
+import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.infrastructure.dto.MemberMatchCountDto;
+import at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryImpl;
+import at.mateball.domain.groupmember.GroupMemberStatus;
+import at.mateball.domain.groupmember.core.GroupMember;
+import at.mateball.domain.user.core.User;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({QuerydslConfig.class, GroupV3RepositoryImpl.class})
+class CountGroupMembersByUserIdsTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private GroupV3RepositoryImpl groupV3Repository;
+
+    @Test
+    void 함께한_매칭_수는_매칭완료_상태만_집계한다() {
+        // given
+        User leader = persistUser(1000L);
+        User target = persistUser(2000L);
+
+        // target 유저: MATCHED 2건 + 비-MATCHED(요청/실패 등) 3건
+        em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
+        em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
+        em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.PENDING_REQUEST.getValue()));
+        em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.AWAITING_APPROVAL.getValue()));
+        em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCH_FAILED.getValue()));
+
+        em.flush();
+        em.clear();
+
+        // when
+        Map<Long, Integer> countMap = groupV3Repository
+                .countGroupMembersByUserIds(List.of(target.getId()))
+                .stream()
+                .collect(Collectors.toMap(MemberMatchCountDto::memberId, MemberMatchCountDto::matchCount));
+
+        // then: 전체 5건이 아니라 MATCHED 2건만 집계되어야 한다
+        assertThat(countMap.getOrDefault(target.getId(), 0)).isEqualTo(2);
+    }
+
+    @Test
+    void 매칭완료_내역이_없으면_결과에서_제외된다() {
+        // given
+        User leader = persistUser(1001L);
+        User target = persistUser(2001L);
+
+        em.persist(GroupMember.member(target, persistGroup(leader),
+                GroupMemberStatus.PENDING_REQUEST.getValue()));
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<MemberMatchCountDto> result = groupV3Repository.countGroupMembersByUserIds(List.of(target.getId()));
+
+        // then: getOrDefault(..., 0) 으로 본인 프로필과 동일하게 0 으로 해석된다
+        assertThat(result).isEmpty();
+    }
+
+    private User persistUser(long kakaoUserId) {
+        User user = new User(kakaoUserId, "male", "http://example.com");
+        em.persist(user);
+        return user;
+    }
+
+    private Group persistGroup(User leader) {
+        GameInformation game = new GameInformation(
+                "두산", "LG", LocalDate.of(2026, 6, 13), LocalTime.of(18, 30), "잠실");
+        em.persist(game);
+        Group group = Group.create(leader, game, false);
+        em.persist(group);
+        return group;
+    }
+}

--- a/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
+++ b/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
@@ -35,12 +35,12 @@ class CountGroupMembersByUserIdsTest {
     private GroupV3RepositoryImpl groupV3Repository;
 
     @Test
-    void 함께한_매칭_수는_매칭완료_상태만_집계한다() {
+    void 함께한_매칭_수는_상태와_무관하게_신청_수_전체를_집계한다() {
         // given
         User leader = persistUser(1000L);
         User target = persistUser(2000L);
 
-        // target 유저: MATCHED 2건 + 비-MATCHED(요청/실패 등) 3건
+        // target 유저: 상태와 무관하게 신청한 모든 내역(요청/대기/완료/실패 등) 5건
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.PENDING_REQUEST.getValue()));
@@ -56,18 +56,17 @@ class CountGroupMembersByUserIdsTest {
                 .stream()
                 .collect(Collectors.toMap(MemberMatchCountDto::memberId, MemberMatchCountDto::matchCount));
 
-        // then: 전체 5건이 아니라 MATCHED 2건만 집계되어야 한다
-        assertThat(countMap.getOrDefault(target.getId(), 0)).isEqualTo(2);
+        // then: MATCHED 만이 아니라 신청한 전체 5건이 집계되어야 한다
+        assertThat(countMap.getOrDefault(target.getId(), 0)).isEqualTo(5);
     }
 
     @Test
-    void 매칭완료_내역이_없으면_결과에서_제외된다() {
+    void 신청_내역이_없으면_결과에서_제외된다() {
         // given
-        User leader = persistUser(1001L);
+        persistUser(1001L);
         User target = persistUser(2001L);
 
-        em.persist(GroupMember.member(target, persistGroup(leader),
-                GroupMemberStatus.PENDING_REQUEST.getValue()));
+        // target 유저: 신청 내역 없음
 
         em.flush();
         em.clear();

--- a/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
+++ b/src/test/java/at/mateball/group/CountGroupMembersByUserIdsTest.java
@@ -35,12 +35,12 @@ class CountGroupMembersByUserIdsTest {
     private GroupV3RepositoryImpl groupV3Repository;
 
     @Test
-    void 함께한_매칭_수는_상태와_무관하게_신청_수_전체를_집계한다() {
+    void 함께한_매칭_수는_매칭완료_상태만_집계한다() {
         // given
         User leader = persistUser(1000L);
         User target = persistUser(2000L);
 
-        // target 유저: 상태와 무관하게 신청한 모든 내역(요청/대기/완료/실패 등) 5건
+        // target 유저: MATCHED 2건 + 비-MATCHED(요청/대기/실패 등) 3건
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.MATCHED.getValue()));
         em.persist(GroupMember.member(target, persistGroup(leader), GroupMemberStatus.PENDING_REQUEST.getValue()));
@@ -56,17 +56,19 @@ class CountGroupMembersByUserIdsTest {
                 .stream()
                 .collect(Collectors.toMap(MemberMatchCountDto::memberId, MemberMatchCountDto::matchCount));
 
-        // then: MATCHED 만이 아니라 신청한 전체 5건이 집계되어야 한다
-        assertThat(countMap.getOrDefault(target.getId(), 0)).isEqualTo(5);
+        // then: 전체 5건이 아니라 MATCHED 2건만 집계되어야 한다
+        assertThat(countMap.getOrDefault(target.getId(), 0)).isEqualTo(2);
     }
 
     @Test
-    void 신청_내역이_없으면_결과에서_제외된다() {
+    void 매칭완료_내역이_없으면_결과에서_제외된다() {
         // given
-        persistUser(1001L);
+        User leader = persistUser(1001L);
         User target = persistUser(2001L);
 
-        // target 유저: 신청 내역 없음
+        // target 유저: 매칭완료가 아닌 신청 내역만 존재
+        em.persist(GroupMember.member(target, persistGroup(leader),
+                GroupMemberStatus.PENDING_REQUEST.getValue()));
 
         em.flush();
         em.clear();
@@ -74,7 +76,7 @@ class CountGroupMembersByUserIdsTest {
         // when
         List<MemberMatchCountDto> result = groupV3Repository.countGroupMembersByUserIds(List.of(target.getId()));
 
-        // then: getOrDefault(..., 0) 으로 본인 프로필과 동일하게 0 으로 해석된다
+        // then: 매칭완료 내역이 없으므로 결과에서 제외되고, getOrDefault(..., 0) 으로 0 으로 해석된다
         assertThat(result).isEmpty();
     }
 


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #265

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

프로필 정보에서 `함께한 매칭 수`와 `시즌 평균 직관 수`가 유저 본인이 설정한 값과 타인에게 노출되는 값이 일치하지 않는 문제를 수정했습니다.

기존에는 본인 프로필 조회와 타인 프로필 조회 흐름에서 해당 숫자를 참조하는 기준이 달라, 유저가 값을 변경해도 일부 조회 경로에서는 이전 값 또는 다른 값이 노출될 수 있었습니다.

이번 작업에서는 프로필 조회 시 사용되는 값을 동일한 기준으로 맞춰, 유저가 설정한 `함께한 매칭 수`, `시즌 평균 직관 수`가 본인 화면과 타인 조회 화면에서 동일하게 노출되도록 수정했습니다.

주요 수정 내용은 다음과 같습니다.

* 프로필 수정 시 저장되는 `함께한 매칭 수`, `시즌 평균 직관 수` 기준 확인
* 내 프로필 조회와 타인 프로필 조회에서 해당 값이 동일한 source를 참조하도록 수정
* 기존 프론트 응답 필드명과 응답 구조는 유지
* 프로필 수정 후 타인이 조회하는 프로필 응답에도 최신 값이 반영되도록 처리
* 관련 프로필 응답 경로에서 값 불일치가 발생하지 않도록 정리

검증 항목은 다음과 같습니다.

* 유저 A가 프로필 숫자 수정 후, 유저 A의 내 프로필 조회 값 확인
* 유저 B가 유저 A의 프로필 조회 시 동일한 값이 노출되는지 확인
* 유저 A가 값을 재수정한 직후 유저 B 조회 응답에 최신 값이 반영되는지 확인
* 여러 계정 기준으로 동일 현상이 재발하지 않는지 확인
* 기존 프로필 응답 필드명/구조 변경 없음 확인

<br/>

### ❤️ To 다진 / To 헤음

---

오랜만에 작업해서 어렵다 어려워.. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 그룹 멤버 집계가 중복을 제거하고 "매칭 완료(MATCHED)" 상태인 멤버만 카운트하도록 개선되었습니다.
  * 마이페이지 관련 그룹 집계 로직이 단순화되어 일부 집계 결과가 변경될 수 있습니다.

* **테스트**
  * 그룹 멤버 집계 기능의 정확성을 검증하는 JPA 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->