### PR TITLE
[fix] 이미지 경로 변경

### DIFF
--- a/src/main/java/at/mateball/domain/group/api/dto/DirectCreateRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/DirectCreateRes.java
@@ -66,4 +66,11 @@ public record DirectCreateRes(
         );
     }
 
+    public DirectCreateRes withImgUrl(String resolvedImgUrl) {
+        return new DirectCreateRes(
+                id, nickname, age, gender, team, style,
+                awayTeam, homeTeam, stadium, date, resolvedImgUrl
+        );
+    }
+
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/GroupCreateRes.java
@@ -45,4 +45,10 @@ public record GroupCreateRes(
                 imgUrls
         );
     }
+
+    public GroupCreateRes withImgUrl(List<String> resolvedImgUrls) {
+        return new GroupCreateRes(
+                id, nickname, awayTeam, homeTeam, stadium, date, count, resolvedImgUrls
+        );
+    }
 }

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -52,7 +52,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                         game.homeTeamName,
                         game.stadiumName,
                         game.gameDate,
-                        user.imgUrl
+                        user.profileImageKey
                 ))
                 .from(group)
                 .join(user).on(group.leader.eq(user))
@@ -153,7 +153,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                 .fetchOne()).orElse(0);
 
         List<String> imgUrls = queryFactory
-                .select(member.imgUrl)
+                .select(member.profileImageKey)
                 .from(groupMember)
                 .join(member).on(groupMember.user.eq(member))
                 .where(

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -24,6 +24,7 @@ import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,12 +50,13 @@ public class GroupService {
     private final GameInformationRepository gameInformationRepository;
     private final GroupExecutor groupExecutor;
     private final AgeValidator ageValidator;
+    private final FileStorage fileStorage;
 
     private final static int MAX_DIRECT_COUNT = 3;
     private final static int MAX_GROUP_COUNT = 2;
     private final static int TOTAL_GROUP_MEMBER = 4;
 
-    public GroupService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, AlarmService alarmService, GameInformationRepository gameInformationRepository, GroupExecutor groupExecutor, AgeValidator ageValidator) {
+    public GroupService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, AlarmService alarmService, GameInformationRepository gameInformationRepository, GroupExecutor groupExecutor, AgeValidator ageValidator, FileStorage fileStorage) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.matchRequirementService = matchRequirementService;
@@ -62,6 +64,7 @@ public class GroupService {
         this.gameInformationRepository = gameInformationRepository;
         this.groupExecutor = groupExecutor;
         this.ageValidator = ageValidator;
+        this.fileStorage = fileStorage;
     }
 
     public DirectCreateRes getDirectMatching(Long userId, Long matchId) {
@@ -75,7 +78,7 @@ public class GroupService {
             throw new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND);
         }
 
-        return result;
+        return result.withImgUrl(fileStorage.getImageUrl(result.imgUrl()));
     }
 
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
@@ -106,8 +109,14 @@ public class GroupService {
     }
 
     public GroupCreateRes getGroupMatching(Long userId, Long matchId) {
-        return groupRepository.findGroupCreateRes(userId, matchId)
+        GroupCreateRes result = groupRepository.findGroupCreateRes(userId, matchId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        List<String> imgUrls = result.imgUrl().stream()
+                .map(fileStorage::getImageUrl)
+                .toList();
+
+        return result.withImgUrl(imgUrls);
     }
 
     @Transactional

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -26,6 +26,7 @@ import at.mateball.domain.matchrequirement.api.dto.MatchingScoreDto;
 import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,7 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
     private final AlarmService alarmService;
     private final GroupExecutor groupExecutor;
     private final AgeValidator ageValidator;
+    private final FileStorage fileStorage;
 
     private final static int MAX_DIRECT_COUNT = 3;
     private final static int MAX_GROUP_COUNT = 2;
@@ -68,7 +70,7 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
             throw new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND);
         }
 
-        return result;
+        return result.withImgUrl(fileStorage.getImageUrl(result.imgUrl()));
     }
 
     public DirectGetListRes getDirects(Long userId, LocalDate date) {
@@ -98,8 +100,14 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
     }
 
     public GroupCreateRes getGroupMatching(Long userId, Long matchId) {
-        return groupRepository.findGroupCreateRes(userId, matchId)
+        GroupCreateRes result = groupRepository.findGroupCreateRes(userId, matchId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.GROUP_NOT_FOUND));
+
+        List<String> imgUrls = result.imgUrl().stream()
+                .map(fileStorage::getImageUrl)
+                .toList();
+
+        return result.withImgUrl(imgUrls);
     }
 
     @Transactional


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #이슈번호

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

  - 일대일/그룹 매칭 조회 API(/v1/users/direct/{matchId}, /v1/users/group/{matchId})의 imgUrl을 DB의 img_url 컬럼이 아닌 S3(profile_image_key 기반)에서 가져오도록 변경                                                                                                                                 
  - Repository projection을 user.imgUrl → user.profileImageKey로 바꾸고, Service에서 FileStorage.getImageUrl()로 실제 S3 URL을 생성하도록
  - key가 없는 유저는 기본 프로필 URL이 반환됩니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 그룹 및 매칭 조회 결과의 프로필 이미지가 올바른 이미지 URL로 제공됩니다.
  * 개별 사용자와 그룹 멤버의 이미지 표시 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->