### PR TITLE
[fix] matchCnt 반환시, 매칭완료된 수만 집계하도록 수정

### DIFF
--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -255,7 +255,8 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .from(groupMember)
                 .where(
                         groupMember.user.id.in(memberIds),
-                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue())
+                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue()),
+                        groupMember.group.status.eq(GroupStatus.COMPLETED.getValue())
                 )
                 .groupBy(groupMember.user.id)
                 .fetch();

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -1,5 +1,7 @@
 package at.mateball.domain.user.core.repository;
 
+import at.mateball.domain.group.core.GroupStatus;
+import at.mateball.domain.groupmember.GroupMemberStatus;
 import at.mateball.domain.groupmember.core.QGroupMember;
 import at.mateball.domain.matchrequirement.core.QMatchRequirement;
 import at.mateball.domain.user.api.dto.response.*;
@@ -147,8 +149,11 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                 .leftJoin(matchRequirement)
                 .on(matchRequirement.user.id.eq(user.id))
                 .leftJoin(groupMember)
-                .on(groupMember.user.id.eq(user.id))
-                .where(user.id.eq(userId))
+                .on(
+                        groupMember.user.id.eq(user.id),
+                        groupMember.status.eq(GroupMemberStatus.MATCHED.getValue()),
+                        groupMember.group.status.eq(GroupStatus.COMPLETED.getValue())
+                )                .where(user.id.eq(userId))
                 .groupBy(
                         user.id,
                         matchRequirement.team,


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #269

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

기존 전체 매칭수를 반환하던 matchCnt (함께한 매칭 수)를 매칭완료된 매칭수로 반환하도록 변경했습니다.
적용된 api: 매칭 요청 상세 조회, 마이페이지 (v3)


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자별 매칭된 그룹 멤버 집계 및 마이페이지 정보 조회 시, 완료 상태의 그룹에 속한 경우에만 포함되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->