### PR TITLE
[chore/#270] 누락된 matchId 쿼리문 추가

### DIFF
--- a/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/infrastructure/repository/GroupV3RepositoryImpl.java
@@ -231,6 +231,7 @@ public class GroupV3RepositoryImpl implements GroupV3RepositoryCustom {
                 .join(groupMember.user, memberUser)
                 .leftJoin(memberRequirement).on(memberRequirement.user.id.eq(memberUser.id))
                 .where(
+                        groupMember.group.id.eq(matchId),
                         groupMember.status.in(
                                         GroupMemberStatus.APPROVED.getValue(),
                                         GroupMemberStatus.MATCHED.getValue()


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #270

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 네... matchId 확인하는걸.. 리팩하면서 빼먹었네요.... 개인정보 유출 사건 발생할뻔..


<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매치 ID로 멤버를 조회할 때 해당 매치에 속한 그룹 멤버만 정확히 표시되도록 필터링을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->