### PR TITLE
[fix] 오픈채팅방 접속 문제

### DIFF
--- a/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
+++ b/src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java
@@ -2,6 +2,8 @@ package at.mateball.domain.groupRequest;
 
 import at.mateball.domain.alarm.common.AlarmType;
 import at.mateball.domain.alarm.core.service.AlarmService;
+import at.mateball.domain.chatting.core.Chatting;
+import at.mateball.domain.chatting.core.service.ChattingV2Service;
 import at.mateball.domain.group.api.dto.GroupValidationRes;
 import at.mateball.domain.group.api.dto.RequestValidationRes;
 import at.mateball.domain.group.core.Group;
@@ -37,6 +39,7 @@ public class GroupRequestService {
     private final GroupMemberV3Service groupMemberV3Service;
     private final GroupRequestValidator groupRequestValidator;
     private final ConstraintExceptionTranslator constraintExceptionTranslator;
+    private final ChattingV2Service chattingV2Service;
     private final EntityManager entityManager;
 
     @Transactional
@@ -68,12 +71,12 @@ public class GroupRequestService {
         Long requesterId = Optional.ofNullable(summary.requesterId())
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.REQUESTER_NOT_FOUND));
 
-        if (isGroup) processGroupMatch(userId, requesterId, groupId, summary);
-        else processDirectMatch(userId, requesterId, groupId);
+        if (isGroup) processGroupMatch(group, userId, requesterId, groupId, summary);
+        else processDirectMatch(group, userId, requesterId, groupId);
     }
 
     private Group getValidatedGroup(Long userId, Long groupId) {
-        Group group = groupRepository.findById(groupId)
+        Group group = groupRepository.findGroupWithLock(groupId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
 
         GroupValidator.validate(group);
@@ -85,17 +88,18 @@ public class GroupRequestService {
         return group;
     }
 
-    private void processDirectMatch(Long userId, Long requesterId, Long groupId) {
+    private void processDirectMatch(Group group, Long userId, Long requesterId, Long groupId) {
         groupMemberV3Service.updateMemberStatusMatched(userId, groupId);
         groupMemberV3Service.updateMemberStatusMatched(requesterId, groupId);
 
         updateGroupStatusCompleted(groupId);
+        assignChattingIfAbsent(group);
 
         alarmService.notifyMatched(userId, groupId);
         alarmService.notifyMatched(requesterId, groupId);
     }
 
-    private void processGroupMatch(Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
+    private void processGroupMatch(Group group, Long userId, Long requesterId, Long groupId, GroupMatchSummaryRes summary) {
         groupMemberV3Service.updateMemberStatusMatched(requesterId, groupId);
 
         boolean isFull = isGroupFull(summary);
@@ -103,6 +107,7 @@ public class GroupRequestService {
         if (isFull) {
             groupMemberV3Service.updateMemberStatusMatched(userId, groupId);
             updateGroupStatusCompleted(groupId);
+            assignChattingIfAbsent(group);
 
             alarmService.notifyMatched(userId, groupId);
             alarmService.notifyMatched(requesterId, groupId);
@@ -115,6 +120,15 @@ public class GroupRequestService {
 
     public void updateGroupStatusCompleted(Long groupId) { // 순환참조 발생으로 request service 에 위치
         groupRepository.updateGroupStatus(groupId, GroupStatus.COMPLETED.getValue());
+    }
+
+    private void assignChattingIfAbsent(Group group) {
+        if (group.getChatting() != null) {
+            return;
+        }
+
+        Chatting chatting = chattingV2Service.assignChatting();
+        groupRepository.assignChattingToGroup(group.getId(), chatting.getId());
     }
 
     private boolean isGroupFull(GroupMatchSummaryRes summary) {

--- a/src/test/java/at/mateball/domain/groupRequest/GroupRequestServiceTest.java
+++ b/src/test/java/at/mateball/domain/groupRequest/GroupRequestServiceTest.java
@@ -1,0 +1,156 @@
+package at.mateball.domain.groupRequest;
+
+import at.mateball.domain.alarm.core.service.AlarmService;
+import at.mateball.domain.chatting.core.Chatting;
+import at.mateball.domain.chatting.core.service.ChattingV2Service;
+import at.mateball.domain.group.core.Group;
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.group.core.repository.GroupRepository;
+import at.mateball.domain.groupmember.api.dto.GroupMatchSummaryRes;
+import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import at.mateball.domain.groupmember.core.service.GroupMemberV3Service;
+import at.mateball.domain.user.core.User;
+import at.mateball.exception.BusinessException;
+import at.mateball.exception.code.BusinessErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GroupRequestServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+    @Mock
+    private at.mateball.domain.group.infrastructure.repository.GroupV3RepositoryCustom groupV3RepositoryCustom;
+    @Mock
+    private AlarmService alarmService;
+    @Mock
+    private GroupMemberV3Service groupMemberV3Service;
+    @Mock
+    private GroupRequestValidator groupRequestValidator;
+    @Mock
+    private at.mateball.exception.ConstraintExceptionTranslator constraintExceptionTranslator;
+    @Mock
+    private ChattingV2Service chattingV2Service;
+    @Mock
+    private jakarta.persistence.EntityManager entityManager;
+
+    @InjectMocks
+    private GroupRequestService groupRequestService;
+
+    private static final Long LEADER_ID = 1L;
+    private static final Long REQUESTER_ID = 2L;
+    private static final Long GROUP_ID = 100L;
+    private static final Long CHATTING_ID = 55L;
+
+    private Group mockPendingGroup(boolean isGroup, Chatting assignedChatting) {
+        Group group = org.mockito.Mockito.mock(Group.class);
+        User leader = org.mockito.Mockito.mock(User.class);
+        when(group.getStatus()).thenReturn(GroupStatus.PENDING.getValue());
+        when(group.getLeader()).thenReturn(leader);
+        when(leader.getId()).thenReturn(LEADER_ID);
+        when(group.isGroup()).thenReturn(isGroup);
+        when(group.getId()).thenReturn(GROUP_ID);
+        when(group.getChatting()).thenReturn(assignedChatting);
+        return group;
+    }
+
+    @Test
+    @DisplayName("케이스 A: 다이렉트 매칭 수락 시 채팅방이 없으면 새로 배정한다")
+    void permitRequest_direct_assignsChattingWhenAbsent() {
+        Group group = mockPendingGroup(false, null);
+        when(groupRepository.findGroupWithLock(GROUP_ID)).thenReturn(Optional.of(group));
+        when(groupMemberRepository.getMatchSummary(GROUP_ID))
+                .thenReturn(Optional.of(new GroupMatchSummaryRes(REQUESTER_ID, 0L)));
+
+        Chatting chatting = org.mockito.Mockito.mock(Chatting.class);
+        when(chatting.getId()).thenReturn(CHATTING_ID);
+        when(chattingV2Service.assignChatting()).thenReturn(chatting);
+
+        groupRequestService.permitRequest(LEADER_ID, GROUP_ID);
+
+        verify(chattingV2Service).assignChatting();
+        verify(groupRepository).assignChattingToGroup(GROUP_ID, CHATTING_ID);
+    }
+
+    @Test
+    @DisplayName("케이스 B: 이미 채팅방이 배정된 매칭은 새 채팅방을 배정하지 않는다")
+    void permitRequest_skipsAssignWhenAlreadyAssigned() {
+        Chatting existing = org.mockito.Mockito.mock(Chatting.class);
+        Group group = mockPendingGroup(false, existing);
+        when(groupRepository.findGroupWithLock(GROUP_ID)).thenReturn(Optional.of(group));
+        when(groupMemberRepository.getMatchSummary(GROUP_ID))
+                .thenReturn(Optional.of(new GroupMatchSummaryRes(REQUESTER_ID, 0L)));
+
+        groupRequestService.permitRequest(LEADER_ID, GROUP_ID);
+
+        verify(chattingV2Service, never()).assignChatting();
+        verify(groupRepository, never()).assignChattingToGroup(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("케이스 C/D: 가용 채팅방이 없으면 CHATTING_NOT_FOUND 가 전파되고 그룹에 링크하지 않는다")
+    void permitRequest_propagatesWhenNoChattingAvailable() {
+        Group group = mockPendingGroup(false, null);
+        when(groupRepository.findGroupWithLock(GROUP_ID)).thenReturn(Optional.of(group));
+        when(groupMemberRepository.getMatchSummary(GROUP_ID))
+                .thenReturn(Optional.of(new GroupMatchSummaryRes(REQUESTER_ID, 0L)));
+        when(chattingV2Service.assignChatting())
+                .thenThrow(new BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND));
+
+        assertThatThrownBy(() -> groupRequestService.permitRequest(LEADER_ID, GROUP_ID))
+                .isInstanceOf(BusinessException.class);
+
+        verify(groupRepository, never()).assignChattingToGroup(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("그룹 매칭은 정원이 차지 않으면 채팅방을 배정하지 않는다")
+    void permitRequest_group_notFull_doesNotAssign() {
+        Group group = mockPendingGroup(true, null);
+        when(groupRepository.findGroupWithLock(GROUP_ID)).thenReturn(Optional.of(group));
+        // matchedParticipants + 1 = 2 != 4 -> 정원 미달
+        when(groupMemberRepository.getMatchSummary(GROUP_ID))
+                .thenReturn(Optional.of(new GroupMatchSummaryRes(REQUESTER_ID, 1L)));
+
+        groupRequestService.permitRequest(LEADER_ID, GROUP_ID);
+
+        verify(chattingV2Service, never()).assignChatting();
+        verify(groupRepository, never()).assignChattingToGroup(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("그룹 매칭은 정원이 차면(4명) 채팅방을 배정한다")
+    void permitRequest_group_full_assignsChatting() {
+        Group group = mockPendingGroup(true, null);
+        when(groupRepository.findGroupWithLock(GROUP_ID)).thenReturn(Optional.of(group));
+        // matchedParticipants + 1 = 4 -> 정원 충족
+        when(groupMemberRepository.getMatchSummary(GROUP_ID))
+                .thenReturn(Optional.of(new GroupMatchSummaryRes(REQUESTER_ID, 3L)));
+
+        Chatting chatting = org.mockito.Mockito.mock(Chatting.class);
+        when(chatting.getId()).thenReturn(CHATTING_ID);
+        when(chattingV2Service.assignChatting()).thenReturn(chatting);
+
+        groupRequestService.permitRequest(LEADER_ID, GROUP_ID);
+
+        verify(chattingV2Service).assignChatting();
+        verify(groupRepository).assignChattingToGroup(GROUP_ID, CHATTING_ID);
+    }
+}


### PR DESCRIPTION
### 📌 이슈 번호

---

closed #267 

<br/>

### ✅ 어떻게 이슈를 해결했나요?

---

V3 매칭 요청 수락 흐름에서 매칭이 성사되었음에도 오픈채팅방이 배정되지 않아, 일부 활성 매칭에서 `채팅방 입장하기` 클릭 시 `존재하지 않는 채팅방입니다` 메시지가 노출될 수 있는 문제를 수정했습니다.

이번 작업에서는 V3 요청 수락 처리 흐름인 `GroupRequestService`에 채팅방 배정 로직을 추가했습니다.

주요 수정 내용은 다음과 같습니다.

* V3 매칭 수락 후 매칭이 `COMPLETED` 상태가 되는 시점에 오픈채팅방 배정 처리 추가
* 다이렉트 매칭 성사 시점에 채팅방 배정
* 그룹 매칭 정원 충족 시점에 채팅방 배정
* 정원 미달 상태에서는 채팅방을 배정하지 않도록 처리
* 이미 채팅방이 배정된 그룹은 재배정하지 않도록 방어 로직 추가
* 기존 V2 채팅방 배정 정책인 `ChattingV2Service.assignChatting()`과 `GroupRepository.assignChattingToGroup()` 재사용
* 동시 수락 시 같은 그룹에 대한 경쟁을 막기 위해 그룹 조회를 `findGroupWithLock(PESSIMISTIC_WRITE)` 기준으로 변경
* Controller / DTO / Entity / DB schema 변경 없이 기존 응답 구조 유지

채팅방 중복 배정 방지는 아래 기준으로 처리했습니다.

* 이미 `group.getChatting()`이 존재하면 새 채팅방을 배정하지 않음
* 이미 완료된 그룹은 기존 검증 로직에서 `ALREADY_COMPLETED_GROUP`으로 차단
* 채팅방 선점은 기존 `assignChatting()`의 `PESSIMISTIC_WRITE` 락 기반 조회를 사용
* `assignChattingToGroup`의 `WHERE chatting_id IS NULL` 조건과 기존 유니크 제약으로 중복 연결 방지

사용 가능한 채팅방이 없는 경우에는 기존 예외인 `BusinessException(BusinessErrorCode.CHATTING_NOT_FOUND)`를 그대로 사용합니다. 이 경우 수락 트랜잭션은 롤백되며, 별도 응답 구조 변경은 없습니다.

변경 파일은 다음과 같습니다.

* `src/main/java/at/mateball/domain/groupRequest/GroupRequestService.java`
* `src/test/java/at/mateball/domain/groupRequest/GroupRequestServiceTest.java`

테스트는 아래 단위 테스트 기준으로 확인했습니다.

* 다이렉트 매칭 수락 시 채팅방 신규 배정
* 이미 채팅방이 배정된 매칭은 재배정하지 않음
* 사용 가능한 채팅방이 없을 때 `CHATTING_NOT_FOUND` 전파
* 그룹 정원 미달 시 채팅방 미배정
* 그룹 정원 충족 시 채팅방 배정

테스트 결과:

```bash
./gradlew test --tests "*GroupRequestServiceTest"
```

```text
BUILD SUCCESSFUL
```

<br/>

### ❤️ To 다진 / To 헤음

---

* V3 매칭 요청 수락 후 `match_group.chatting_id`가 정상적으로 채워지는지..
* 이후 `채팅방 입장하기`에서 유효한 카카오 오픈채팅 URL이 반환되는지....
* 기존에 이미 `COMPLETED` 상태인데 `chatting_id`가 없는 매칭은 이번 코드 변경만으로 자동 복구 안되가지고 이거 해결해보겠삼


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 매칭 승인 시 채팅방이 자동으로 할당됩니다. 그룹에 채팅방이 없으면 새로 생성되어 연결됩니다.

* **개선 사항**
  * 매칭 요청 처리 흐름이 개선되어 더 일관된 상태 관리가 이루어집니다.

* **테스트**
  * 매칭 승인 시나리오에 대한 포괄적인 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->