### PR TITLE
[fix] 매칭 생성자가 수락한 멤버만 반환되도록 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -231,8 +231,10 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .join(groupMember.user, memberUser)
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
-                        groupMember.group.id.eq(matchId),
-                        groupMember.status.eq(GroupMemberStatus.APPROVED.getValue())
+                        groupMember.status.in(
+                                        GroupMemberStatus.APPROVED.getValue(),
+                                        GroupMemberStatus.MATCHED.getValue()
+                                )
                                 .or(groupMember.group.leader.id.eq(memberUser.id))
                 )
                 .orderBy(groupMember.id.asc())

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -92,7 +92,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .join(member).on(
                         member.group.id.eq(group.id)
                                 .and(member.isParticipant.isTrue())
-                )                .join(member.user, memberUser)
+                ).join(member.user, memberUser)
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
                         group.gameInformation.id.eq(gameId),
@@ -156,7 +156,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .join(groupMember).on(
                         groupMember.group.id.eq(group.id)
                                 .and(groupMember.isParticipant.isTrue())
-                )                .where(group.leader.id.eq(userId))
+                ).where(group.leader.id.eq(userId))
                 .groupBy(
                         group.id,
                         leaderUser.nickname,
@@ -232,7 +232,8 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
                         groupMember.group.id.eq(matchId),
-                        groupMember.status.ne(GroupMemberStatus.MATCH_FAILED.getValue())
+                        groupMember.status.eq(GroupMemberStatus.APPROVED.getValue()),
+                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
                 )
                 .orderBy(groupMember.id.asc())
                 .fetch();

--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -232,8 +232,8 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
                         groupMember.group.id.eq(matchId),
-                        groupMember.status.eq(GroupMemberStatus.APPROVED.getValue()),
-                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
+                        groupMember.status.eq(GroupMemberStatus.APPROVED.getValue())
+                                .or(groupMember.group.leader.id.eq(memberUser.id))
                 )
                 .orderBy(groupMember.id.asc())
                 .fetch();


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #270 

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 기존: 매칭실패된 인원을 제외하고 모두 반환 -> 수정: 매칭완료,수락완료된 인원만 반환


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 그룹 매칭 시 회원 상태 필터링 로직을 개선했습니다. 이제 승인된 회원과 매칭된 회원만 대상으로 정확히 조회되어 매칭 결과의 신뢰도가 향상되었습니다.
* **개선**
  * 매칭 후보 및 생성 그룹 관련 조회 조건이 더 일관되게 정리되어 관련 결과가 안정적으로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->