### PR TITLE
[fix] member-details 프로필 이미지 S3 반환

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV3Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV3Service.java
@@ -76,9 +76,6 @@ public class GroupMemberV3Service {
     }
 
     private String resolveProfileImageUrl(String profileImageKey) {
-        if (profileImageKey == null || profileImageKey.isBlank()) {
-            return null;
-        }
         return fileStorage.getImageUrl(profileImageKey);
     }
 

--- a/src/main/java/at/mateball/domain/groupmember/infrastructure/repository/GroupMemberQueryRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/infrastructure/repository/GroupMemberQueryRepositoryImpl.java
@@ -76,7 +76,7 @@ public class GroupMemberQueryRepositoryImpl implements GroupMemberQueryRepositor
                         matchRequirement.teamAllowed,
                         matchRequirement.style,
                         user.introduction,
-                        user.imgUrl,
+                        user.profileImageKey,
                         user.avgSeason
                 ))
                 .from(groupMember)


### PR DESCRIPTION
### 📌 이슈 번호

---

<!-- 관련 이슈 없음 -->

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

`GET /v3/users/match/{matchId}/member-details` 응답의 프로필 이미지가 옛날 이미지/깨진 URL로 내려가던 문제를 수정했습니다.

**원인**
- `user` 테이블에 이미지 컬럼이 두 개 존재합니다.
  - `img_url` (레거시): 로그인 시 카카오 CDN URL만 저장됨. 프로필 업로드로는 갱신되지 않음
  - `profile_image_key` (신규): 프로필 업로드/수정 시 S3 오브젝트 키(`profiles/...`)가 저장됨
- 기존 `member-details` 쿼리는 **옛날 `img_url`을 읽고** 있어서, S3 URL 뒤에 카카오 URL이 통째로 인코딩되어 붙은 깨진 URL이 내려갔고, 프로필을 업데이트해도 반영되지 않았습니다.

**수정 내용**
- 조회 컬럼을 `user.imgUrl` -> `user.profileImageKey`로 변경 (`GroupMemberQueryRepositoryImpl`)
- `resolveProfileImageUrl`이 `profileImageKey` 기반으로 S3 URL을 생성하도록 단순화. 키가 null/blank이면 S3 기본 프로필(`profile.jpg`)을 반환 (`GroupMemberV3Service`)

**검증 (로컬 인스턴스 실호출)**
- 업로드 이미지 보유 멤버 -> `https://mateball-file.s3.../profiles/..._IMG_2253.jpg` (HTTP 200, 실제 이미지 확인)
- 키 없는 멤버 -> `https://mateball-file.s3.../profile.jpg` (HTTP 200, 기본 이미지)

<br/>


### ❤️ To 다진 / To 헤음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)