### PR TITLE
[fix] 매칭 완료된 경우도 수락완료로 값 전달

### DIFF
--- a/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
+++ b/src/main/java/at/mateball/domain/groupmember/GroupMemberStatus.java
@@ -33,7 +33,7 @@ public enum GroupMemberStatus {
     public String toResponseLabel() {
         return switch (this) {
             case AWAITING_APPROVAL -> "수락 대기 중";
-            case APPROVED -> "수락완료";
+            case APPROVED,MATCHED -> "수락완료";
             default -> null;
         };
     }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. 
ex. [feat] searchPublicCourse -->

### 📌 이슈 번호

---

closed #277

<br/>


### ✅ 어떻게 이슈를 해결했나요?

---

- 회원 상태가 수락완료일때만 라벨값이 변환되고 있어서, 매칭완료의 경우 또한 라벨값을 변환해주도록 수정했습니다.

<br/>


### ❤️ To 다진 / To 헤음

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 매칭이 완료된 상태에서도 응답 라벨이 정상적으로 표시되도록 수정했습니다.
  * `MATCHED` 상태에 이제 “수락완료” 라벨이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->