### PR TITLE
[fix] 프로필 이미지 조회 profile_image_key 기반 S3 URL 통일

### DIFF
--- a/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
+++ b/src/main/java/at/mateball/domain/auth/api/dto/LoginResult.java
@@ -1,7 +1,5 @@
 package at.mateball.domain.auth.api.dto;
 
-import at.mateball.domain.user.core.User;
-
 public record LoginResult(
         String accessToken,
         String refreshToken,
@@ -10,18 +8,4 @@ public record LoginResult(
         String email,
         String profileImage
 ) {
-    public static LoginResult from(User user, String accessToken, String refreshToken, String kakaoAccessToken) {
-        String profileImage = (user.getImgUrl() != null)
-                ? user.getImgUrl()
-                : User.DEFAULT_PROFILE_IMAGE_URL;
-
-        return new LoginResult(
-                accessToken,
-                refreshToken,
-                kakaoAccessToken,
-                user.getId(),
-                user.getEmail(),
-                profileImage
-        );
-    }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/LoginService.java
@@ -11,6 +11,7 @@ import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,7 @@ public class LoginService {
     private final JwtTokenGenerator jwtTokenGenerator;
     private final TokenService tokenService;
     private final RedirectUriResolver redirectUriResolver;
+    private final FileStorage fileStorage;
 
     @Transactional
     public LoginResult login(LoginCommand loginCommand) {
@@ -86,7 +88,7 @@ public class LoginService {
                 kakaoToken.accessToken(),
                 user.getId(),
                 user.getEmail(),
-                user.getImgUrl()
+                fileStorage.getImageUrl(user.getProfileImageKey())
         );
     }
 }

--- a/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
+++ b/src/main/java/at/mateball/domain/auth/core/service/ReissueService.java
@@ -7,6 +7,7 @@ import at.mateball.domain.user.core.User;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
@@ -18,12 +19,14 @@ public class ReissueService {
     private final JwtTokenGenerator jwtTokenGenerator;
     private final TokenService tokenService;
     private final UserRepository userRepository;
+    private final FileStorage fileStorage;
 
-    public ReissueService(JwtCookieProvider jwtCookieProvider, JwtTokenGenerator jwtTokenGenerator, TokenService tokenService, UserRepository userRepository) {
+    public ReissueService(JwtCookieProvider jwtCookieProvider, JwtTokenGenerator jwtTokenGenerator, TokenService tokenService, UserRepository userRepository, FileStorage fileStorage) {
         this.jwtCookieProvider = jwtCookieProvider;
         this.jwtTokenGenerator = jwtTokenGenerator;
         this.tokenService = tokenService;
         this.userRepository = userRepository;
+        this.fileStorage = fileStorage;
     }
 
     @Transactional
@@ -56,7 +59,7 @@ public class ReissueService {
                 null,
                 user.getId(),
                 user.getEmail(),
-                user.getImgUrl()
+                fileStorage.getImageUrl(user.getProfileImageKey())
         );
     }
 }

--- a/src/main/java/at/mateball/domain/group/api/dto/base/DirectGetBaseRes.java
+++ b/src/main/java/at/mateball/domain/group/api/dto/base/DirectGetBaseRes.java
@@ -17,6 +17,24 @@ public record DirectGetBaseRes(
         Integer matchRate,
         String imgUrl
 ) {
+    public DirectGetBaseRes withImgUrl(String imgUrl) {
+        return new DirectGetBaseRes(
+                id,
+                leaderId,
+                nickname,
+                birthYear,
+                gender,
+                team,
+                style,
+                awayTeam,
+                homeTeam,
+                stadium,
+                date,
+                matchRate,
+                imgUrl
+        );
+    }
+
     public DirectGetBaseRes withMatchRate(Integer matchRate) {
         return new DirectGetBaseRes(
                 id,

--- a/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/group/core/repository/querydsl/GroupRepositoryImpl.java
@@ -90,7 +90,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                         game.stadiumName,
                         game.gameDate,
                         Expressions.nullExpression(Integer.class),
-                        user.imgUrl
+                        user.profileImageKey
                 ))
                 .from(group)
                 .join(user).on(group.leader.eq(user))

--- a/src/main/java/at/mateball/domain/group/core/service/GroupService.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupService.java
@@ -101,6 +101,7 @@ public class GroupService {
 
         List<DirectGetRes> directGetRes = filtered.stream()
                 .map(res -> res.withMatchRate(matchRateMap.getOrDefault(res.leaderId(), 0)))
+                .map(res -> res.withImgUrl(fileStorage.getImageUrl(res.imgUrl())))
                 .map(DirectGetRes::from)
                 .sorted(Comparator.comparingInt(DirectGetRes::matchRate).reversed())
                 .toList();
@@ -226,7 +227,9 @@ public class GroupService {
                 .map(groupBase -> {
                     Long groupId = groupBase.id();
                     int count = groupToMemberCount.getOrDefault(groupId, 1);
-                    List<String> imgs = groupToImgUrls.getOrDefault(groupId, List.of());
+                    List<String> imgs = groupToImgUrls.getOrDefault(groupId, List.of()).stream()
+                            .map(fileStorage::getImageUrl)
+                            .toList();
                     int avgMatchRate = groupToAvgMatchRate.getOrDefault(groupId, 0);
 
                     return GroupGetRes.from(groupBase, avgMatchRate, count, imgs);

--- a/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
+++ b/src/main/java/at/mateball/domain/group/core/service/GroupV2Service.java
@@ -92,6 +92,7 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
 
         List<DirectGetRes> directGetRes = filtered.stream()
                 .map(res -> res.withMatchRate(matchRateMap.getOrDefault(res.leaderId(), 0)))
+                .map(res -> res.withImgUrl(fileStorage.getImageUrl(res.imgUrl())))
                 .map(DirectGetRes::from)
                 .sorted(Comparator.comparingInt(DirectGetRes::matchRate).reversed())
                 .toList();
@@ -206,7 +207,9 @@ import static at.mateball.domain.groupmember.GroupMemberStatus.MATCH_FAILED;
                 .map(groupBase -> {
                     Long groupId = groupBase.id();
                     int count = groupToMemberCount.getOrDefault(groupId, 1);
-                    List<String> imgs = groupToImgUrls.getOrDefault(groupId, List.of());
+                    List<String> imgs = groupToImgUrls.getOrDefault(groupId, List.of()).stream()
+                            .map(fileStorage::getImageUrl)
+                            .toList();
                     int avgMatchRate = groupToAvgMatchRate.getOrDefault(groupId, 0);
 
                     return GroupGetRes.from(groupBase, avgMatchRate, count, imgs);

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DetailMatchingBaseRes.java
@@ -17,4 +17,21 @@ public record DetailMatchingBaseRes(
         LocalDate date,
         String imgUrl
 ) {
+    public DetailMatchingBaseRes withImgUrl(String imgUrl) {
+        return new DetailMatchingBaseRes(
+                id,
+                userId,
+                nickname,
+                birthYear,
+                gender,
+                team,
+                style,
+                introduction,
+                awayTeam,
+                homeTeam,
+                stadium,
+                date,
+                imgUrl
+        );
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseRes.java
@@ -16,4 +16,20 @@ public record DirectStatusBaseRes(
         Integer status,
         String imgUrl
 ) {
+    public DirectStatusBaseRes withImgUrl(String imgUrl) {
+        return new DirectStatusBaseRes(
+                id,
+                nickname,
+                birthYear,
+                gender,
+                team,
+                style,
+                awayTeam,
+                homeTeam,
+                stadium,
+                date,
+                status,
+                imgUrl
+        );
+    }
 }

--- a/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseResV2.java
+++ b/src/main/java/at/mateball/domain/groupmember/api/dto/base/DirectStatusBaseResV2.java
@@ -16,4 +16,22 @@ public record DirectStatusBaseResV2(
         LocalDate date,
         Integer status,
         String imgUrl
-) {}
+) {
+    public DirectStatusBaseResV2 withImgUrl(String imgUrl) {
+        return new DirectStatusBaseResV2(
+                id,
+                leaderId,
+                nickname,
+                birthYear,
+                gender,
+                team,
+                style,
+                awayTeam,
+                homeTeam,
+                stadium,
+                date,
+                status,
+                imgUrl
+        );
+    }
+}

--- a/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/repository/querydsl/GroupMemberRepositoryImpl.java
@@ -74,7 +74,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
         if (groupIds.isEmpty()) return Map.of();
 
         return queryFactory
-                .select(member.group.id, user.imgUrl)
+                .select(member.group.id, user.profileImageKey)
                 .from(member)
                 .join(user).on(member.user.eq(user))
                 .where(
@@ -122,7 +122,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.stadiumName,
                         gameInformation.gameDate,
                         groupMember.status,
-                        leader.imgUrl
+                        leader.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.group, group)
@@ -158,7 +158,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.stadiumName,
                         gameInformation.gameDate,
                         groupMember.status,
-                        leader.imgUrl
+                        leader.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.group, group)
@@ -279,7 +279,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         game.homeTeamName,
                         game.stadiumName,
                         game.gameDate,
-                        user.imgUrl
+                        user.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.user, user)
@@ -340,7 +340,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         game.homeTeamName,
                         game.stadiumName,
                         game.gameDate,
-                        user.imgUrl
+                        user.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.user, user)
@@ -649,7 +649,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.stadiumName,
                         gameInformation.gameDate,
                         groupMember.status,
-                        leader.imgUrl
+                        leader.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.group, group)
@@ -686,7 +686,7 @@ public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
                         gameInformation.stadiumName,
                         gameInformation.gameDate,
                         groupMember.status,
-                        leader.imgUrl
+                        leader.profileImageKey
                 ))
                 .from(groupMember)
                 .join(groupMember.group, group)

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberService.java
@@ -13,6 +13,7 @@ import at.mateball.domain.matchrequirement.core.service.MatchRequirementService;
 import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,18 +27,21 @@ public class GroupMemberService {
     private final GroupMemberRepository groupMemberRepository;
     private final MatchRequirementService matchRequirementService;
     private final UserRepository userRepository;
+    private final FileStorage fileStorage;
 
-    public GroupMemberService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, UserRepository userRepository) {
+    public GroupMemberService(GroupRepository groupRepository, GroupMemberRepository groupMemberRepository, MatchRequirementService matchRequirementService, UserRepository userRepository, FileStorage fileStorage) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.matchRequirementService = matchRequirementService;
         this.userRepository = userRepository;
+        this.fileStorage = fileStorage;
     }
 
     public DirectStatusListRes getDirectStatus(Long userId, GroupStatus groupStatus) {
         List<DirectStatusBaseRes> baseResList = groupMemberRepository.findDirectMatchingsByUserAndGroupStatus(userId, groupStatus.getValue());
 
         List<DirectStatusRes> result = baseResList.stream()
+                .map(this::resolveImgUrl)
                 .map(DirectStatusRes::from)
                 .toList();
 
@@ -48,6 +52,7 @@ public class GroupMemberService {
         List<DirectStatusBaseRes> baseResList = groupMemberRepository.findAllDirectMatchingsByUser(userId);
 
         List<DirectStatusRes> result = baseResList.stream()
+                .map(this::resolveImgUrl)
                 .map(DirectStatusRes::from)
                 .toList();
 
@@ -81,7 +86,7 @@ public class GroupMemberService {
         List<DetailMatchingRes> result = newRequests.stream()
                 .map(base -> {
                     Integer matchRate = matchRateMap.getOrDefault(base.userId(), 0);
-                    return DetailMatchingRes.from(base, matchRate);
+                    return DetailMatchingRes.from(resolveImgUrl(base), matchRate);
                 })
                 .toList();
 
@@ -108,7 +113,7 @@ public class GroupMemberService {
         List<DetailMatchingRes> result = participants.stream()
                 .map(base -> {
                     Integer matchRate = matchRateMap.getOrDefault(base.userId(), 0);
-                    return DetailMatchingRes.from(base, matchRate);
+                    return DetailMatchingRes.from(resolveImgUrl(base), matchRate);
                 })
                 .toList();
 
@@ -133,11 +138,25 @@ public class GroupMemberService {
                 .map(res -> GroupStatusRes.from(
                         res,
                         countMap.getOrDefault(res.id(), 0),
-                        imgMap.getOrDefault(res.id(), List.of())
+                        resolveImgUrls(imgMap.getOrDefault(res.id(), List.of()))
                 ))
                 .toList();
 
         return new GroupStatusListRes(result);
+    }
+
+    private DirectStatusBaseRes resolveImgUrl(DirectStatusBaseRes baseRes) {
+        return baseRes.withImgUrl(fileStorage.getImageUrl(baseRes.imgUrl()));
+    }
+
+    private DetailMatchingBaseRes resolveImgUrl(DetailMatchingBaseRes baseRes) {
+        return baseRes.withImgUrl(fileStorage.getImageUrl(baseRes.imgUrl()));
+    }
+
+    private List<String> resolveImgUrls(List<String> profileImageKeys) {
+        return profileImageKeys.stream()
+                .map(fileStorage::getImageUrl)
+                .toList();
     }
 
     public GroupMemberCountRes countGroupMember(final Long matchId) {

--- a/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
+++ b/src/main/java/at/mateball/domain/groupmember/core/service/GroupMemberV2Service.java
@@ -8,6 +8,7 @@ import at.mateball.domain.groupmember.api.dto.GroupStatusResV2;
 import at.mateball.domain.groupmember.api.dto.base.DirectStatusBaseResV2;
 import at.mateball.domain.groupmember.api.dto.base.GroupStatusBaseResV2;
 import at.mateball.domain.groupmember.core.repository.GroupMemberRepository;
+import at.mateball.storage.FileStorage;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,9 +17,11 @@ import java.util.Map;
 @Service
 public class GroupMemberV2Service {
     private final GroupMemberRepository groupMemberRepository;
+    private final FileStorage fileStorage;
 
-    public GroupMemberV2Service(GroupMemberRepository groupMemberRepository) {
+    public GroupMemberV2Service(GroupMemberRepository groupMemberRepository, FileStorage fileStorage) {
         this.groupMemberRepository = groupMemberRepository;
+        this.fileStorage = fileStorage;
     }
 
     public DirectStatusListRes getDirectStatusV2(Long userId, GroupStatus groupStatus) {
@@ -26,7 +29,7 @@ public class GroupMemberV2Service {
                 groupMemberRepository.findDirectMatchingsByUserAndGroupStatusV2(userId, groupStatus.getValue());
 
         List<DirectStatusResV2> result = baseResList.stream()
-                .map(baseRes -> DirectStatusResV2.fromV2(baseRes, userId))
+                .map(baseRes -> DirectStatusResV2.fromV2(resolveImgUrl(baseRes), userId))
                 .toList();
 
         return new DirectStatusListRes(result);
@@ -37,7 +40,7 @@ public class GroupMemberV2Service {
                 groupMemberRepository.findAllDirectMatchingsByUserV2(userId);
 
         List<DirectStatusResV2> result = baseResList.stream()
-                .map(baseRes -> DirectStatusResV2.fromV2(baseRes, userId))
+                .map(baseRes -> DirectStatusResV2.fromV2(resolveImgUrl(baseRes), userId))
                 .toList();
 
         return new DirectStatusListRes(result);
@@ -57,7 +60,7 @@ public class GroupMemberV2Service {
                 .map(base -> GroupStatusResV2.from(
                         base,
                         countMap.getOrDefault(base.id(), 0),
-                        imgMap.getOrDefault(base.id(), List.of()),
+                        resolveImgUrls(imgMap.getOrDefault(base.id(), List.of())),
                         userId
                 ))
                 .toList();
@@ -79,11 +82,21 @@ public class GroupMemberV2Service {
                 .map(base -> GroupStatusResV2.from(
                         base,
                         countMap.getOrDefault(base.id(), 0),
-                        imgMap.getOrDefault(base.id(), List.of()),
+                        resolveImgUrls(imgMap.getOrDefault(base.id(), List.of())),
                         userId
                 ))
                 .toList();
 
         return new GroupStatusListRes(result);
+    }
+
+    private DirectStatusBaseResV2 resolveImgUrl(DirectStatusBaseResV2 baseRes) {
+        return baseRes.withImgUrl(fileStorage.getImageUrl(baseRes.imgUrl()));
+    }
+
+    private List<String> resolveImgUrls(List<String> profileImageKeys) {
+        return profileImageKeys.stream()
+                .map(fileStorage::getImageUrl)
+                .toList();
     }
 }

--- a/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
+++ b/src/main/java/at/mateball/domain/user/api/dto/response/UserInformationRes.java
@@ -22,6 +22,18 @@ public record UserInformationRes(
         @Schema(description = "사용자의 프로필 이미지")
         String imgUrl
 ) {
+    public UserInformationRes withImgUrl(String imgUrl) {
+        return new UserInformationRes(
+                nickname,
+                age,
+                gender,
+                team,
+                style,
+                introduction,
+                imgUrl
+        );
+    }
+
     public static UserInformationRes fromBase(UserInformationBaseRes userInformationBaseRes) {
         if (userInformationBaseRes == null) {
             return new UserInformationRes(

--- a/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
+++ b/src/main/java/at/mateball/domain/user/core/repository/UserRepositoryImpl.java
@@ -40,7 +40,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         matchRequirement.team,
                         matchRequirement.style,
                         user.introduction,
-                        user.imgUrl
+                        user.profileImageKey
                 ))
                 .from(user, matchRequirement)
                 .where(user.id.eq(userId),

--- a/src/main/java/at/mateball/domain/user/core/service/UserService.java
+++ b/src/main/java/at/mateball/domain/user/core/service/UserService.java
@@ -11,6 +11,7 @@ import at.mateball.domain.user.core.repository.UserRepository;
 import at.mateball.domain.user.core.validator.NicknameValidator;
 import at.mateball.exception.BusinessException;
 import at.mateball.exception.code.BusinessErrorCode;
+import at.mateball.storage.FileStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ import static at.mateball.exception.code.BusinessErrorCode.*;
 public class UserService {
     private final UserRepository userRepository;
     private final MatchRequirementRepository matchRequirementRepository;
+    private final FileStorage fileStorage;
 
     public KaKaoInformationRes getKakaoInformation(final Long userId) {
         User user = userRepository.findById(userId)
@@ -66,7 +68,9 @@ public class UserService {
             throw new BusinessException(BusinessErrorCode.MATCH_REQUIREMENT_NOT_FOUND);
         }
 
-        return userRepository.findUserInformation(userId);
+        UserInformationRes userInformation = userRepository.findUserInformation(userId);
+
+        return userInformation.withImgUrl(fileStorage.getImageUrl(userInformation.imgUrl()));
     }
 
     public User findUser(final Long userId) {


### PR DESCRIPTION
### 📌 이슈 번호

---

<!-- 관련 이슈 없음 -->

<br/>


### ✅ 어떻게 이슈를 해결했나요?

프로필 이미지를 내려주는 **나머지 조회 API 전부**를 `profile_image_key` 기반 S3 URL로 통일했습니다.
#273(일대일/그룹 매칭 조회), #275(member-details)에서 개별적으로 고쳤던 것의 마무리입니다.

---

**원인**

`user` 테이블에 이미지 컬럼이 두 개 존재합니다.
- `img_url` (레거시): **로그인할 때만** 카카오 CDN URL로 갱신됨 (`LoginService`)
- `profile_image_key` (신규): 프로필 업로드/수정 시 S3 오브젝트 키가 저장됨 (`UserProfileImageService`)

**프로필 이미지를 업로드해도 `img_url`은 갱신되지 않습니다.** 그런데 아직 `img_url`을 읽는 조회가 다수 남아있어서, 프론트가 호출하는 API에 따라 업로드한 사진 대신 카카오 CDN 이미지가 내려갔습니다.

**수정 내용**

- 남은 조회 쿼리 9곳을 `user.imgUrl` → `user.profileImageKey`로 변경
  - `GroupRepositoryImpl` (일대일 매칭 리스트)
  - `GroupMemberRepositoryImpl` (그룹원 이미지, 직관/그룹 현황 V1·V2, 요청 상세)
  - `UserRepositoryImpl` (마이페이지)
- 각 소비 서비스에서 `fileStorage.getImageUrl()`로 S3 URL 변환 추가
  - 쿼리만 바꾸면 **키 문자열이 URL 자리에 그대로 응답으로 나가므로**, 소비처를 전수 조사해 누락 없이 반영했습니다
  - 기존 `DirectCreateRes.withImgUrl` 패턴을 그대로 사용해 바깥 `from()` 매핑은 건드리지 않았습니다
- 로그인/재발급 응답(`LoginResult.profileImage`)도 `profile_image_key` 기반으로 변경
- 호출부가 없는 dead code `LoginResult.from` 제거 (raw `img_url`을 반환하던 유일한 잔재)

**API 계약 변경 없음**

필드명(`imgUrl`, `profileImage`)·타입·JSON 구조 모두 그대로입니다. 키가 null/blank면 `getImageUrl()`이 기본 프로필(`profile.jpg`)로 폴백하므로 항상 non-null입니다. **프론트 코드 변경은 필요 없습니다.**

<br/>


### ❤️ To 다진 / To 헤음

---
